### PR TITLE
Add breast and penis augmentation surgeries

### DIFF
--- a/code/modules/surgery/breast_augmentation.dm
+++ b/code/modules/surgery/breast_augmentation.dm
@@ -1,0 +1,78 @@
+/datum/surgery/breast_augmentation
+	name = "Breast augmentation"
+	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/retract_skin, /datum/surgery_step/augment_breasts, /datum/surgery_step/close)
+	species = list(/mob/living/carbon/human)
+	possible_locs = list(BODY_ZONE_CHEST)
+
+/datum/surgery_step/augment_breasts
+	name = "augment breasts"
+	implements = list(/obj/item/scalpel = 100, /obj/item/stack/sheet/plastic = 100, /obj/item/melee/transforming/energy/sword = 75, /obj/item/kitchen/knife = 65,
+		/obj/item/shard = 45, /obj/item = 30) // 30% success with any sharp item.
+	time = 32
+	repeatable = TRUE
+
+/datum/surgery_step/augment_breasts/tool_check(mob/user, obj/item/tool)
+	if(istype(tool, /obj/item/cautery) || istype(tool, /obj/item/gun/energy/laser))
+		return FALSE
+	return !tool.is_hot()
+
+/datum/surgery_step/augment_breasts/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	//Patient has titties
+	if(target.has_breasts())
+		if(tool.is_sharp())
+			display_results(user, target, "<span class='notice'>You begin to cut the excess out of [target]'s breasts, bringing them down a cup size...</span>",
+			"[user] begins to augment [target]'s breasts.",
+			"[user] begins to augment [target]'s breasts.")
+		if(istype(tool, /obj/item/stack/sheet/plastic))
+			display_results(user, target, "<span class='notice'>You begin to mold, shape, and then add plastic to [target]'s breasts, increasing their cup size by 1...</span>",
+			"[user] begins to augment [target]'s breasts.",
+			"[user] begins to augment [target]'s breasts.")
+	//Patient does not have titties
+	else
+		if(istype(tool, /obj/item/stack/sheet/plastic))
+			display_results(user, target, "<span class='notice'>You begin to remodel [target]'s chest, creating a new pair of breasts which are barely A cups...</span>",
+			"[user] begins to perform plastic surgery on [target].",
+			"[user] begins to perform plastic surgery on [target].")
+
+/datum/surgery_step/augment_breasts/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/obj/item/organ/genital/breasts/B = target.getorganslot("breasts")
+	//Patient has titties
+	if(B)
+		//Reduce their size (you fucking monster)
+		if(tool.is_sharp())
+			B.cached_size = B.cached_size - 1
+			B.update()
+			return 1
+		//Increase the size (that's more like it!)
+		if(istype(tool, /obj/item/stack/sheet/plastic))
+			var/obj/item/stack/sheet/plastic/pS = tool
+			pS.amount = pS.amount - 1
+			if(pS.amount < 1)
+				pS.Destroy()
+
+			B.cached_size = B.cached_size + 1
+			B.update()
+			return 1
+	//Patient does not have titties
+	else
+		//Give 'em titties
+		if(istype(tool, /obj/item/stack/sheet/plastic))
+			//Makes it so no one has any weird coloured tits
+			var/mob/living/carbon/human/H = target
+			if(H.dna.species.use_skintones)
+				H.dna.features["breasts_color"] = skintone2hex(H.skin_tone)
+			else
+				H.dna.features["breasts_color"] = H.dna.features["mcolor"]
+
+			var/obj/item/stack/sheet/plastic/pS = tool
+			pS.amount = pS.amount - 1
+			if(pS.amount < 1)
+				pS.Destroy()
+
+			var/obj/item/organ/genital/breasts/nB = new
+			nB.size = "flat"
+			nB.cached_size = 0
+			nB.prev_size = 0
+			nB.Insert(target)
+			nB.update()
+			return 1

