### PR TITLE
Radstorms no longer affect survival pods in the station z-level

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -18,7 +18,7 @@
 
 	area_type = /area
 	protected_areas = list(/area/maintenance, /area/ai_monitored/turret_protected/ai_upload, /area/ai_monitored/turret_protected/ai_upload_foyer,
-	/area/ai_monitored/turret_protected/ai, /area/storage/emergency/starboard, /area/storage/emergency/port, /area/shuttle)
+	/area/ai_monitored/turret_protected/ai, /area/storage/emergency/starboard, /area/storage/emergency/port, /area/shuttle, /area/survivalpod)
 	target_trait = ZTRAIT_STATION
 
 	immunity_type = "rad"


### PR DESCRIPTION
## About The Pull Request

this makes it so that you don't die in a survival pod from a radiation storm event

## Why It's Good For The Game

rng shouldn't just fuck you over just because you wanted to make a balling waystation in space

## Changelog
:cl: Kraso
add: Radstorms will no longer occur in survival pods in the same z-level as the station.
/:cl:
