### PR TITLE
Adds a cooldown to tasting the acidity of a mixture ("bugfix" to chat spam)

### DIFF
--- a/code/modules/mob/living/taste.dm
+++ b/code/modules/mob/living/taste.dm
@@ -4,6 +4,7 @@
 	var/last_taste_time
 	var/last_taste_text
 	var/last_ph_taste_time
+	var/last_ph_taste_number
 
 /mob/living/proc/get_taste_sensitivity()
 	return DEFAULT_TASTE_SENSITIVITY
@@ -51,17 +52,29 @@
 		return
 	if (!HAS_TRAIT(src, TRAIT_AGEUSIA)) //I'll let you get away with not having 1 damage.
 		if(last_ph_taste_time + 50 < world.time)
+			var/ph_taste_number
 			switch(from.pH)
 				if(11.5 to INFINITY)
-					to_chat(src, "<span class='warning'>You taste a strong alkaline flavour!</span>")
+					ph_taste_number = 1
 				if(8.5 to 11.5)
-					to_chat(src, "<span class='notice'>You taste a sort of soapy tone in the mixture.</span>")
+					ph_taste_number = 2
 				if(2.5 to 5.5)
-					to_chat(src, "<span class='notice'>You taste a sort of acid tone in the mixture.</span>")
+					ph_taste_number = 3
 				if(-INFINITY to 2.5)
+					ph_taste_number = 4
+
+			if(ph_taste_number != last_ph_taste_number || last_ph_taste_time + 200 < world.time)
+				if (ph_taste_number == 1)
+					to_chat(src, "<span class='warning'>You taste a strong alkaline flavour!</span>")
+				if (ph_taste_number == 2)
+					to_chat(src, "<span class='notice'>You taste a sort of soapy tone in the mixture.</span>")
+				if (ph_taste_number == 3)
+					to_chat(src, "<span class='notice'>You taste a sort of acid tone in the mixture.</span>")
+				if (ph_taste_number == 4)
 					to_chat(src, "<span class='warning'>You taste a strong acidic flavour!</span>")
 
-			last_ph_taste_time = world.time
+				last_ph_taste_time = world.time
+				last_ph_taste_number = ph_taste_number
 
 
 #undef DEFAULT_TASTE_SENSITIVITY

--- a/code/modules/mob/living/taste.dm
+++ b/code/modules/mob/living/taste.dm
@@ -3,6 +3,7 @@
 /mob/living
 	var/last_taste_time
 	var/last_taste_text
+	var/last_ph_taste_time
 
 /mob/living/proc/get_taste_sensitivity()
 	return DEFAULT_TASTE_SENSITIVITY
@@ -49,14 +50,18 @@
 		say("The pH is appropriately [round(from.pH, 1)].")
 		return
 	if (!HAS_TRAIT(src, TRAIT_AGEUSIA)) //I'll let you get away with not having 1 damage.
-		switch(from.pH)
-			if(11.5 to INFINITY)
-				to_chat(src, "<span class='warning'>You taste a strong alkaline flavour!</span>")
-			if(8.5 to 11.5)
-				to_chat(src, "<span class='notice'>You taste a sort of soapy tone in the mixture.</span>")
-			if(2.5 to 5.5)
-				to_chat(src, "<span class='notice'>You taste a sort of acid tone in the mixture.</span>")
-			if(-INFINITY to 2.5)
-				to_chat(src, "<span class='warning'>You taste a strong acidic flavour!</span>")
+		if(last_ph_taste_time + 50 < world.time)
+			switch(from.pH)
+				if(11.5 to INFINITY)
+					to_chat(src, "<span class='warning'>You taste a strong alkaline flavour!</span>")
+				if(8.5 to 11.5)
+					to_chat(src, "<span class='notice'>You taste a sort of soapy tone in the mixture.</span>")
+				if(2.5 to 5.5)
+					to_chat(src, "<span class='notice'>You taste a sort of acid tone in the mixture.</span>")
+				if(-INFINITY to 2.5)
+					to_chat(src, "<span class='warning'>You taste a strong acidic flavour!</span>")
+
+			last_ph_taste_time = world.time
+
 
 #undef DEFAULT_TASTE_SENSITIVITY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title, especially apparent when you'd dip your cigs, use a vape or a rollie where the mixture would have a higher and lower PH than normal - your chat would get spammed with annoying messages.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Your chatbox is no longer 1/2 spam if you smoke a dipped cig

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: cooldown for acidity taste
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