--- a/code/modules/surgery/penis_augmentation.dm
+++ b/code/modules/surgery/penis_augmentation.dm
@@ -1,0 +1,78 @@
+/datum/surgery/penis_augmentation
+	name = "Penis augmentation"
+	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/retract_skin, /datum/surgery_step/augment_penis, /datum/surgery_step/close)
+	species = list(/mob/living/carbon/human)
+	possible_locs = list(BODY_ZONE_PRECISE_GROIN)
+
+/datum/surgery_step/augment_penis
+	name = "augment penis"
+	implements = list(/obj/item/scalpel = 100, /obj/item/stack/sheet/plastic = 100, /obj/item/melee/transforming/energy/sword = 75, /obj/item/kitchen/knife = 65,
+		/obj/item/shard = 45, /obj/item = 30) // 30% success with any sharp item.
+	time = 32
+	repeatable = TRUE
+
+/datum/surgery_step/augment_penis/tool_check(mob/user, obj/item/tool)
+	if(istype(tool, /obj/item/cautery) || istype(tool, /obj/item/gun/energy/laser))
+		return FALSE
+	return !tool.is_hot()
+
+/datum/surgery_step/augment_penis/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	//Patient has a cock
+	if(target.has_penis())
+		if(tool.is_sharp())
+			display_results(user, target, "<span class='notice'>You begin to reshape [target]'s penis, decreasing it's length by an inch...</span>",
+			"[user] begins to augment [target]'s penis.",
+			"[user] begins to augment [target]'s penis.")
+		if(istype(tool, /obj/item/stack/sheet/plastic))
+			display_results(user, target, "<span class='notice'>You begin to mold, shape, and then add plastic to [target]'s penis, making it one inch bigger...</span>",
+			"[user] begins to augment [target]'s penis.",
+			"[user] begins to augment [target]'s penis.")
+	//Patient does not have a cock
+	else
+		if(istype(tool, /obj/item/stack/sheet/plastic))
+			display_results(user, target, "<span class='notice'>You begin to remodel [target]'s groin, creating a new penis of length 1 inch...</span>",
+			"[user] begins to perform plastic surgery on [target].",
+			"[user] begins to perform plastic surgery on [target].")
+
+/datum/surgery_step/augment_penis/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/obj/item/organ/genital/penis/P = target.getorganslot("penis")
+	//Patient has a cock
+	if(P)
+		//Reduce their size
+		if(tool.is_sharp())
+			P.cached_length = P.cached_length - 1
+			P.update()
+			return 1
+		//Increase the size
+		if(istype(tool, /obj/item/stack/sheet/plastic))
+			var/obj/item/stack/sheet/plastic/pS = tool
+			pS.amount = pS.amount - 1
+			if(pS.amount < 1)
+				pS.Destroy()
+
+			P.cached_length = P.cached_length + 1
+			P.update()
+			return 1
+	//Patient does not have a cock
+	else
+		//Give 'em a cock
+		if(istype(tool, /obj/item/stack/sheet/plastic))
+			//Makes it so no one has a weird coloured dick
+			var/mob/living/carbon/human/H = target
+			if(H.dna.species.use_skintones)
+				H.dna.features["penis_color"] = skintone2hex(H.skin_tone)
+			else
+				H.dna.features["penis_color"] = H.dna.features["mcolor"]
+
+			var/obj/item/stack/sheet/plastic/pS = tool
+			pS.amount = pS.amount - 1
+			if(pS.amount < 1)
+				pS.Destroy()
+
+			var/obj/item/organ/genital/penis/nP = new
+			nP.length = 1
+			nP.cached_length = 1
+			nP.prev_length = 0
+			nP.Insert(target)
+			nP.update()
+			return 1

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2739,6 +2739,8 @@
 #include "code\modules\station_goals\shield.dm"
 #include "code\modules\station_goals\station_goal.dm"
 #include "code\modules\surgery\amputation.dm"
+#include "code\modules\surgery\breast_augmentation.dm"
+#include "code\modules\surgery\penis_augmentation.dm"
 #include "code\modules\surgery\brain_surgery.dm"
 #include "code\modules\surgery\cavity_implant.dm"
 #include "code\modules\surgery\core_removal.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This adds two new surgeries which allows for the creation, removal or resizing of breasts and penises

Breasts: Chest
Penis: Groin

Scalpel -> haemostat -> retractors -> scalpel (decrease size/remove) OR plastic sheet (increase size/create) 

Increasing the size consumes one plastic sheet per inch/cup size

NOTE: I am entirely new to coding in byond wafflescript, this is mostly just stitched together surgery code and succubus milk / incubus draft code, so there may be things im not aware of that may not have been accounted for, so if you notice anything wrong, please do tell me. However this has been tested and works as intented.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Incase there's no chemist on, or the chemist is othereise occupied and can't make the chems required to revert any changes you may have inflicted on your body whilst downing all the pills you found in maint: these surgeries add another option in regards to getting people who don't have the luxury of being able to control their size back in condition to wear clothes again (or the total opposite depending on context).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: breast augmentation surgery
add: penis augmentation surgery
tweak: Added the surgery files in the .dme
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
