### PR TITLE
Attack verb fix

### DIFF
--- a/hyperstation/code/obj/plushes.dm
+++ b/hyperstation/code/obj/plushes.dm
@@ -8,7 +8,6 @@
 /obj/item/toy/plush/mammal/marilyn
 	desc = "A cute stuffed fox toy. Now, about that sponge bath..."
 	icon = 'hyperstation/icons/obj/plushes.dmi'
-	attack_verb = list("hugged", "cuddled", "embraced")
 	icon_state = "marilyn"
 	item_state = "marilyn"
 
@@ -18,7 +17,6 @@
 	icon = 'hyperstation/icons/obj/plushes.dmi'
 	icon_state = "winterbloo"
 	item_state = "winterbloo"
-	attack_verb = list("hugged", "cuddled", "embraced")
 
 /obj/item/toy/plush/lizardplushie/chris
 	name = "Chris Plushie"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Not sure if Quote Fox or Winfre was aware of this, but the attack verbs are purely there for flavor text. This PR removes the attack verbs from the plushies, assuming they were accidentally added.

Let me know if you wanted to keep these attack verbs or change them to be specific to the plushies involved.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Consistency

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed attack verbs from Marylin and winterbloo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
