### PR TITLE
Thruster Module for worker exosuits

### DIFF
--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -478,3 +478,46 @@
 /obj/item/mecha_parts/mecha_equipment/generator/nuclear/process()
 	if(..())
 		radiation_pulse(get_turf(src), rad_per_cycle)
+
+
+
+/////////////////////////////////////////// THRUSTER MODULE /////////////////////////////////////////////
+
+
+/obj/item/mecha_parts/mecha_equipment/thruster_module
+	name = "exosuit thruster module"
+	desc = "A set of heavy duty ion thrusters, capable of propelling industrial mechs"
+	icon_state = "tesla"
+	energy_drain = 50
+	range = 0
+	selectable = 0
+	var/datum/effect_system/trail_follow/ion/ion_trail
+	
+/obj/item/mecha_parts/mecha_equipment/thruster_module/Initialize()
+	ion_trail = new
+	ion_trail.set_up(src)
+	
+/obj/item/mecha_parts/mecha_equipment/thruster_module/Topic(href, href_list)
+	..()
+	if(href_list["toggle_thruster"])
+		if(equip_ready) //inactive
+			chassis.thrusters_active = TRUE
+			ion_trail.start()
+			set_ready_state(0)
+			log_message("Activated.")
+		else
+			chassis.thrusters_active = FALSE
+			ion_trail.stop()
+			set_ready_state(1)
+			log_message("Deactivated.")
+			
+/obj/item/mecha_parts/mecha_equipment/thruster_module/can_attach(obj/mecha/working/M)
+	if(..())
+		if(istype(M))
+			return 1
+	return 0
+	
+/obj/item/mecha_parts/mecha_equipment/thruster_module/get_equip_info()
+	if(!chassis)
+		return
+	return "<span style=\"color:[equip_ready?"#0f0":"#f00"];\">*</span>&nbsp; [src.name] - <a href='?src=[REF(src)];toggle_thruster=1'>[equip_ready?"A":"Dea"]ctivate</a>"

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -13,6 +13,7 @@
 	var/can_move = 0 //time of next allowed movement
 	var/mob/living/carbon/occupant = null
 	var/step_in = 10 //make a step in step_in/10 sec.
+	var/did_space_move = 0
 	var/dir_in = 2//What direction will the mech face when entered/powered on? Defaults to South.
 	var/normal_step_energy_drain = 10 //How much energy the mech will consume each time it moves. This variable is a backup for when leg actuators affect the energy drain.
 	var/step_energy_drain = 10
@@ -504,7 +505,9 @@
 /obj/mecha/Process_Spacemove(var/movement_dir = 0)
 	. = ..()
 	if(.)
+		did_space_move = 0
 		return 1
+	did_space_move = 1
 	if(thrusters_active && movement_dir && use_power(step_energy_drain))
 		return 1
 
@@ -577,12 +580,13 @@
 	if(strafe)
 		setDir(current_dir)
 	if(result && stepsound)
-		playsound(src,stepsound,40,1)
+		if (!did_space_move)
+			playsound(src,stepsound,40,1)
 	return result
 
 /obj/mecha/proc/mechsteprand()
 	var/result = step_rand(src)
-	if(result && stepsound)
+	if(result && stepsound && !did_space_move)
 		playsound(src,stepsound,40,1)
 	return result
 

--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -396,3 +396,13 @@
 	construction_time = 250
 	build_path = /obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam
 	category = list("Exosuit Equipment")
+	
+/datum/design/mech_thruster_module
+	name = "Exosuit Module (Thruster Module)"
+	desc = "Thruster Module for space exploration."
+	id = "mech_repair_droid"
+	build_type = MECHFAB
+	build_path = /obj/item/mecha_parts/mecha_equipment/thruster_module
+	materials = list(MAT_METAL=10000,MAT_GLASS=5000,MAT_GOLD=1000,MAT_SILVER=2000)
+	construction_time = 100
+	category = list("Exosuit Equipment")

--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -396,13 +396,13 @@
 	construction_time = 250
 	build_path = /obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam
 	category = list("Exosuit Equipment")
-	
+
 /datum/design/mech_thruster_module
 	name = "Exosuit Module (Thruster Module)"
 	desc = "Thruster Module for space exploration."
-	id = "mech_repair_droid"
+	id = "mech_thruster_module"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/thruster_module
-	materials = list(MAT_METAL=10000,MAT_GLASS=5000,MAT_GOLD=1000,MAT_SILVER=2000)
-	construction_time = 100
+	materials = list(MAT_METAL=10000, MAT_GLASS = 4000, MAT_GOLD=2000)
+	construction_time = 200
 	category = list("Exosuit Equipment")

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -173,7 +173,7 @@
 	display_name = "Advanced Engineering"
 	description = "Pushing the boundaries of physics, one chainsaw-fist at a time."
 	prereq_ids = list("engineering", "emp_basic")
-	design_ids = list("engine_goggles", "magboots", "forcefield_projector", "weldingmask", "tray_goggles_prescription", "engine_goggles_prescription", "mesons_prescription", "double_emergency_oxygen")
+	design_ids = list("engine_goggles", "magboots", "forcefield_projector", "weldingmask", "tray_goggles_prescription", "engine_goggles_prescription", "mesons_prescription", "double_emergency_oxygen","rcd_loaded", "pipe_dispenser","rcd_upgrade_frames", "rcd_upgrade_simple_circuits")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 4000)
 	export_price = 5000
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -173,7 +173,7 @@
 	display_name = "Advanced Engineering"
 	description = "Pushing the boundaries of physics, one chainsaw-fist at a time."
 	prereq_ids = list("engineering", "emp_basic")
-	design_ids = list("engine_goggles", "magboots", "forcefield_projector", "weldingmask", "tray_goggles_prescription", "engine_goggles_prescription", "mesons_prescription", "double_emergency_oxygen","rcd_loaded", "pipe_dispenser","rcd_upgrade_frames", "rcd_upgrade_simple_circuits")
+	design_ids = list("engine_goggles", "magboots", "forcefield_projector", "weldingmask", "tray_goggles_prescription", "engine_goggles_prescription", "mesons_prescription", "double_emergency_oxygen")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 4000)
 	export_price = 5000
 
@@ -718,7 +718,7 @@
 	display_name = "Advanced Exosuits"
 	description = "For when you just aren't Gundam enough."
 	prereq_ids = list("adv_robotics")
-	design_ids = list("mech_repair_droid")
+	design_ids = list("mech_repair_droid", "mech_thruster_module")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in a new thruster module for worker exosuits (Ripley, Ripley MK II, Firefighter), allowing them to move in space freely when installed. This PR also makes some slight changes, such as preventing exosuits from making stomp noises when in space (because... there's nothing to stomp on). The thruster module has also been added to the techweb under "Advanced Exosuits", and made at an exosuit fabricator.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Mechs are a sorely underused tool as of currently because of many drawbacks they impose on the player which are much better solved without mech assistance. The ability to use mechs with thrusters would make them valuable tools for engineers and miners, needing them not expose themselves to the harsh vacuum of space, without having to take one of the potentially unavailable/stolen hardsuits their department normally uses.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added the "Thruster Module", an exosuit module for any worker exosuits (such as the Ripley, Ripley MK II and the Firefighter MK III), which allows the exosuit to fly in space. It can be found in the "Advanced Exosuits" research node, and made at an exosuit fabricator.
tweak: Mechs will not stomp when moving in space (since there's nothing to stomp on...)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
