### PR TITLE
Changes the birthday cake to use normal ingredients

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_cake.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_cake.dm
@@ -69,8 +69,9 @@
 /datum/crafting_recipe/food/birthdaycake
 	name = "Birthday cake"
 	reqs = list(
-		/obj/item/clothing/head/hardhat/cakehat = 1,
-		/obj/item/reagent_containers/food/snacks/store/cake/plain = 1
+		/obj/item/reagent_containers/food/snacks/store/cake/plain = 1,
+		/obj/item/candle = 1,
+		/datum/reagent/consumable/sugar = 5,
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/birthday
 	subcategory = CAT_CAKE


### PR DESCRIPTION

## About The Pull Request
basically we don't have a cakehat on our map as far as I can tell which makes Caks and birthday cakes uncraftable, this gives them a normal recipe instead.

## Why It's Good For The Game
a few things are unobtainable because of the cringe cakehat.
## Changelog
:cl:
tweak: birthday cake no longer needs cakehat.
/:cl:
