### PR TITLE
Patch 14

### DIFF
--- a/_maps/templates/deepbluespace.dmm
+++ b/_maps/templates/deepbluespace.dmm
@@ -1,0 +1,19 @@
+"a" = (/turf/closed/indestructible/riveted,/area/deepbluespace)
+"b" = (/turf/open/indestructible/deepBluespaceExit,/area/deepbluespace)
+"c" = (/turf/open/floor/plating,/area/deepbluespace)
+"e" = (/obj/machinery/power/apc/auto_name/north{cell_type = /obj/item/stock_parts/cell/bluespace},/turf/open/floor/plating,/area/deepbluespace)
+"f" = (/obj/machinery/light{dir = 8},/turf/open/floor/plating,/area/deepbluespace)
+"g" = (/obj/machinery/light{dir = 4},/turf/open/floor/plating,/area/deepbluespace)
+"h" = (/obj/machinery/light,/turf/open/floor/plating,/area/deepbluespace)
+
+(1,1,1) = {"
+aaaabaaaa
+aceccccca
+afcccccga
+accccccca
+accccccca
+accccccca
+afcccccga
+accchccca
+aaaaaaaaa
+"}

--- a/hyperstation/code/obj/deepbagofholding.dm
+++ b/hyperstation/code/obj/deepbagofholding.dm
@@ -1,0 +1,140 @@
+/obj/item/deepbackpack
+	name = "deep bag of holding"
+	desc = "A bluespace bag infused with astrogen, increasing the size of it's pocket dimension. It's huge!" 
+	// Alternative descriptions: "Enslaved Tardis", "It's bigger on the inside", "Mobile ERP den", "Mobile dormitory", "Mini drug lab", e.t.c
+	icon = 'icons/obj/storage.dmi'
+	icon_state = "backpack"
+	item_state = "backpack"
+	lefthand_file = 'icons/mob/inhands/equipment/backpack_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/backpack_righthand.dmi'
+	w_class = WEIGHT_CLASS_BULKY
+	slot_flags = ITEM_SLOT_BACK
+	resistance_flags = NONE
+	max_integrity = 300
+
+	var/datum/map_template/deepbluespace/linkedDimTemp
+	var/datum/turf_reservation/linkedDim
+
+	var/turf/open/entry
+
+/obj/item/deepbackpack/Initialize()
+	. = ..()
+
+	// Sets up the minidimension and spawns it
+	linkedDimTemp = new()
+	linkedDim = SSmapping.RequestBlockReservation(linkedDimTemp.width, linkedDimTemp.height)
+	linkedDimTemp.load(locate(linkedDim.bottom_left_coords[1], linkedDim.bottom_left_coords[2], linkedDim.bottom_left_coords[3]))
+	var/area/deepbluespace/currentArea = get_area(locate(linkedDim.bottom_left_coords[1], linkedDim.bottom_left_coords[2], linkedDim.bottom_left_coords[3]))
+
+	// Links the minidimension to the bag and vis-versa
+	for(var/turf/open/indestructible/deepBluespaceExit/exit in currentArea)
+		exit.parent = src
+	entry =	locate(linkedDim.bottom_left_coords[1] + linkedDimTemp.landingZoneRelativeX, \
+		    	  linkedDim.bottom_left_coords[2] + linkedDimTemp.landingZoneRelativeY, \
+		   		  linkedDim.bottom_left_coords[3])
+
+	// Start processing air and shit
+	START_PROCESSING(SSobj, src)
+
+// Called when we attack the bag with an item
+/obj/item/deepbackpack/attackby(obj/item/I, mob/user, params)
+
+	// Checks if this item has no drop, so you can't cheese it off your hand
+	if(HAS_TRAIT(I, TRAIT_NODROP))
+		to_chat(user, "<span class='warning'>\the [I] is stuck to your hand, you can't put it in \the [src]!</span>")
+		return FALSE
+
+	// Tells everyone about it
+	for(var/mob/viewing in viewers(user, null))
+		if(user == viewing)
+			to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
+		else if(in_range(user, viewing)) //If someone is standing close enough, they can tell what it is...
+			viewing.show_message("<span class='notice'>[user] puts [I] into [src].</span>", 1)
+		else if(I && I.w_class >= 3) //Otherwise they can only see large or normal items from a distance...
+			viewing.show_message("<span class='notice'>[user] puts [I] into [src].</span>", 1)
+
+	// Inserting the item
+	mobinsert(I, user)
+
+// Called when we attack something with the bag
+/obj/item/deepbackpack/afterattack(atom/movable/A, mob/user, proximity)
+
+	// If we are not next to the item, or the atom isn't a movable type, then let's forget this ever happened
+	if(!(proximity) || !isatom(A))
+		return
+
+	if(!(A.can_be_z_moved) || A.anchored)
+		return
+
+	// If this is a mob, we'll have a progress bar to make sure you're not spamming this everywhere and stuffing them into the bag
+	if (ismob(A))
+		var/mob/M = A
+		user.visible_message("<span class='warning'>[user] tries to stuff [M] into [src].</span>", \
+				 	 		 "<span class='warning'>You try to stuff [M] into [src].</span>")
+		if(!do_mob(user, M)) // If they don't succeed, fuck 'em and return from this proc
+			return
+		user.visible_message("<span class='notice'>[user] stuffs [M] into [src].</span>", \
+				 	 		 "<span class='notice'>You stuff [M] into [src].</span>")
+
+		// Oh, and if they're holding the bag, drop it. Because otherwise you essentially trap yoruself
+		if(src in M.contents)
+			src.forceMove(M.loc)
+
+	// Inserting the item
+	mobinsert(A, user)
+
+// Use this if a mob is inserting an item into the bag. This adds some animations and shit for the sake of it.
+/obj/item/deepbackpack/proc/mobinsert(atom/movable/A, mob/user)
+	playsound(src, "rustle", 50, 1, -5)
+	do_jiggle()
+	add_fingerprint(user)
+	insert(A)
+
+// Use this if you just want to put an item into the bag. This is the mechanical part.
+/obj/item/deepbackpack/proc/insert(atom/movable/A)
+
+	 // If this is in a mobs inventory, drop it.
+	var/mob/M
+	var/obj/item/I
+
+	if(ismob(A.loc) && isitem(A))
+		M = A.loc
+		I = A
+
+	// Move it to the dimension
+	A.forceMove(entry)
+
+	// Calling dropped after the move to make micros work. Life's tough ):
+	if(ismob(M) && isitem(A))
+		I.dropped(M)
+
+/*/obj/item/deepbackpack/process()
+	var/turf/T = get_turf(src)
+	T.air.share(entry/air)*/
+
+
+/turf/open/indestructible/deepBluespaceExit
+    name = "Bluespace Tunnel"
+    icon_state = "hoteldoor"
+    explosion_block = INFINITY
+    blocks_air = TRUE
+    opacity = TRUE
+    var/parent
+
+/turf/open/indestructible/deepBluespaceExit/Entered(atom/movable/A)
+    . = ..()
+    A.forceMove(get_turf(parent))
+
+/datum/map_template/deepbluespace
+    name = "Deep Bluespace"
+    mappath = '_maps/templates/deepbluespace.dmm'
+    var/landingZoneRelativeX = 4
+    var/landingZoneRelativeY = 7
+
+/area/deepbluespace
+    name = "Deep Bluespace"
+    icon_state = "hilbertshotel"
+    requires_power = TRUE
+    has_gravity = TRUE
+    noteleport = TRUE
+    hidden = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in a new item, the deep bluespace bag. Lacks sprite as of right now.

The deep bluespace bag opens into a litteral pocket dimension you can store items, friends, enemies, valids, captains, security, clowns, drugs, drug labs, bots, medical equipment, kinky shit, singularities, and much, much more.

It works like a normal bag, in that you can place items in it as normal. Use it as a tool on another player, structure, e.t.c to stuff it into the bag. Yes it works on structures, only if they are unanchored however.

I've tested it to the best of my abilities, but chances are bugs will show up. If anyone wants to make a sprite for it, be my guest.

Currently uncraftable while it's being tested. Once I'm happy with it, I'll let players make it with astrogen on a bag of holding. Alternatively, it could also need a shock from a tesla coil, an anomaly core, or other entertainingly hard to get substance.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Originally intended for giants to store their victims inside, allowing people to make their own pocket dimensions would be entertaining for long rounds or scientists with to much time.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added the deep bag of holding, for storing items, friends, enemies, valids, captains, security, clowns, drugs, drug labs, bots, medical equipment, kinky shit, singularities, and much, much more.
admin: Deep bag of holding is currently uncraftable. Ideally it should be used for entertaining shenanighans to put it to the test, or for use during giantism rampages.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
