### PR TITLE
[Merge Conflict] Removes Fake Greenshift and Obfuscated voting

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -224,7 +224,7 @@ SUBSYSTEM_DEF(vote)
 
 		SEND_SOUND(world, sound('sound/misc/notice2.ogg'))
 		reset()
-		obfuscated = hideresults //CIT CHANGE - adds obfuscated votes
+		obfuscated = FALSE //CIT CHANGE - adds obfuscated votes
 		switch(vote_type)
 			if("restart")
 				choices.Add("Restart Round","Continue Playing")

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -19,14 +19,10 @@
 	false_report_weight = 0
 
 /datum/game_mode/extended/announced/generate_station_goals()
-	if(flipseclevel) //CIT CHANGE - allows the sec level to be flipped roundstart
-		return ..()
 	for(var/T in subtypesof(/datum/station_goal))
 		var/datum/station_goal/G = new T
 		station_goals += G
 		G.on_report()
 
 /datum/game_mode/extended/announced/send_intercept(report = 0)
-	if(flipseclevel) //CIT CHANGE - allows the sec level to be flipped roundstart
-		return ..()
 	priority_announce("Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!", "Security Report", 'sound/ai/commandreport.ogg')

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -48,7 +48,6 @@
 
 	var/gamemode_ready = FALSE //Is the gamemode all set up and ready to start checking for ending conditions.
 	var/setup_error		//What stopepd setting up the mode.
-	var/flipseclevel = FALSE //CIT CHANGE - adds a 10% chance for the alert level to be the opposite of what the gamemode is supposed to have
 
 /datum/game_mode/proc/announce() //Shows the gamemode's name and a fast description.
 	to_chat(world, "<b>The gamemode is: <span class='[announce_span]'>[name]</span>!</b>")
@@ -84,8 +83,6 @@
 		report = !CONFIG_GET(flag/no_intercept_report)
 	addtimer(CALLBACK(GLOBAL_PROC, .proc/display_roundstart_logout_report), ROUNDSTART_LOGOUT_REPORT_TIME)
 
-	if(prob(20)) //CIT CHANGE - adds a 20% chance for the security level to be the opposite of what it normally is
-		flipseclevel = TRUE
 	if(SSdbcore.Connect())
 		var/sql
 		if(SSticker.mode)
@@ -256,9 +253,6 @@
 	return 0
 
 /datum/game_mode/proc/send_intercept()
-	if(flipseclevel && !(config_tag == "extended"))//CIT CHANGE - lets the security level be flipped roundstart
-		priority_announce("Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!", "Security Report", 'sound/ai/commandreport.ogg')
-		return
 	var/intercepttext = "<b><i>Central Command Status Summary</i></b><hr>"
 	intercepttext += "<b>Central Command has intercepted and partially decoded a Syndicate transmission with vital information regarding their movements. The following report outlines the most \
 	likely threats to appear in your sector.</b>"
@@ -517,12 +511,6 @@
 		rev.remove_revolutionary(TRUE)
 
 /datum/game_mode/proc/generate_station_goals()
-	if(flipseclevel && !(config_tag == "extended")) //CIT CHANGE - allows the sec level to be flipped roundstart
-		for(var/T in subtypesof(/datum/station_goal))
-			var/datum/station_goal/G = new T
-			station_goals += G
-			G.on_report()
-		return
 	var/list/possible = list()
 	for(var/T in subtypesof(/datum/station_goal))
 		var/datum/station_goal/G = T


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the 20% fake green shift that can be applied to non-extended / secret extended rounds. 

Removes the Obfuscation on the round start game mode vote.

![image](https://user-images.githubusercontent.com/6519623/70843836-7e8c9180-1e06-11ea-8b87-0ecc8845bb28.png)

![image](https://user-images.githubusercontent.com/6519623/70843838-83e9dc00-1e06-11ea-86c7-c600036cbceb.png)

## Why It's Good For The Game

This solves part of the issue with players power gaming once the round begins. People should know at the beginning of the round what kind of shift they should expect. People can see how many votes showed up for Secret and how many for Extended, thus set their expectations to where it is needed. If the vote shows up Extended winning, people can safely do their job, fuck off the ERP, or just do the bare minimum of work. If it shows up Secret, people can expect to have an idea that there will be a possibility of some form of threat existing on the station, and have the sense of paranoia among fellow crew members that SS13 is known for.

Also removing the "Flip sec level" variable on game modes and extended. I believe fake green shift devalues actual green shifts because players will honestly never really trust a report showing up as green when there is a 20% chance for every secret game mode, included secret extended (Fake Blue), to show up green. Green shifts are meant for players to relax and maybe actually roleplay their characters instead of being paranoid the report was fake and you get gibbed by a traitor. Also, funny enough, Fake Green appears it can effect Fake blueshift as well.

!(config_tag == "extended")) would imply any game mode config BUT Extended, and Secret Extended is config_tag = "secret_extended". So a Fake blueshift can turn into a fake greenshift which is just Extended with extra steps and a slap in the face for anyone who voted Secret.

## Changelog
:cl:
del: Removes "Fake Greenshift" and Vote obfuscation for roundstart voting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
