### PR TITLE
Coom code part 1

### DIFF
--- a/code/__DEFINES/citadel_defines.dm
+++ b/code/__DEFINES/citadel_defines.dm
@@ -32,9 +32,9 @@
 #define BALLS_VOLUME_BASE	25
 #define BALLS_VOLUME_MULT	1
 
-#define BALLS_SIZE_MIN		1
-#define BALLS_SIZE_DEF		2
-#define BALLS_SIZE_MAX		3
+#define BALLS_SIZE_MIN		1 //Hyper - Unchanged
+#define BALLS_SIZE_DEF		8 //Changed from 2
+#define BALLS_SIZE_MAX		40 //Changed from 3
 
 #define BALLS_SACK_SIZE_MIN 1
 #define BALLS_SACK_SIZE_DEF	8

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -129,6 +129,7 @@
 // item traits
 #define TRAIT_NODROP            "nodrop"
 
+//roundstart traits
 #define TRAIT_ALCOHOL_TOLERANCE	"alcohol_tolerance"
 #define TRAIT_AGEUSIA			"ageusia"
 #define TRAIT_HEAVY_SLEEPER		"heavy_sleeper"
@@ -160,6 +161,7 @@
 #define TRAIT_CULT_EYES 		"cult_eyes"
 #define TRAIT_XRAY_VISION       "xray_vision"
 #define TRAIT_THERMAL_VISION    "thermal_vision"
+//#define TRAIT_CUM_PLUS			"cum_plus"
 
 
 // common trait sources

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -779,6 +779,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						else
 							dat += "<b>Testicles Color:</b></a><BR>"
 							dat += "<span style='border: 1px solid #161616; background-color: #[features["balls_color"]];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=balls_color;task=input'>Change</a><br>"
+						//dat += "<b>Ball Circumference:</b> <a style='display:block;width:120px' href='?_src_=prefs;preference=balls_size;task=input'>[features["balls_size"]] inch(es)</a>" // The menu works but doesn't do anything yet. Need to figure it out.
 						dat += "<b>Testicles showing:</b><a style='display:block;width:50px' href='?_src_=prefs;preference=balls_shape;task=input'>[features["balls_shape"]]</a>"
 						dat += "<b>Produces:</b><a style='display:block;width:50px' href='?_src_=prefs;preference=balls_fluid;task=input'>[features["balls_fluid"]]</a>"
 				dat += APPEARANCE_CATEGORY_COLUMN
@@ -1979,6 +1980,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/new_length = input(user, "Penis length in inches:\n([COCK_SIZE_MIN]-[COCK_SIZE_MAX])", "Character Preference") as num|null
 					if(new_length)
 						features["cock_length"] = max(min( round(text2num(new_length)), COCK_SIZE_MAX),COCK_SIZE_MIN)
+
+				if("balls_size")
+					var/new_balls_size = input(user, "Testicle circumference in inches:\n([BALLS_SIZE_MIN]-[BALLS_SIZE_MAX])", "Character Preference") as num|null
+					if(new_balls_size)
+						features["balls_size"] = max(min( round(text2num(new_balls_size)), BALLS_SIZE_MAX),BALLS_SIZE_MIN)
 
 				if("cock_shape")
 					var/new_shape

--- a/hyperstation/code/modules/traits.dm
+++ b/hyperstation/code/modules/traits.dm
@@ -1,0 +1,34 @@
+#define TRAIT_CUM_PLUS			"cum_plus"
+
+
+//Jay - Coooooom
+/datum/quirk/cum_plus
+	name = "Extra productive genitals"
+	desc = "Your lower bits produce more and hold more than normal."
+	value = 0
+	mob_trait = TRAIT_CUM_PLUS
+	gain_text = "<span class='notice'>You feel pressure in your groin.</span>"
+	lose_text = "<span class='notice'>You feel a weight lifted from your groin.</span>"
+	medical_record_text = "Patient has greatly increased production of sexual fluids"
+
+/datum/quirk/cum_plus/add()
+	var/mob/living/carbon/M = quirk_holder
+	if(M.getorganslot("testicles"))
+		var/obj/item/organ/genital/testicles/T = M.getorganslot("testicles")
+		T.fluid_mult = 1.5 //Base is 1
+		T.fluid_max_volume = 5
+
+/datum/quirk/cum_plus/remove()
+	var/mob/living/carbon/M = quirk_holder
+	if(quirk_holder.getorganslot("testicles"))
+		var/obj/item/organ/genital/testicles/T = M.getorganslot("testicles")
+		T.fluid_mult = 1 //Base is 1
+		T.fluid_max_volume = 3 //Base is 3
+
+/datum/quirk/cum_plus/on_process()
+	var/mob/living/carbon/M = quirk_holder //If you get balls later, then this will still proc
+	if(M.getorganslot("testicles"))
+		var/obj/item/organ/genital/testicles/T = M.getorganslot("testicles")
+		if(T.fluid_max_volume <= 5 || T.fluid_mult <= 0.2) //INVALID EXPRESSION?
+			T.fluid_mult = 1.5 //Base is 0.133
+			T.fluid_max_volume = 5

--- a/modular_citadel/code/modules/arousal/organs/testicles.dm
+++ b/modular_citadel/code/modules/arousal/organs/testicles.dm
@@ -10,8 +10,9 @@
 	shape					= "single"
 	var/sack_size			= BALLS_SACK_SIZE_DEF
 	var/cached_size			= 6
-	fluid_mult				= 0.133 // Set to a lower value due to production scaling with size (I.E. 6 inches the "normal" amount)
-	fluid_max_volume		= 6
+	//fluid_mult				= 0.133 // Set to a lower value due to production scaling with size (I.E. 6 inches the "normal" amount)
+	fluid_mult				= 1.0 //Defaults to 1 no matter what you do. It just does. Just gonna adapt I guess.
+	fluid_max_volume		= 3
 	fluid_id 				= "semen"
 	producing				= TRUE
 	can_masturbate_with		= FALSE
@@ -24,17 +25,19 @@
 		return
 	if(!reagents || !owner)
 		return
-	reagents.maximum_volume = fluid_max_volume * cached_size// fluid amount is also scaled by the size of the organ
+	//reagents.maximum_volume = fluid_max_volume * cached_size// fluid amount is also scaled by the size of the organ
+	reagents.maximum_volume = fluid_max_volume * ((cached_size / 2) + 1) * ((size / 2) + 1) * fluid_mult //Hyper - New calculation for more dynamic fluid levels. I can't believe I typed that.
 	if(fluid_id && producing)
 		if(reagents.total_volume == 0) // Apparently, 0.015 gets rounded down to zero and no reagents are created if we don't start it with 0.1 in the tank.
 			fluid_rate = 0.1
 		else
-			fluid_rate = CUM_RATE * cached_size * fluid_mult // fluid rate is scaled by the size of the organ
+			//fluid_rate = CUM_RATE * cached_size * fluid_mult // fluid rate is scaled by the size of the organ
+			fluid_rate = ((CUM_RATE / 5) * (cached_size / 3) * (size / 4) * fluid_mult) / 10 //Hyper - Production was way too high by default. This should drop it back down, but allow for it to get really high
 		generate_cum()
 
 /obj/item/organ/genital/testicles/proc/generate_cum()
-	reagents.maximum_volume = fluid_max_volume
-	if(reagents.total_volume >= reagents.maximum_volume)
+	//reagents.maximum_volume = fluid_max_volume //This is the line that broke cum for so long
+	if(reagents.total_volume >= reagents.maximum_volume - 0.1) //Hyper - Check for it being close to the maximum. It sometimes doesn't proc due to a rounding error.
 		if(!sent_full_message)
 			send_full_message()
 			sent_full_message = TRUE
