### PR TITLE
Enables respawns in default config

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -189,7 +189,7 @@ VOTE_AUTOTRANSFER_INTERVAL 18000
 # DEFAULT_NO_VOTE
 
 ## disable abandon mob
-NORESPAWN
+# NORESPAWN
 
 ## disables calling del(src) on newmobs if they logout before spawnin in
 # DONT_DEL_NEWMOB


### PR DESCRIPTION
#232  About The Pull Request

Changes the default config to have respawns enabled. 

## Why It's Good For The Game

Respawns are an important feature most 'long round' furry servers allow for, and allow people to change characters during the round. The majority of other large servers such as this allow respawns by default now, this is just a change to bring us closer to the standard others have.

## Changelog
:cl:
config: Enables respawns by default in the config.
/:cl:
