### PR TITLE
Additional species mutations w/ green extracts

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2228,6 +2228,14 @@
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/xeno
 	mutationtext = "<span class='danger'>The pain subsides. You feel... very alien compared to your previous self.</span>"
+
+/datum/reagent/mutationtoxin/insect
+	name = "Insect Mutation Toxin"
+	id = "insectmutationtoxin"
+	description = "A buggy toxin."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/insect
+	mutationtext = "<span class='danger'>The pain subsides. You feel... oddly attracted to light.</span>"
 	
 /datum/reagent/mutationtoxin/ipc
 	name = "IPC Mutation Toxin"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2194,3 +2194,45 @@
 		to_chat(M, "<span class = 'notice'>[pick("Headpats feel nice.", "The feeling of a hairball...", "Backrubs would be nice.", "Whats behind those doors?")]</span>")
 	M.adjustArousalLoss(2)
 	..()
+
+// Adding new mutation toxin stuff from /code/modules/reagent/chemistry/recipes/slime_extracts.dm
+//Some other stuff like moth and felinid ( /datum/reagent/mutationtoxin/moth and /datum/reagent/mutationtoxin/felinid ) already exists. - Chemlight
+/datum/reagent/mutationtoxin/mammal
+	name = "Mammal Mutation Toxin"
+	id = "mammalmutationtoxin"
+	description = "A fuzzy toxin."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/mammal
+	mutationtext = "<span class='danger'>The pain subsides. You feel... furry.</span>"
+
+/datum/reagent/mutationtoxin/avian
+	name = "Avian Mutation Toxin"
+	id = "avianmutationtoxin"
+	description = "A bird-like toxin."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/avian
+	mutationtext = "<span class='danger'>The pain subsides. You feel... feathery.</span>"
+
+/datum/reagent/mutationtoxin/aquatic
+	name = "Aquatic Mutation Toxin"
+	id = "aquaticmutationtoxin"
+	description = "A aquatic toxin."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/aquatic
+	mutationtext = "<span class='danger'>The pain subsides. You feel... parched and wet.</span>"
+
+/datum/reagent/mutationtoxin/xeno
+	name = "Xeno Mutation Toxin"
+	id = "xenomutationtoxin"
+	description = "A xenomorhpic toxin."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/xeno
+	mutationtext = "<span class='danger'>The pain subsides. You feel... very alien compared to your previous self.</span>"
+	
+/datum/reagent/mutationtoxin/ipc
+	name = "IPC Mutation Toxin"
+	id = "ipcmutationtoxin"
+	description = "A robotic toxin." //NANOMACHINES SON.
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/ipc
+	mutationtext = "<span class='danger'>The pain subsides. You feel... metallic.</span>"

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -720,11 +720,11 @@
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/green
 
-/datum/chemical_reaction/slime/slimemoth //Mothmen species, you have a strange attraction to... lamp..
-	name = "Moth Mutation Toxin"
-	id = "mothmuttoxin"
-	results = list("mothmutationtoxin" = 1)
-	required_reagents = list("ammonia" = 1) //Ammonia, in the recipe /datum/chemical_reaction/moff and the mut /datum/reagent/mutationtoxin/moth already exists in code, THIS ONE IS OPTIONAL AS WELL.
+/datum/chemical_reaction/slime/slimeinsect //insect species, you have a strange attraction to... lamp..
+	name = "Insect Mutation Toxin"
+	id = "insectmuttoxin"
+	results = list("insectmutationtoxin" = 1)
+	required_reagents = list("ammonia" = 1) //Ammonia, used for the mothman chemical reaction so it's more of a reference.
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/green
 

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -676,3 +676,62 @@
 /datum/chemical_reaction/slime/flight_potion/on_reaction(datum/reagents/holder)
 	new /obj/item/reagent_containers/glass/bottle/potion/flight(get_turf(holder.my_atom))
 	..()
+
+// Hyper change addition with granting more mutations to the existing races in the code.
+// Back to the special snowflame mammal race, and more!
+// If something isn't wanted here, just delet this - Chemlight
+/datum/chemical_reaction/slime/slimemammal //Mammal species, pet dog.
+	name = "Mammal Mutation Toxin"
+	id = "mammalmuttoxin"
+	results = list("mammalmutationtoxin" = 1)
+	required_reagents = list("sulfur" = 1) //Sulfur, furry, GET IT?!
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slime/slimeavian //BIRDUP Species
+	name = "Avian Mutation Toxin"
+	id = "avianmuttoxin"
+	results = list("avianmutationtoxin" = 1)
+	required_reagents = list("oxygen" = 1) //Oxygen gives you.. wait that's redbull.
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slime/slimeaquatic //Aquatic species, aquaman got now shit on you.
+	name = "Aquatic Mutation Toxin"
+	id = "aquaticmuttoxin"
+	results = list("aquaticmutationtoxin" = 1)
+	required_reagents = list("water" = 1) //Water, 60% found in a human body, you tipped the scales, you fucked up.
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slime/slimexeno //HISS(Xeno hybrid) species, the other hiss not cats.
+	name = "Xeno Mutation Toxin"
+	id = "xenomuttoxin"
+	results = list("xenomutationtoxin" = 1)
+	required_reagents = list("sacid" = 1) //Sulphuric Acid, just like xeno spit, yuck.
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slime/slimefelinid //Felinid species, like cats, but the degenerate kind.
+	name = "Felinid Mutation Toxin"
+	id = "felinidmuttoxin"
+	results = list("felinidmutationtoxin" = 1)
+	required_reagents = list("aphro" = 1) //Crocin, *points* HORNY, also the whole /datum/chemical_reaction/cat and /datum/reagent/mutationtoxin/felinid already exists in code, THIS ONE IS OPTIONAL.
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slime/slimemoth //Mothmen species, you have a strange attraction to... lamp..
+	name = "Moth Mutation Toxin"
+	id = "mothmuttoxin"
+	results = list("mothmutationtoxin" = 1)
+	required_reagents = list("ammonia" = 1) //Ammonia, in the recipe /datum/chemical_reaction/moff and the mut /datum/reagent/mutationtoxin/moth already exists in code, THIS ONE IS OPTIONAL AS WELL.
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slime/slimeipc //IPC species, BEEP.
+	name = "IPC Mutation Toxin"
+	id = "ipcmuttoxin"
+	results = list("ipcmutationtoxin" = 1)
+	required_reagents = list("oil" = 1) //Oil, makes sense for it being their blood, so..
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Provides additional effects to the current green extract when injected with different chemicals. This is to provide ways back to one's original species since for a while Lizardpeople were the only ones who had this luxury along with humans, while slimes just got bonuses.

Sulfur > Mammal
Oxygen > Avian
Water > Aquatic
Sulphuric Acid > Xeno Hybrid
Ammonia > Insect 
Crocin > Felinid
Oil > IPC


## Why It's Good For The Game

This provides addition species related changes to the xenobio department, for example if someone were to be forced into a lizard person via green extracts and radium, one can get changed back to their original species, Although plasmamen weren't added into the mutations due to griefing potential.

## Changelog
:cl:
add: Added new mutation toxin reactions.
fix: Originally species insect was species moth.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