@@ -66,11 +69,14 @@
 
 /obj/item/organ/genital/testicles/update_appearance()
 	switch(size)
-		if(0.1 to 1)
+		//if(0.1 to 1) //Hyper - Change the displayed ball sizes
+		if(0.1 to 3)
 			size_name = "average"
-		if(1.1 to 2)
+		//if(1.1 to 2)
+		if(3.1 to 8)
 			size_name = "enlarged"
-		if(2.1 to INFINITY)
+		//if(2.1 to INFINITY)
+		if(8.1 to INFINITY)
 			size_name = "engorged"
 		else
 			size_name = "nonexistant"

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/enlargement.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/enlargement.dm
@@ -251,6 +251,7 @@
 		return
 	var/mob/living/carbon/human/H = M
 	var/obj/item/organ/genital/penis/P = M.getorganslot("penis")
+	var/obj/item/organ/genital/testicles/T = M.getorganslot("testicles") //Hyper Change
 	if(!P)//They do have a preponderance for escapism, or so I've heard.
 
 		//If they have Acute hepatic pharmacokinesis, then route processing though liver.
@@ -273,8 +274,33 @@
 			nP.prev_length = 1
 			M.reagents.remove_reagent(id, 5)
 			P = nP
+	
+	if(!T)//Hyper change// Adds testicles if there are none. 
+
+		//If they have Acute hepatic pharmacokinesis, then route processing though liver.
+		if(HAS_TRAIT(M, TRAIT_PHARMA))
+			var/obj/item/organ/liver/L = M.getorganslot("liver")
+			if(L)
+				L.swelling+= 0.05
+				return..()
+			else
+				M.adjustToxLoss(1)
+				return..()
+
+		//otherwise proceed as normal
+		var/obj/item/organ/genital/testicles/nT = new
+		nT.Insert(M)
+		if(nT)
+			nT.size = BALLS_SIZE_MIN
+			to_chat(M, "<span class='warning'>Your groin feels warm, as you feel two sensitive orbs taking shape below.</b></span>")
+			nT.cached_size = 1
+			nT.sack_size = BALLS_SACK_SIZE_DEF
+			T = nT
 
 	P.cached_length = P.cached_length + 0.1
+	//Hyper change// Increase ball size too
+	T.size = T.size + 0.1
+
 	if (P.cached_length >= 20.5 && P.cached_length < 21)
 		if(H.w_uniform || H.wear_suit|| H.arousalloss > 33)
 			//Hyper change// Check for a flag before we remove clothes.
@@ -286,6 +312,7 @@
 				to_chat(M, "<span class='warning'>Your cock begins to strain against your clothes tightly!</b></span>")
 				M.apply_damage(1, BRUTE, target)
 
+	T.update() //Hyper change - Make the ball size update
 	P.update()
 	..()
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2885,6 +2885,7 @@
 #include "hyperstation\code\mobs\hugbot.dm"
 #include "hyperstation\code\mobs\mimic.dm"
 #include "hyperstation\code\mobs\werewolf.dm"
+#include "hyperstation\code\modules\traits.dm"
 #include "hyperstation\code\modules\antagonists\werewolf\werewolf.dm"
 #include "hyperstation\code\modules\clothing\head.dm"
 #include "hyperstation\code\modules\crafting\recipes.dm"


### PR DESCRIPTION
Fixes production and capacity, and adds a new trait

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

"Your balls finally feel full, again". Capacity has always been very very low, and regen was instant. This fixes a few of those problems. Capacity and generation are now linked to cock size. Additionally, there is a new trait you can take to increase both.

The PR also adds in code so balls can actually be resized and set on the preferences screen. At the moment, it's disabled, because for some reason balls always get set to default sizes no matter how I set this stuff up. Something in the code regularly overwrites the sizes, so I've got some more diving to do.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's more fetish content. More coom.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Extra productive genitals quirk
tweak: Reworked coom
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
