### PR TITLE
Adds robotic voiceboxes as contraband in the Roboticist Vendor

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -131,6 +131,7 @@
 					/obj/item/clothing/mask/bandana/skull = 2)
 	premium = list(/obj/item/radio/headset/headset_rob = 2) //Cit change
 	contraband = list(/obj/item/clothing/suit/hooded/techpriest = 2)
+	contraband = list(/obj/item/organ/tongue/robot = 2)
 	refill_canister = /obj/item/vending_refill/wardrobe/robo_wardrobe
 
 /obj/item/vending_refill/wardrobe/robo_wardrobe


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The title explains most of it, really.

## Why It's Good For The Game

It's a bit sad that in order to let your fully augged patient speak like a robot, you have to wait for a meat-eor shower or use other esoteric means to give them the SPAN_ROBOT span. Now you can hack your vendor and make your patient an even better imitation of an android and/or add an extra element to your cardborg costume.

## Changelog
:cl:
add: Added two robotic voiceboxes to the contraband section of the Robotech Deluxe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
