### PR TITLE
Modifies the Mechfab to use the Ore Silo

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -18,7 +18,9 @@
 	var/list/queue = list()
 	var/processing_queue = 0
 	var/screen = "main"
+	var/link_on_init = TRUE
 	var/temp
+	var/datum/component/remote_materials/rmat
 	var/list/part_sets = list(
 								"Cyborg",
 								"Ripley",
@@ -33,13 +35,11 @@
 								"Misc"
 								)
 
-/obj/machinery/mecha_part_fabricator/Initialize()
-    var/datum/component/material_container/materials = AddComponent(/datum/component/material_container,
-     list(MAT_METAL, MAT_GLASS, MAT_SILVER, MAT_GOLD, MAT_DIAMOND, MAT_PLASMA, MAT_URANIUM, MAT_BANANIUM, MAT_TITANIUM, MAT_BLUESPACE), 0,
-        TRUE, /obj/item/stack, CALLBACK(src, .proc/is_insertion_ready), CALLBACK(src, .proc/AfterMaterialInsert))
-    materials.precise_insertion = TRUE
-    stored_research = new
-    return ..()
+/obj/machinery/mecha_part_fabricator/Initialize(mapload)
+	stored_research = new
+	rmat = AddComponent(/datum/component/remote_materials, "mechfab", mapload && link_on_init)
+	RefreshParts() //Recalculating local material sizes if the fab isn't linked
+	return ..()
 
 /obj/machinery/mecha_part_fabricator/RefreshParts()
 	var/T = 0
@@ -47,8 +47,7 @@
 	//maximum stocking amount (default 300000, 600000 at T4)
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)
 		T += M.rating
-	GET_COMPONENT(materials, /datum/component/material_container)
-	materials.max_amount = (200000 + (T*50000))
+	rmat.set_local_size((200000 + (T*50000)))
 
 	//resources adjustment coefficient (1 -> 0.85 -> 0.7 -> 0.55)
 	T = 1.15
@@ -61,6 +60,12 @@
 	for(var/obj/item/stock_parts/manipulator/Ml in component_parts)
 		T += Ml.rating
 	time_coeff = round(initial(time_coeff) - (initial(time_coeff)*(T))/5,0.01)
+
+/obj/machinery/mecha_part_fabricator/examine(mob/user)
+	. = ..()
+	if(in_range(user, src) || isobserver(user))
+		. += "<span class='notice'>The status display reads: Storing up to <b>[rmat.local_size]</b> material units.<br>Material consumption at <b>[component_coeff*100]%</b>.<br>Build time reduced by <b>[100-time_coeff*100]%</b>.<span>"
+
 
 
 /obj/machinery/mecha_part_fabricator/emag_act()
@@ -104,16 +109,22 @@
 
 /obj/machinery/mecha_part_fabricator/proc/output_available_resources()
 	var/output
-	GET_COMPONENT(materials, /datum/component/material_container)
-	for(var/mat_id in materials.materials)
-		var/datum/material/M = materials.materials[mat_id]
-		output += "<span class=\"res_name\">[M.name]: </span>[M.amount] cm&sup3;"
-		if(M.amount >= MINERAL_MATERIAL_AMOUNT)
-			output += "<span style='font-size:80%;'>- Remove \[<a href='?src=[REF(src)];remove_mat=1;material=[mat_id]'>1</a>\]"
-			if(M.amount >= (MINERAL_MATERIAL_AMOUNT * 10))
-				output += " | \[<a href='?src=[REF(src)];remove_mat=10;material=[mat_id]'>10</a>\]"
-			output += " | \[<a href='?src=[REF(src)];remove_mat=50;material=[mat_id]'>All</a>\]</span>"
-		output += "<br/>"
+	var/datum/component/material_container/materials = rmat.mat_container
+
+	if(materials)
+		for(var/mat_id in materials.materials)
+			var/datum/material/M = mat_id
+			var/amount = materials.materials[mat_id]
+			var/ref = REF(M)
+			output += "<span class=\"res_name\">[M.name]: </span>[amount] cm&sup3;"
+			if(amount >= MINERAL_MATERIAL_AMOUNT)
+				output += "<span style='font-size:80%;'>- Remove \[<a href='?src=[REF(src)];remove_mat=1;material=[ref]'>1</a>\]"
+				if(amount >= (MINERAL_MATERIAL_AMOUNT * 10))
+					output += " | \[<a href='?src=[REF(src)];remove_mat=10;material=[ref]'>10</a>\]"
+				output += " | \[<a href='?src=[REF(src)];remove_mat=50;material=[ref]'>50</a>\]</span>"
+			output += "<br>"
+	else
+		output += "<font color='red'>No material storage connected, please contact the quartermaster.</font><br>"
 	return output
 
 /obj/machinery/mecha_part_fabricator/proc/get_resources_w_coeff(datum/design/D)
