### PR TITLE
[Port] Build Your Own Shuttle

### DIFF
--- a/_maps/shuttles/emergency_construction.dmm
+++ b/_maps/shuttles/emergency_construction.dmm
@@ -1,0 +1,598 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"b" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"c" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
+"d" = (
+/obj/structure/window/reinforced,
+/obj/structure/shuttle/engine/heater{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"e" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"f" = (
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"g" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"h" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"i" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency/shuttle_build{
+	dwidth = 9;
+	height = 15;
+	name = "Shuttle Under Construction";
+	port_direction = 4;
+	preferred_direction = 2;
+	width = 26
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"j" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 3;
+	pixel_y = 10
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/airlock_painter,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"k" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical,
+/obj/item/clothing/gloves/color/yellow{
+	pixel_y = 8
+	},
+/obj/item/storage/toolbox/electrical,
+/obj/item/multitool{
+	pixel_x = 2;
+	pixel_y = -4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"l" = (
+/obj/structure/table,
+/obj/item/storage/box/lights/mixed{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/electronics/airalarm{
+	pixel_x = 8
+	},
+/obj/item/electronics/airalarm{
+	pixel_x = 8
+	},
+/obj/item/electronics/airalarm{
+	pixel_x = 8
+	},
+/obj/item/electronics/airalarm{
+	pixel_x = 8
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"m" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/metal/fifty{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"n" = (
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/titanium/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/mineral/titanium/fifty{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"o" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/titaniumglass{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"p" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+
+(1,1,1) = {"
+a
+c
+e
+e
+h
+e
+e
+g
+e
+i
+e
+e
+h
+e
+e
+g
+e
+g
+e
+p
+a
+a
+a
+a
+a
+a
+"}
+(2,1,1) = {"
+b
+d
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+e
+p
+a
+a
+a
+a
+a
+"}
+(3,1,1) = {"
+b
+d
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+e
+a
+a
+a
+a
+a
+"}
+(4,1,1) = {"
+c
+c
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+e
+e
+h
+h
+h
+a
+"}
+(5,1,1) = {"
+b
+d
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+h
+h
+"}
+(6,1,1) = {"
+b
+d
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+h
+"}
+(7,1,1) = {"
+b
+d
+f
+f
+f
+f
+f
+f
+f
+f
+j
+m
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+h
+"}
+(8,1,1) = {"
+c
+c
+f
+f
+f
+f
+f
+f
+f
+f
+k
+n
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+h
+"}
+(9,1,1) = {"
+b
+d
+f
+f
+f
+f
+f
+f
+f
+f
+l
+o
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+h
+"}
+(10,1,1) = {"
+b
+d
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+h
+"}
+(11,1,1) = {"
+b
+d
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+h
+h
+"}
+(12,1,1) = {"
+c
+c
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+e
+e
+h
+h
+h
+a
+"}
+(13,1,1) = {"
+b
+d
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+e
+a
+a
+a
+a
+a
+"}
+(14,1,1) = {"
+b
+d
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+e
+p
+a
+a
+a
+a
+a
+"}
+(15,1,1) = {"
+a
+c
+e
+e
+h
+e
+e
+e
+h
+e
+e
+e
+h
+e
+e
+e
+h
+e
+e
+p
+a
+a
+a
+a
+a
+a
+"}

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -174,16 +174,16 @@
 	name = "Backup Shuttle"
 	can_be_bought = FALSE
 
-/datum/map_template/shuttle/emergency/airless
-	suffix = "airless"
+/datum/map_template/shuttle/emergency/construction
+	suffix = "construction"
 	name = "Build your own shuttle kit"
-	description = "Save money by building your own shuttle! The chassis will dock upon purchase, but launch will have to be authorized as usual via shuttle call. Interior and atmosphere not included."
-	admin_notes = "No brig, no medical facilities, no air."
-	credit_cost = -7500
+	description = "For the enterprising shuttle engineer! The chassis will dock upon purchase, but launch will have to be authorized as usual via shuttle call. Comes stocked with construction materials."
+	admin_notes = "No brig, no medical facilities, no shuttle console."
+	credit_cost = 2500
 
 /datum/map_template/shuttle/emergency/airless/prerequisites_met()
-	// first 10 minutes only
-	return world.time - SSticker.round_start_time < 6000
+	// first 30 minutes only
+	return world.time - SSticker.round_start_time < 18000
 
 /datum/map_template/shuttle/emergency/airless/on_bought()
 	//enable buying engines from cargo


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the current Build Your Own Shuttle (BYOS) from TG to the list of purchasable shuttles. 

## Why It's Good For The Game

It gives Engineers and other crews another option in terms of building projects, especially during green shifts, outside of station objectives which are honestly extremely resource intensive like the Bluespace canon or can be mostly completed with just Botany or Xenobio when it comes to the DNA vault. Meteor shielding isn't really an "objective" since it is more of a reactionary purchase / build for engineers and crew.

30 minutes is enough time for the crew to decide if they wanna build one of these on a green shift, as well as the 2500 cost instead of a negative cost _somewhat_ deters troll purchases, but consider that Daniel is a 5k shuttle so there are more lynchable shuttles to purchase for that purpose alone.

![BYOS](https://user-images.githubusercontent.com/6519623/68536679-8d25eb80-0324-11ea-8218-9249b0fbc11c.png)

Engineers when the BYOS is purchased and built.

![image](https://media1.giphy.com/media/3iLasPhfaIdQk/giphy.gif)

## Changelog
:cl: BigFatAnimeTiddies
add: Adds the "Build Your Own Shuttle" to the list of purchasable shuttles. There is no shuttle console, so it would need to be launched manually from a communication console.
balance: Cost is 2500 to somewhat deter troll purchases, compared to the previous negative costs that awarded money instead. Can be purchased within the first 30 minutes of a round.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
