### PR TITLE
[Port] Adds "Empty" Cloning, Logging, and related fixes

### DIFF
--- a/code/__DEFINES/logging.dm
+++ b/code/__DEFINES/logging.dm
@@ -35,6 +35,7 @@
 #define LOG_GAME		(1 << 12)
 #define LOG_ADMIN_PRIVATE (1 << 13)
 #define LOG_ASAY		(1 << 14)
+#define LOG_CLONING			(1 << 15)
 
 //Individual logging panel pages
 #define INDIVIDUAL_ATTACK_LOG		(LOG_ATTACK)

--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -100,6 +100,10 @@
 #define NUKE_ON_TIMING		2
 #define NUKE_ON_EXPLODING	3
 
+//cloning defines. These are flags.
+#define CLONING_SUCCESS (1<<0)
+#define CLONING_DELETE_RECORD (1<<1)
+
 //these flags are used to tell the DNA modifier if a plant gene cannot be extracted or modified.
 #define PLANT_GENE_REMOVABLE	(1<<0)
 #define PLANT_GENE_EXTRACTABLE	(1<<1)

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -58,6 +58,10 @@
 	if (CONFIG_GET(flag/log_game))
 		WRITE_LOG(GLOB.world_game_log, "GAME: [text]")
 
+/proc/log_cloning(text, mob/initiator)
+	if(CONFIG_GET(flag/log_cloning))
+		WRITE_LOG(GLOB.world_cloning_log, "CLONING: [text]")
+
 /proc/log_access(text)
 	if (CONFIG_GET(flag/log_access))
 		WRITE_LOG(GLOB.world_game_log, "ACCESS: [text]")

--- a/code/_globalvars/logging.dm
+++ b/code/_globalvars/logging.dm
@@ -26,6 +26,8 @@ GLOBAL_VAR(query_debug_log)
 GLOBAL_PROTECT(query_debug_log)
 GLOBAL_VAR(world_job_debug_log)
 GLOBAL_PROTECT(world_job_debug_log)
+GLOBAL_VAR(world_cloning_log)
+GLOBAL_PROTECT(world_cloning_log)
 
 GLOBAL_LIST_EMPTY(bombers)
 GLOBAL_PROTECT(bombers)

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -39,6 +39,8 @@
 
 /datum/config_entry/flag/log_game	// log game events
 
+/datum/config_entry/flag/log_cloning // log cloning actions.
+
 /datum/config_entry/flag/log_vote	// log voting
 
 /datum/config_entry/flag/log_whisper	// log client whisper

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -371,7 +371,7 @@
 		updateappearance(icon_update=0)
 
 	if(LAZYLEN(mutation_index))
-		dna.mutation_index = mutation_index
+		dna.mutation_index = mutation_index.Copy()
 		domutcheck()
 
 	if(mrace || newfeatures || ui)

--- a/code/game/machinery/exp_cloner.dm
+++ b/code/game/machinery/exp_cloner.dm
@@ -9,7 +9,7 @@
 	internal_radio = FALSE
 
 //Start growing a human clone in the pod!
-/obj/machinery/clonepod/experimental/growclone(ckey, clonename, ui, se, datum/species/mrace, list/features, factions)
+/obj/machinery/clonepod/experimental/growclone(clonename, ui, mutation_index, mindref, last_death, blood_type, datum/species/mrace, list/features, factions, list/quirks, datum/bank_account/insurance)
 	if(panel_open)
 		return FALSE
 	if(mess || attempting)
@@ -20,7 +20,7 @@
 
 	var/mob/living/carbon/human/H = new /mob/living/carbon/human(src)
 
-	H.hardset_dna(ui, se, H.real_name, null, mrace, features)
+	H.hardset_dna(ui, mutation_index, H.real_name, blood_type, mrace, features)
 
 	if(efficiency > 2)
 		var/list/unclean_mutations = (GLOB.not_good_mutations|GLOB.bad_mutations)
@@ -292,6 +292,6 @@
 		temp = "<font class='bad'>Cloning cycle already in progress.</font>"
 		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 	else
-		pod.growclone(null, mob_occupant.real_name, dna.uni_identity, dna.mutation_index, clone_species, dna.features, mob_occupant.faction)
+		pod.growclone(mob_occupant.real_name, dna.uni_identity, dna.mutation_index, null, null, dna.blood_type, clone_species, dna.features, mob_occupant.faction)
 		temp = "[mob_occupant.real_name] => <font class='good'>Cloning data sent to pod.</font>"
 		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -100,6 +100,7 @@ GLOBAL_VAR(restart_counter)
 		GLOB.picture_log_directory = "data/picture_logs/[override_dir]"
 
 	GLOB.world_game_log = "[GLOB.log_directory]/game.log"
+	GLOB.world_cloning_log = "[GLOB.log_directory]/cloning.log"
 	GLOB.world_attack_log = "[GLOB.log_directory]/attack.log"
 	GLOB.world_pda_log = "[GLOB.log_directory]/pda.log"
 	GLOB.world_telecomms_log = "[GLOB.log_directory]/telecomms.log"

--- a/config/config.txt
+++ b/config/config.txt
@@ -146,6 +146,9 @@ LOG_MANIFEST
 ## Enable logging pictures
 # LOG_PICTURES
 
+## log cloning actions
+LOG_CLONING
+
 ##Log camera pictures - Must have picture logging enabled
 PICTURE_LOGGING_CAMERA
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Original PR: https://github.com/tgstation/tgstation/pull/44442
Fixes clones DNA sequences being linked #44951: https://github.com/tgstation/tgstation/pull/44951 
Fixes being unable to clone multiple empty clones simultaneously #45768: https://github.com/tgstation/tgstation/pull/45768 
AIs can check clone pod status again #45635: https://github.com/tgstation/tgstation/pull/45635 
Clicking the cloning pod examinates it. #45530: https://github.com/tgstation/tgstation/pull/45530 
[s] Fixes emagging an empty clone killing the last real clone #45643: https://github.com/tgstation/tgstation/pull/45643 
Clone blood type fix #47440: https://github.com/tgstation/tgstation/pull/47440

Cloning actions are also logged now

[2019-11-29 06:18:18.804] CLONING: Autoprocess added the record of BigFatAnimeTiddies/(Kerensa Willey) to the cloning console at Genetics Lab (154, 113, 2).
[2019-11-29 06:18:46.407] CLONING: BigFatAnimeTiddies/(Kerensa Willey) initiated EMPTY cloning of *null* via the cloning console at Genetics Lab (154, 113, 2). Pod: the cloning pod at Genetics Lab (155, 113, 2).

## Why It's Good For The Game

Monkey-cloning was always an option, but kind of unintuitive and rather complicated when you consider you have literal cloning technology one room over.
Can be used to create clone armies, or to pre-prepare a replacement body for a crewmember (and potentially add augments, surgical buffs, and so on) to swap them into at a later time. 

Also general cloning logging is good for admins to look over if need be.

## Changelog
:cl:
add: Cloners now have the option to "Empty Clone" a record, creating a mindless replica of that person.
add: To aid the above function, cloners can now do Body-Only scans, which can be used to create empty clones but not real clones, but bypass the sentience restrictions on scans. They can also be deleted without requiring access.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
