### PR TITLE
You can now get an advanced camera console

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -31,6 +31,7 @@
 
 /obj/machinery/computer/camera_advanced/syndie
 	icon_keyboard = "syndie_key"
+	circuit = /obj/item/circuitboard/computer/advanced_camera
 
 /obj/machinery/computer/camera_advanced/proc/CreateEye()
 	eyeobj = new()

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -14,6 +14,10 @@
 	name = "Security Cameras (Computer Board)"
 	build_path = /obj/machinery/computer/security
 
+/obj/item/circuitboard/computer/advanced_camera
+	name = "Advanced Camera Console (Computer Board)"
+	build_path = /obj/machinery/computer/camera_advanced/syndie
+
 /obj/item/circuitboard/computer/xenobiology
 	name = "circuit board (Xenobiology Console)"
 	build_path = /obj/machinery/computer/camera_advanced/xenobio

--- a/code/modules/research/designs/comp_board_designs/comp_board_designs_sec.dm
+++ b/code/modules/research/designs/comp_board_designs/comp_board_designs_sec.dm
@@ -41,3 +41,11 @@
 	build_path = /obj/item/circuitboard/computer/card
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY	| DEPARTMENTAL_FLAG_ENGINEERING 	//Honestly should have a bridge techfab for this sometime.
+
+/datum/design/board/advanced_camera
+	name = "Computer Design (Advanced Camera Console)"
+	desc = "Allows for the construction of circuit boards used to build advanced camera consoles."
+	id = "advanced_camera"
+	build_path = /obj/item/circuitboard/computer/advanced_camera
+	category = list("Computer Boards")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1052,7 +1052,7 @@
 	display_name = "Illegal Technology"
 	description = "Dangerous research used to create dangerous objects."
 	prereq_ids = list("adv_engi", "adv_weaponry", "explosive_weapons")
-	design_ids = list("decloner", "borg_syndicate_module", "suppressor", "largecrossbow", "donksofttoyvendor")
+	design_ids = list("decloner", "borg_syndicate_module", "suppressor", "largecrossbow", "donksofttoyvendor", "advanced_camera")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 	hidden = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can get an advanced camera console from illegal tech.

## Why It's Good For The Game
Allows for checking on station better without those shitty ass dropdown menus if illegal tech is obtained. Is under illegal tech because only syndies use the consoles and the ai camera upgrade is there so makes sense.

It is only printable at the Security Lathe once researched, so it isn't like some average Joe is going to have advanced cams once the research is done. Perfect for Warden players though.

Original PR: https://github.com/tgstation/tgstation/pull/45202

## Changelog
:cl:
add: You can now get an advanced camera console from the security lathe after illegal technology has been obtained.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
