### PR TITLE
adds comfortable uniform and puts it in loadout. Edit, also adds suit sensors to taticool stuff seeing as how it's not actually syndicate stuff.

### DIFF
--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -68,9 +68,9 @@
 	item_color = "syndicate_combat"
 	can_adjust = FALSE
 
-/obj/item/clothing/under/syndicate/comfortable
-	name = "Comfortable Uniform"
-	desc = "A modified combat uniform, it has had much of it's armor stripped out and replaced with padding to make it as comfortable as possible."
+/obj/item/clothing/under/syndicate/combat/comfortable
+	name = "Padded Uniform"
+	desc = "A uniform of similar design to the combat uniform, it has had it's armor replaced with extra padding while providing pockets to hold useful gear."
 	icon_state = "syndicate_combat"
 	item_color = "syndicate_combat"
 	can_adjust = FALSE

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -67,3 +67,11 @@
 	icon_state = "syndicate_combat"
 	item_color = "syndicate_combat"
 	can_adjust = FALSE
+
+/obj/item/clothing/under/syndicate/comfortable
+	name = "Comfortable Uniform"
+	desc = "A modified combat uniform, it has had much of it's armor stripped out and replaced with padding to make it as comfortable as possible."
+	icon_state = "syndicate_combat"
+	item_color = "syndicate_combat"
+	can_adjust = FALSE
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -25,6 +25,7 @@
 	icon_state = "tactifool"
 	item_state = "bl_suit"
 	item_color = "tactifool"
+	has_sensor = HAS_SENSORS
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)
 
 /obj/item/clothing/under/syndicate/tacticool/skirt
@@ -33,6 +34,7 @@
 	icon_state = "tactifool_skirt"
 	item_state = "bl_suit"
 	item_color = "tactifool_skirt"
+	has_sensor = HAS_SENSORS
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)
 	fitted = FEMALE_UNIFORM_TOP
 
@@ -68,10 +70,11 @@
 	item_color = "syndicate_combat"
 	can_adjust = FALSE
 
-/obj/item/clothing/under/syndicate/combat/comfortable
+/obj/item/clothing/under/syndicate/comfortable
 	name = "Padded Uniform"
 	desc = "A uniform of similar design to the combat uniform, it has had it's armor replaced with extra padding while providing pockets to hold useful gear."
 	icon_state = "syndicate_combat"
 	item_color = "syndicate_combat"
 	can_adjust = FALSE
+	has_sensor = HAS_SENSORS
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)

--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -144,9 +144,9 @@
 	path = /obj/item/clothing/under/pants/track
 
 /datum/gear/comfortable
-	name = "Comfortable Uniform"
+	name = "padded uniform"
 	category = SLOT_WEAR_SUIT
-	path = /obj/item/clothing/under/syndicate/comfortable
+	path = /obj/item/clothing/under/syndicate/combat/comfortable
 
 // Pantsless Sweaters
 

--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -145,7 +145,7 @@
 
 /datum/gear/comfortable
 	name = "padded uniform"
-	category = SLOT_WEAR_SUIT
+	category =  SLOT_W_UNIFORM
 	path = /obj/item/clothing/under/syndicate/combat/comfortable
 
 // Pantsless Sweaters

--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -144,9 +144,9 @@
 	path = /obj/item/clothing/under/pants/track
 
 /datum/gear/comfortable
-	name = "padded uniform"
+	name = "Padded Uniform"
 	category =  SLOT_W_UNIFORM
-	path = /obj/item/clothing/under/syndicate/combat/comfortable
+	path = /obj/item/clothing/under/syndicate/comfortable
 
 // Pantsless Sweaters
 

--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -143,6 +143,11 @@
 	category = SLOT_W_UNIFORM
 	path = /obj/item/clothing/under/pants/track
 
+/datum/gear/comfortable
+	name = "Comfortable Uniform"
+	category = SLOT_WEAR_SUIT
+	path = /obj/item/clothing/under/syndicate/comfortable
+
 // Pantsless Sweaters
 
 /datum/gear/turtleneck


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Just me learning how loadout and clothing code works a bit. Also more customization options seem like a good idea right now.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
add: Adds a new version of the combat uniform with only the benefits of a regular jumpsuit called the comfortable uniform. It is available in loadout for 1 point.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