@@ -125,18 +136,29 @@
 /obj/machinery/mecha_part_fabricator/proc/check_resources(datum/design/D)
 	if(D.reagents_list.len) // No reagents storage - no reagent designs.
 		return FALSE
-	GET_COMPONENT(materials, /datum/component/material_container)
+	var/datum/component/material_container/materials = rmat.mat_container
 	if(materials.has_materials(get_resources_w_coeff(D)))
 		return TRUE
 	return FALSE
 
 /obj/machinery/mecha_part_fabricator/proc/build_part(datum/design/D)
-	being_built = D
-	desc = "It's building \a [initial(D.name)]."
 	var/list/res_coef = get_resources_w_coeff(D)
 
-	GET_COMPONENT(materials, /datum/component/material_container)
+	var/datum/component/material_container/materials = rmat.mat_container
+	if (!materials)
+		say("No access to material storage, please contact the quartermaster.")
+		return FALSE
+	if (rmat.on_hold())
+		say("Mineral access is on hold, please contact the quartermaster.")
+		return FALSE
+	if(!check_resources(D))
+		say("Not enough resources. Queue processing stopped.")
+		return FALSE
+	being_built = D
+	desc = "It's building \a [initial(D.name)]."
 	materials.use_amount(res_coef)
+	rmat.silo_log(src, "built", -1, "[D.name]", res_coef)
+
 	add_overlay("fab-active")
 	use_power = ACTIVE_POWER_USE
 	updateUsrDialog()
@@ -191,13 +213,10 @@
 	while(D)
 		if(stat&(NOPOWER|BROKEN))
 			return FALSE
-		if(!check_resources(D))
-			say("Not enough resources. Queue processing stopped.")
-			temp = {"<span class='alert'>Not enough resources to build next part.</span><br>
-						<a href='?src=[REF(src)];process_queue=1'>Try again</a> | <a href='?src=[REF(src)];clear_temp=1'>Return</a><a>"}
+		if(build_part(D))
+			remove_from_queue(1)
+		else
 			return FALSE
-		remove_from_queue(1)
-		build_part(D)
 		D = listgetindex(queue, 1)
 	say("Queue processing finished successfully.")
 
@@ -379,16 +398,32 @@
 					break
 
 	if(href_list["remove_mat"] && href_list["material"])
-		GET_COMPONENT(materials, /datum/component/material_container)
-		materials.retrieve_sheets(text2num(href_list["remove_mat"]), href_list["material"])
+		var/datum/material/Mat = locate(href_list["material"])
+		eject_sheets(Mat, text2num(href_list["remove_mat"]))
 
 	updateUsrDialog()
 	return
 
-/obj/machinery/mecha_part_fabricator/on_deconstruction()
-	GET_COMPONENT(materials, /datum/component/material_container)
-	materials.retrieve_all()
-	..()
+/obj/machinery/mecha_part_fabricator/proc/do_process_queue()		
+	if(processing_queue || being_built)		
+		return FALSE		
+	processing_queue = 1
+	process_queue()		
+	processing_queue = 0
+
+/obj/machinery/mecha_part_fabricator/proc/eject_sheets(eject_sheet, eject_amt)
+	var/datum/component/material_container/mat_container = rmat.mat_container
+	if (!mat_container)
+		say("No access to material storage, please contact the quartermaster.")
+		return 0
+	if (rmat.on_hold())
+		say("Mineral access is on hold, please contact the quartermaster.")
+		return 0
+	var/count = mat_container.retrieve_sheets(text2num(eject_amt), eject_sheet, drop_location())
+	var/list/matlist = list()
+	matlist[eject_sheet] = text2num(eject_amt)
+	rmat.silo_log(src, "ejected", -count, "sheets", matlist)
+	return count
 
 /obj/machinery/mecha_part_fabricator/proc/AfterMaterialInsert(type_inserted, id_inserted, amount_inserted)
 	var/stack_name = material2name(id_inserted)
@@ -417,3 +452,6 @@
 		return FALSE
 
 	return TRUE
+
+/obj/machinery/mecha_part_fabricator/maint
+	link_on_init = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Port from https://github.com/tgstation/tgstation/pull/47619

## Why It's Good For The Game

This links the Ore Silo to the roundstart Mechfabs in robotics. Allows for Roboticists to not have to pull materials manually and horde them from the rest of the station. Quartermaster, Captain, or anyone with access to the vault can also unlink or hold the materials on the mechfab should Roboticists be doing things they shouldn't be. Unlinked mechfabs still work as normal. There is also a subtype of mechfab to use /maint in order to be unlinked at round start for maps that have abandoned machinery, but considering Hyper is Box 24/7, I didn't think it was worth adding that to Delta or Meta maps for now.

## Changelog
:cl:
add: Modifications have been made to the Mech Fabricator to allow it to withdraw and deposit to the ore silo (Thanks to alexkar598 from Yogstation for the code!)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
