### PR TITLE
Adds language speaker quirks

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -203,3 +203,33 @@
 /datum/quirk/bloodpressure/remove()
 	var/mob/living/M = quirk_holder
 	M.blood_ratio = 1
+
+/datum/quirk/draconicspeaker
+	name = "Draconic speaker"
+	desc = "Due to your time spent around lizards, you can speak Draconic!"
+	value = 1
+	gain_text = "<span class='notice'>You feel sensitive to hissing noises and your tongue curls comfortably.</span>"
+	lose_text = "<span class='notice'>You forget how to speak Draconic!</span>"
+
+/datum/quirk/draconicspeaker/add()
+	var/mob/living/M = quirk_holder
+	M.grant_language(/datum/language/draconic)
+
+/datum/quirk/draconicspeaker/remove()
+	var/mob/living/M = quirk_holder
+	M.remove_language(/datum/language/draconic)
+
+/datum/quirk/slimespeaker
+	name = "Slime speaker"
+	desc = "Due to your time spent around slimes, you can speak Slimespeak!"
+	value = 1
+	gain_text = "<span class='notice'>You feel sensitive to blorbling noises, and your throat produces melodic sounds.</span>"
+	lose_text = "<span class='notice'>You forget how to speak Slimespeak!</span>"
+
+/datum/quirk/slimespeaker/add()
+	var/mob/living/M = quirk_holder
+	M.grant_language(/datum/language/slime)
+
+/datum/quirk/slimespeaker/remove()
+	var/mob/living/M = quirk_holder
+	M.remove_language(/datum/language/slime)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A simple addition that adds two quirks, which allow the player to speak slimetongue and draconic as a non-slime and non-lizard race, respectively. Each quirk costs one point. It is not that game breaking, since anyone competent at circuits can make a translator, but I digress.
It is also useful for role-play and lore, where your character may have learnt other languages due to their exposure to other races.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Everyone hates it when liggers are speaking draconic over common and nobody knows if they're plotting to take over the station or flirting awkwardly, and thus this quirk will allow you to know what they are saying, or have others have this quirk and have them translate.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added "Draconic Speaker" quirk, a quirk which costs 1 quirk point and allows you to understand and speak Draconic.
add: Added "Slime Speaker" quirk, a quirk which costs 1 quirk point and allows you to understand and speak Slimespeak.
balance: Indirectly nerfed draconic :P
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
