### PR TITLE
makes slime hungry

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -69,7 +69,7 @@
 
 						if(Target.Adjacent(src))
 							Target.attack_slime(src)
-					return
+					break
 				if(!Target.lying && prob(80))
 
 					if(Target.client && Target.health >= 20)


### PR DESCRIPTION
Original fix made by Kriksog.
Their explanation for this was that using a return here could break the process loop without resetting the ai proc variable getting them stuck outside the loop if they couldn't eat the slime they wanted to or a different target.
