### PR TITLE
Altered new book text and mechannics to make sense

### DIFF
--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -182,12 +182,11 @@
 	name = "Datapad"
 	icon = 'icons/obj/library.dmi'
 	icon_state ="book"
-	desc = "A fancy new state of the art Digital-Readpad(tm) provided by Nanotrasen, No more 20th century paper!"
+	desc = "A fancy new state of the art Digital-Readpad™ provided by Nanotrasen, No more 20th century paper!"
 	throw_speed = 1
 	throw_range = 5
 	w_class = WEIGHT_CLASS_NORMAL		 //upped to three because books are, y'know, pretty big. (and you could hide them inside eachother recursively forever)
 	attack_verb = list("bashed", "whacked", "educated")
-	resistance_flags = FLAMMABLE
 	var/dat				//Actual page content
 	var/due_date = 0	//Game time in 1/10th seconds
 	var/author			//Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
@@ -200,28 +199,28 @@
 		to_chat(user, "<span class='warning'>As you are trying to read, you suddenly feel very stupid!</span>")
 		return
 	if(ismonkey(user))
-		to_chat(user, "<span class='notice'>You skim through the book but can't comprehend any of it.</span>")
+		to_chat(user, "<span class='notice'>You skim through the datapad but can't comprehend any of it.</span>")
 		return
 	if(dat)
-		user << browse("<TT><I>Penned by [author].</I></TT> <BR>" + "[dat]", "window=book[window_size != null ? ";size=[window_size]" : ""]")
-		user.visible_message("[user] opens a book titled \"[title]\" and begins reading intently.")
+		user << browse("<TT><I>Created by [author].</I></TT> <BR>" + "[dat]", "window=book[window_size != null ? ";size=[window_size]" : ""]")
+		user.visible_message("[user] begins reading a datapad titled \"[title]\" intently.")
 		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "book_nerd", /datum/mood_event/book_nerd)
 		onclose(user, "book")
 	else
-		to_chat(user, "<span class='notice'>This book is completely blank!</span>")
+		to_chat(user, "<span class='notice'>This datapad is completely blank!</span>")
 
 
 /obj/item/book/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/pen))
 		if(is_blind(user))
-			to_chat(user, "<span class='warning'> As you are trying to write on the book, you suddenly feel very stupid!</span>")
+			to_chat(user, "<span class='warning'> As you are trying to edit the datapad, you suddenly feel very stupid!</span>")
 			return
 		if(unique)
-			to_chat(user, "<span class='warning'>These pages don't seem to take the ink well! Looks like you can't modify it.</span>")
+			to_chat(user, "<span class='warning'>These entries don't seem to be editable! Looks like you can't modify it.</span>")
 			return
 		var/literate = user.is_literate()
 		if(!literate)
-			to_chat(user, "<span class='notice'>You scribble illegibly on the cover of [src]!</span>")
+			to_chat(user, "<span class='notice'>You enter illegible text on the cover page of [src]!</span>")
 			return
 		var/choice = input("What would you like to change?") in list("Title", "Contents", "Author", "Cancel")
 		if(!user.canUseTopic(src, BE_CLOSE, literate))
@@ -232,7 +231,7 @@
 				if(!user.canUseTopic(src, BE_CLOSE, literate))
 					return
 				if (length(newtitle) > 20)
-					to_chat(user, "That title won't fit on the cover!")
+					to_chat(user, "That title is too large for the datapad's memory!")
 					return
 				if(!newtitle)
 					to_chat(user, "That title is invalid.")
@@ -241,7 +240,7 @@
 					name = newtitle
 					title = newtitle
 			if("Contents")
-				var/content = stripped_input(user, "Write your book's contents (HTML NOT allowed):","","",8192)
+				var/content = stripped_input(user, "Write your datapad's contents (HTML NOT allowed):","","",8192)
 				if(!user.canUseTopic(src, BE_CLOSE, literate))
 					return
 				if(!content)
@@ -250,7 +249,7 @@
 				else
 					dat += content
 			if("Author")
-				var/newauthor = stripped_input(user, "Write the author's name:")
+				var/newauthor = stripped_input(user, "Enter the author's name:")
 				if(!user.canUseTopic(src, BE_CLOSE, literate))
 					return
 				if(!newauthor)
@@ -291,10 +290,10 @@
 					scanner.computer.inventory.Add(src)
 					to_chat(user, "[I]'s screen flashes: 'Book stored in buffer. Title added to general inventory.'")
 
-	else if(istype(I, /obj/item/kitchen/knife) || istype(I, /obj/item/wirecutters))
-		to_chat(user, "<span class='notice'>You begin to carve out [title]...</span>")
+	else if(istype(I, /obj/item/multitool))
+		to_chat(user, "<span class='notice'>You begin to erase the data from [title] with your PDA!...</span>")
 		if(do_after(user, 30, target = src))
-			to_chat(user, "<span class='notice'>You carve out the pages from [title]! You didn't want to read it anyway.</span>")
+			to_chat(user, "<span class='notice'>You erase all the page data from [title] with your PDA! You didn't want to read it anyway.</span>")
 			var/obj/item/storage/book/B = new
 			B.name = src.name
 			B.title = src.title

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -11,7 +11,7 @@
  * Pens
  */
 /obj/item/pen
-	desc = "It's a normal black ink pen."
+	desc = "It's a black ink pen, modified for use with both paper and Nanotransen-brand Digital-Readpads™!"
 	name = "pen"
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "pen"
@@ -33,12 +33,12 @@
 	return(BRUTELOSS)
 
 /obj/item/pen/blue
-	desc = "It's a normal blue ink pen."
+	desc = "It's a blue ink pen, modified for use with both paper and Nanotransen-brand Digital-Readpads™!"
 	icon_state = "pen_blue"
 	colour = "blue"
 
 /obj/item/pen/red
-	desc = "It's a normal red ink pen."
+	desc = "It's a red ink pen, modified for use with both paper and Nanotransen-brand Digital-Readpads™!"
 	icon_state = "pen_red"
 	colour = "red"
 
@@ -48,7 +48,7 @@
 	colour = "white"
 
 /obj/item/pen/fourcolor
-	desc = "It's a fancy four-color ink pen, set to black."
+	desc = "It's a fancy four-color ink pen, set to black. Modified to be compatible with Nanotransen-brand Digital-Readpads™"
 	name = "four-color pen"
 	colour = "black"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the interaction lines of the book, and the tool used to make it unreadable (formerly the knife or wirecutters) so that interactions with them makes sense with their newly introduced look

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Purely for immersion purposes. Dosen't make sense you can set a small computer on fire like a peice of paper, or that regular pens can make their mark on glass with just ink, or that knives could cut the pages out of a digital book.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Changed pen observation text
tweak: Changed book interaction text
tweak: Made the now computerised books non-flamable
tweak: Changed the book erasure tool from a knife or wirecutters to a multitool
tweak: Changed all mention of "book" in the interaction text to "datapad" to match its name
add: added in propper trademark signs (tested them, byond works fine with them)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
