### PR TITLE
Round shuttle auto call change

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -53,7 +53,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	var/lockdown = FALSE	//disallow transit after nuke goes off
 
-	var/auto_call = 72000 //CIT CHANGE - time before in deciseconds in which the shuttle is auto called. Default is 2ish hours plus 15 for the shuttle. So total is 3.
+	var/auto_call = 108000 //CIT CHANGE - time before in deciseconds in which the shuttle is auto called. Default is 2ish hours plus 15 for the shuttle. So total is 3./// Set to 3 by Nam previously 72000
 	var/realtimeofstart = 0
 
 /datum/controller/subsystem/shuttle/Initialize(timeofday)


### PR DESCRIPTION
Tiny change making shifts up to 3.25~ hours crew can choose to call at any time

Previously 72000 now 108000 (deciseconds)

Changelog

🆑
add: Auto Shuttle call is 3 hours
/🆑