### PR TITLE
Sonic Jack Hammer Nerf

### DIFF
--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -50,7 +50,7 @@
 /turf/closed/wall/r_wall/try_destroy(obj/item/I, mob/user, turf/T)
 	if(istype(I, /obj/item/pickaxe/drill/jackhammer))
 		to_chat(user, "<span class='notice'>You begin to smash though [src]...</span>")
-		if(do_after(user, 50, target = src))
+		if(do_after(user, 200, target = src))
 			if(!istype(src, /turf/closed/wall/r_wall))
 				return TRUE
 			I.play_tool_sound(src)

--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -50,7 +50,7 @@
 /turf/closed/wall/r_wall/try_destroy(obj/item/I, mob/user, turf/T)
 	if(istype(I, /obj/item/pickaxe/drill/jackhammer))
 		to_chat(user, "<span class='notice'>You begin to smash though [src]...</span>")
-		if(do_after(user, 200, target = src))
+		if(do_after(user, 150, target = src))
 			if(!istype(src, /turf/closed/wall/r_wall))
 				return TRUE
 			I.play_tool_sound(src)


### PR DESCRIPTION
## About The Pull Request

This change is to modify the sonic jackhammer intereacting with reinforced walls from a previous 5 seconds to a now total of 15 seconds,

## Why It's Good For The Game

In a sense the sonic jack hammer seems to outshine a lot of the methods of deconstruction of reinforced walls, making the normal process laughable and outshining thermite by a mile. This will prevent most players/antags from quickly tearing the station a new one as anyone grabbing one can quickly break into a malf AI's sat without them even blinking or even making a quick get away in a rush to get, grab and go. Miners where they stand are already pretty powerful as it is rushing boss weapons and relics, so giving them or anyone using their tools a bit more time to wait on and develop patience and thoughtful planning.

For reference
Pixel perfect deconstruction with normal tools takes 44 seconds with no pause between each action
Thermite takes about 10 seconds, and is pretty flashy, making it really noticable. is quick to make but needs restocking and a fire source to ignite.
Current (before changes) sonic jackhammer breaks down walls with a 5 second window and a single sound starting and finishing the action, ontop of that, has unlimited uses, meaning you can walk around the outside of the station exterior and space the whole maint/general area. With no pit stops.

## Changelog
:cl:
tweak: A number of 50 to 150 to represent time of 5 seconds to 15
balance: Rebalanced the sonic jackhammer when used on reinforced walls.
/:cl:
