### PR TITLE
Balances the NT Private Security Officers

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/nanotrasen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/nanotrasen.dm
@@ -28,7 +28,7 @@
 	unsuitable_atmos_damage = 15
 	faction = list("nanotrasenprivate")
 	status_flags = CANPUSH
-	speak = list("Stop resisting!", "I AM THE LAW!", "Face the wrath of the golden bolt!", "Stop breaking the law, asshole!")
+	speak = list("Stop resisting!", "I AM THE LAW!", "Get down on the floor, creep!", "Stop breaking the law, asshole!")
 	search_objects = 1
 
 	do_footstep = TRUE
@@ -46,7 +46,7 @@
 	ranged = 1
 	retreat_distance = 3
 	minimum_distance = 5
-	casingtype = /obj/item/ammo_casing/c45
+	casingtype = /obj/item/ammo_casing/c45_nostamina
 	projectilesound = 'sound/weapons/gunshot.ogg'
 	loot = list(/obj/item/gun/ballistic/automatic/pistol/m1911,
 				/obj/effect/mob_spawn/human/corpse/nanotrasensoldier)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Remove the 65 stamina damage done per shot by the NT officers found in the genetics and space battle gateway, and removes a line relating to tasers

## Why It's Good For The Game

No other .45 calibre weapon does stamina damage in the game, and they don't use tasers, they use an M1911. 

## Changelog
:cl:
tweak: Changed the line "Face the wrath of the golden bolt!" to "Get down on the floor, creep!"
balance: Bullets from private NT security officers no longer do 65 stamina damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
