### PR TITLE
Nerfs Earthsblood into the earth.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1177,7 +1177,6 @@
 	M.adjustToxLoss(-3 * REM, 0, TRUE) //Heals TOXINLOVERS
 	M.adjustBrainLoss(2 * REM, 150) //This does, after all, come from ambrosia, and the most powerful ambrosia in existence, at that!
 	M.adjustCloneLoss(-1 * REM, 0)
-	M.adjustStaminaLoss(-30 * REM, 0)
 	M.jitteriness = min(max(0, M.jitteriness + 3), 30)
 	M.druggy = min(max(0, M.druggy + 10), 15) //See above
 	..()


### PR DESCRIPTION
## About The Pull Request

This PR removes the Stamina benefits from Earthsblood.

## Why It's Good For The Game

Because someone decided to put it in a vape and therefore whenever they get stamcritteed they get out of it within ONE SECOND and get their whole stamina back at an extremely fast rate. I don't see how a chem so powerful can be as easy to obtain as spilling some mutagen on ambrosia plants. The chemical is way too powergamey and I don't see why exactly does it need to give stamina benefits to the user at all. It's supposed to heal you but damage your brain, not give you incredible stamina which allows you to just stand up after taking a magdump of rubbershot rounds into your face and shrug it off like nothing happened.

## Changelog
:cl:
balance: Removed Earthsblood stamina benefits because they are way too powerful alongside the healing it gives.
/:cl: