### PR TITLE
removes screwdriver requirement for extinguishers

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -110,7 +110,7 @@
 	to_chat(user, "The safety is [safety ? "on" : "off"].")
 
 	if(reagents.total_volume)
-		to_chat(user, "<span class='notice'>You can loose its <b>screws</b> to empty it.</span>")
+		to_chat(user, "<span class='notice'>Alt-click to empty it.</span>")
 
 /obj/item/extinguisher/proc/AttemptRefill(atom/target, mob/user)
 	if(istype(target, tanktype) && target.Adjacent(user))
@@ -230,8 +230,11 @@
 	repetition++
 	addtimer(CALLBACK(src, /obj/item/extinguisher/proc/move_chair, B, movementdirection, repetition), timer_seconds)
 
-/obj/item/extinguisher/screwdriver_act(mob/user, obj/item/tool)
+/obj/item/extinguisher/AltClick(mob/user)
 	if(!user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
+		return
+	if(!user.is_holding(src))
+		to_chat(user, "<span class='notice'>You must be holding the [src] in your hands do this!</span>")
 		return
 	EmptyExtinguisher(user)
 
@@ -244,7 +247,7 @@
 			var/turf/open/theturf = T
 			theturf.MakeSlippery(TURF_WET_WATER, min_wet_time = 10 SECONDS, wet_time_to_add = 5 SECONDS)
 
-		user.visible_message("[user] empties out \the [src] onto the floor using the release valve.", "<span class='info'>You quietly empty out \the [src] by loosing the release valve's screws.</span>")
+		user.visible_message("[user] empties out \the [src] onto the floor using the release valve.", "<span class='info'>You quietly empty out \the [src] using its release valve.</span>")
 
 //firebot assembly
 /obj/item/extinguisher/attackby(obj/O, mob/user, params)


### PR DESCRIPTION
## About The Pull Request
extinguishers can now be emptied again with just your bare hands (altclick)
also includes a fix from /tg/ so that you can't empty them from storage slots for any stealth slips

## Why It's Good For The Game
its super inconvenient to pour these out to begin with unless you have a screwdriver on you at all times, which then why not just use waterbottles/spraybottles/mop/buckets since they're more easily reliable.

## Changelog
:cl:
tweak: Extinguishers can now be emptied again without the need of a screwdriver. (Alt-clicking them while held.)
fix: Extinguishers can no longer be emptied out while they're in your storage slots.
/:cl:

