### PR TITLE
Miner balance

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -261,7 +261,7 @@
 	desc = "A wing ripped from a watcher. Suitable as a trophy for a kinetic crusher."
 	icon_state = "watcher_wing"
 	denied_type = /obj/item/crusher_trophy/watcher_wing
-	bonus_value = 50
+	bonus_value = 30
 
 /obj/item/crusher_trophy/watcher_wing/effect_desc()
 	return "mark detonation to prevent certain creatures from using certain attacks for <b>[bonus_value*0.1]</b> second\s"
@@ -442,4 +442,4 @@
 		new /obj/effect/temp_visual/hierophant/wall/crusher(otherT, user)
 
 /obj/effect/temp_visual/hierophant/wall/crusher
-	duration = 75
+	duration = 55

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -125,6 +125,8 @@ Difficulty: Very Hard
 		if(H.mind)
 			if(H.mind.martial_art && prob(H.mind.martial_art.deflection_chance))
 				. = TRUE
+		if (is_species(H, /datum/species/golem/sand))
+			. = TRUE
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/alternating_dir_shots()
 	dir_shots(GLOB.diagonals)


### PR DESCRIPTION
This patch, we're addressing the "Crushing dominating megafauna" problem
The kinetic crusher has been dominating too much as soon you get Vortex talisman + Watcher wing

Which absolutely allow you to destroy megafauna with no effort.
Basically the fight turns into
Press Up. Hit. Down. Up. Hit. repeat that simple no counterfight to it.

Miners argue that if you kill the hierophant you ***Deserve it*** but i think it shouldnt make all other megafaunas easy mode.

## Changelog
:cl: Improvedname
balance: Watcher wing reduced from 5 seconds to 3 seconds
balance: Collusus will now enrage at sandstone golems
balance: Hierophant wall stays up for a shorter time.
/:cl: