### PR TITLE
Add headpat slut quirk

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -103,6 +103,7 @@
 #define TRAIT_HOLY				"holy"
 #define TRAIT_DEPRESSION		"depression"
 #define TRAIT_JOLLY				"jolly"
+#define TRAIT_HEADPAT_SLUT		"headpat_slut"
 #define TRAIT_NOCRITDAMAGE		"no_crit"
 #define TRAIT_NOSLIPWATER		"noslip_water"
 #define TRAIT_NOSLIPALL			"noslip_all"

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -113,3 +113,8 @@
 
 /datum/mood_event/happy_empath/add_effects(var/mob/happytarget)
 	description = "<span class='nicegreen'>[happytarget.name]'s happiness is infectious!</span>\n"
+	
+/datum/mood_event/lewd_headpat
+	description = "<span class='nicegreen'>I love headpats so much!</span>\n"
+	mood_change = 3
+	timeout = 2 MINUTES

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -102,3 +102,10 @@
 	medical_record_text = "Patient never skipped ass day."
 	gain_text = "<span class='notice'>Your ass rivals those of golems.</span>"
 	lose_text = "<span class='notice'>Your butt feels more squishy and slappable.</span>"
+	
+/datum/quirk/headpat_slut
+	name = "Headpat Slut"
+	desc = "You like headpats, alot, maybe even a little bit too much. Headpats give you a bigger mood boost and cause arousal"
+	mob_trait = TRAIT_HEADPAT_SLUT
+	value = 0
+	medical_record_text = "Patient seems overly affectionate"

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -282,10 +282,17 @@
 		else if(check_zone(M.zone_selected) == "head")
 			var/mob/living/carbon/human/H = src
 			var/datum/species/pref_species = H.dna.species
-
-			M.visible_message("<span class='notice'>[M] gives [H] a pat on the head to make [p_them()] feel better!</span>", \
+			
+			if(HAS_TRAIT(H, TRAIT_HEADPAT_SLUT))
+				M.visible_message("<span class='notice'>[M] gives [H] a pat on the head to make [p_them()] feel better! They seem incredibly pleased!</span>", \
+							"<span class='notice'>You give [H] a pat on the head to make [p_them()] feel better! They seem to like it way too much</span>")
+				SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "lewd_headpat", /datum/mood_event/lewd_headpat)
+				H.adjustArousalLoss(5) //Headpats are hot af
+			else 
+				M.visible_message("<span class='notice'>[M] gives [H] a pat on the head to make [p_them()] feel better!</span>", \
 						"<span class='notice'>You give [H] a pat on the head to make [p_them()] feel better!</span>")
-			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "headpat", /datum/mood_event/headpat)
+				SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "headpat", /datum/mood_event/headpat)
+				
 			if(HAS_TRAIT(M, TRAIT_FRIENDLY))
 				GET_COMPONENT_FROM(mood, /datum/component/mood, M)
 				if (mood.sanity >= SANITY_GREAT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is a really small one:

Adds in a quirk called headpat slut that causes the user to get turned on from headpats, and get a bigger mood boost.

<hr>

![Headpat Slut](https://cdn.discordapp.com/attachments/646190385370234882/717900007369474159/unknown.png)

<hr>
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
If not purely for the meme, adds a much nicer alternative to ass slaps.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: headpat slut quirk
add: headpat slut trait
add: lewd_headpat moodlet for people who have this trait
tweak: add checking for the headpat slut trait in
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
