### PR TITLE
Held Mobs Have Item Sizes Respective to Size Multiplier

### DIFF
--- a/hyperstation/code/modules/resize/holder_micro.dm
+++ b/hyperstation/code/modules/resize/holder_micro.dm
@@ -6,7 +6,7 @@
 	icon = null
 	icon_state = ""
 	slot_flags = ITEM_SLOT_FEET | ITEM_SLOT_HEAD | ITEM_SLOT_ID | ITEM_SLOT_BACK | ITEM_SLOT_NECK
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = null //handled by their size
 	can_head = TRUE
 
 /obj/item/clothing/head/mob_holder/micro/Initialize(mapload, mob/living/M, _worn_state, alt_worn, lh_icon, rh_icon, _can_head_override = FALSE)
@@ -39,6 +39,8 @@
 			w_class = WEIGHT_CLASS_TINY
 		if(MOB_SIZE_SMALL)
 			w_class = WEIGHT_CLASS_SMALL
+		if(MOB_SIZE_HUMAN)
+			w_class = WEIGHT_CLASS_BULKY
 		if(MOB_SIZE_LARGE)
 			w_class = WEIGHT_CLASS_HUGE
 
@@ -76,7 +78,6 @@
 	var/obj/item/clothing/head/mob_holder/micro/holder = generate_mob_holder()
 	if(!holder)
 		return
-	drop_all_held_items()
 	L.equip_to_slot(holder, SLOT_SHOES)
 	return
 

--- a/hyperstation/code/modules/resize/resizing.dm
+++ b/hyperstation/code/modules/resize/resizing.dm
@@ -25,7 +25,6 @@ var/const/RESIZE_A_TINYMICRO = (RESIZE_TINY + RESIZE_MICRO) / 2
 	M.Scale(size_multiplier)
 	M.Translate(0, 16*(size_multiplier-1)) //translate by 16 * size_multiplier - 1 on Y axis
 	src.transform = M //the source of transform is M
-	src.update_mobsize() //Doesn't work yet
 
 /mob/proc/get_effective_size()
 	return 100000
@@ -38,6 +37,7 @@ mob/living/get_effective_size()
 	if(size_multiplier == previous_size)
 		return 1
 	src.update_transform() //WORK DAMN YOU
+	src.update_mobsize() //Doesn't work yet
 	//Going to change the health and speed values too
 	src.remove_movespeed_modifier(MOVESPEED_ID_SIZE)
 	src.add_movespeed_modifier(MOVESPEED_ID_SIZE, multiplicative_slowdown = (abs(size_multiplier - 1) * 0.8 ))
@@ -191,13 +191,15 @@ mob/living/get_effective_size()
 	tmob.adjustBruteLoss(B) //final result in brute loss
 
 //Proc for changing mob_size to be grabbed for item weight classes
-/mob/living/proc/update_mobsize()
+/mob/living/proc/update_mobsize(var/mob/living/tmob)
 	if(size_multiplier <= 0.50)
-		mob_size = MOB_SIZE_TINY
-	if(size_multiplier <= 1)
-		mob_size = MOB_SIZE_SMALL
-	if(size_multiplier >= 2)
-		mob_size = MOB_SIZE_LARGE
+		mob_size = 0
+	if(size_multiplier < 1)
+		mob_size = 1
+	if(size_multiplier == 1)
+		mob_size = 2 //the default human size
+	if(size_multiplier > 1)
+		mob_size = 3
 			
 //Proc for instantly grabbing valid size difference. Code optimizations soon(TM)
 /*


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Says it on the tin. Makes it so picking up people will apply a mob_size and as a result, apply a weight class when held as well.
This is so normal sized people cannot just be hoarded into a 200% sized person's bag, but as a result, makes micros easier to hoard-- which is intentional, cause fuck micros.

Next I'm gonna rework holders to add more interactions when holding someone in your hand.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Balancing and more features
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: w_class and mob_size respective to size_multiplier
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
