### PR TITLE
Genital size production scaling and minor code cleanup

### DIFF
--- a/modular_citadel/code/modules/arousal/organs/breasts.dm
+++ b/modular_citadel/code/modules/arousal/organs/breasts.dm
@@ -14,35 +14,44 @@
 	var/statuscheck			= FALSE
 	fluid_id				= "milk"
 	var/amount				= 2
+	fluid_mult				= 0.25 // Set to a lower value due to production scaling with size (I.E. D cups produce the "normal" amount)
 	producing				= TRUE
 	shape					= "Pair"
 	can_masturbate_with		= TRUE
 	masturbation_verb 		= "massage"
 	can_climax				= TRUE
 	fluid_transfer_factor 	= 0.5
+	var/sent_full_message	= TRUE //defaults to 1 since they're full to start
 
 /obj/item/organ/genital/breasts/on_life()
 	if(QDELETED(src))
 		return
 	if(!reagents || !owner)
 		return
-	reagents.maximum_volume = fluid_max_volume
+	reagents.maximum_volume = fluid_max_volume * cached_size * fluid_mult // fluid amount is also scaled by the size of the organ
 	if(fluid_id && producing)
 		if(reagents.total_volume == 0) // Apparently, 0.015 gets rounded down to zero and no reagents are created if we don't start it with 0.1 in the tank.
 			fluid_rate = 0.1
 		else
-			fluid_rate = CUM_RATE
-		if(reagents.total_volume >= 5)
-			fluid_mult = 0.5
-		else
-			fluid_mult = 1
+			fluid_rate = CUM_RATE * cached_size * fluid_mult // fluid rate is scaled by the size of the organ
 		generate_milk()
 
 /obj/item/organ/genital/breasts/proc/generate_milk()
 	if(owner.stat == DEAD)
 		return FALSE
+	if(reagents.total_volume >= reagents.maximum_volume)
+		if(!sent_full_message)
+			send_full_message()
+			sent_full_message = TRUE
+		return FALSE
+	sent_full_message = FALSE
 	reagents.isolate_reagent(fluid_id)
-	reagents.add_reagent(fluid_id, (fluid_mult * fluid_rate))
+	reagents.add_reagent(fluid_id, (fluid_rate))
+
+/obj/item/organ/genital/breasts/proc/send_full_message(msg = "Your breasts finally feel full, again.")
+	if(owner && istext(msg))
+		to_chat(owner, msg)
+		return TRUE
 
 /obj/item/organ/genital/breasts/update_appearance()
 	var/lowershape = lowertext(shape)
@@ -64,7 +73,7 @@
 			desc += " You estimate that they're [uppertext(size)]-cups."
 			//string = "breasts_[lowertext(shape)]_[size]-s"
 
-	if(producing && aroused_state)
+	if(producing && sent_full_message)
 		desc += " They're leaking [fluid_id]."
 	var/string
 	if(owner)
@@ -91,7 +100,6 @@
 //this is far too lewd wah
 
 /obj/item/organ/genital/breasts/update_size()//wah
-
 	if(!ishuman(owner) || !owner)
 		return
 	if(cached_size < 0)//I don't actually know what round() does to negative numbers, so to be safe!!fixed


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR cleans up some junk code and frees up a vairable for breast fluid production modification values for whatever ERP shenanigans you come up with. It also changes fluid production to scale with genital size, as well as the storage for said fluid.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Adds in more weh factor.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added in a new functionality where breast fluid production and storage would scale with the size of the breasts
del: Removed a function where breasts would slow down production when containing more than 5 units of regents
code: Freed up fluid_mult for a variable to tweak in order to adjust how much fluid is produced in runtime. 
admin: Added the capacity to tweak fluid_mult in runtime in order to scale the target's fluid production and storage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
