### PR TITLE
Changes and Additions, xenoarch and maint.

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -115,5 +115,9 @@ GLOBAL_LIST_INIT(maintenance_loot, list(
 	/obj/item/clothing/shoes/kindleKicks = 1,
 	/obj/item/autosurgeon/penis = 1,
 	/obj/item/autosurgeon/testicles = 1,
+	/obj/item/autosurgeon/vagina = 1,
+	/obj/item/autosurgeon/breasts = 1,
+	/obj/item/autosurgeon/womb = 1,
+	/obj/item/toy/plush/random = 1,
 	"" = 3
 	))

--- a/code/modules/research/xenoarch/artifact_list.dm
+++ b/code/modules/research/xenoarch/artifact_list.dm
@@ -38,7 +38,7 @@ GLOBAL_LIST_INIT(adv_artifact,list(	/obj/item/shield/riot/roman=1,
 
 GLOBAL_LIST_INIT(ult_artifact,list(	/obj/item/nuke_core/supermatter_sliver=1,
 									/obj/item/storage/belt/sabre/rapier=1,
-									/obj/item/storage/box/syndie_kit/guardian=1,
+									/obj/item/guardiancreator=1,
 									/obj/item/flashlight/emp=1,
 									/obj/item/encryptionkey/binary=1,
 									/obj/item/gun/medbeam=1,


### PR DESCRIPTION
## About The Pull Request

Some little adjustments and additions, to xeno arch and maint with the halo parasite being more of a tarot deck now. Along with added all organ autosurgeons, along with plushies!

## Why It's Good For The Game

The change from the the traitor halo parasite kit to the tarot deck gives it more of a magic twist along with the look compared to the mechanized look. Who knows perhaps more necropolis loot will be added (as chests accidentally fall into pits) As for maint loot, why not add all auto surgeons to the rotation? While finally plushies (just try not make them play with one and other.)

## Changelog
:cl:
add: More maint loot
add: Tarot Deck to xeno arch
del: Removed the traitor haloparasite kit as it confuses me how such technology like that survived over time
/:cl:
