### PR TITLE
Alternate Job Titles fix

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -202,6 +202,7 @@
 	var/static/list/show_directions = list(SOUTH, WEST)
 	if(H.mind && (H.mind.assigned_role != H.mind.special_role))
 		var/assignment
+		var/displayed_rank
 		if(H.mind.assigned_role)
 			assignment = H.mind.assigned_role
 		else if(H.job)
@@ -210,6 +211,8 @@
 			assignment = "Unassigned"
 			if(C && C.prefs && C.prefs.alt_titles_preferences[assignment])
 				assignment = C.prefs.alt_titles_preferences[assignment]
+		if(assignment)
+			displayed_rank = H.client.prefs.alt_titles_preferences[assignment]
 
 		var/static/record_id_num = 1001
 		var/id = num2hex(record_id_num++,6)
@@ -233,6 +236,7 @@
 		G.fields["id"]			= id
 		G.fields["name"]		= H.real_name
 		G.fields["rank"]		= assignment
+		G.fields["job_title"]   = displayed_rank
 		G.fields["age"]			= H.age
 		G.fields["species"]	= H.dna.species.name
 		G.fields["fingerprint"]	= md5(H.dna.uni_identity)
@@ -275,6 +279,7 @@
 		L.fields["id"]			= md5("[H.real_name][H.mind.assigned_role]")	//surely this should just be id, like the others?
 		L.fields["name"]		= H.real_name
 		L.fields["rank"] 		= H.mind.assigned_role
+		L.fields["job_title"]   = displayed_rank
 		L.fields["age"]			= H.age
 		L.fields["sex"]			= H.gender
 		L.fields["blood_type"]	= H.dna.blood_type

--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -17,9 +17,9 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 	circuit = /obj/item/circuitboard/machine/announcement_system
 
 	var/obj/item/radio/headset/radio
-	var/arrival = "%PERSON has signed up as %RANK"
+	var/arrival = "%PERSON has signed up as %DISP_RANK (%RANK)"
 	var/arrivalToggle = 1
-	var/newhead = "%PERSON, %RANK, is the department head."
+	var/newhead = "%PERSON, %DISP_RANK (%RANK), is the department head."
 	var/newheadToggle = 1
 
 	var/greenlight = "Light_Green"
@@ -73,24 +73,25 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 	else
 		return ..()
 
-/obj/machinery/announcement_system/proc/CompileText(str, user, rank) //replaces user-given variables with actual thingies.
+/obj/machinery/announcement_system/proc/CompileText(str, user, rank, displayed_rank) //replaces user-given variables with actual thingies.
 	str = replacetext(str, "%PERSON", "[user]")
 	str = replacetext(str, "%RANK", "[rank]")
+	str = replacetext(str, "%DISP_RANK", "[displayed_rank]")
 	return str
 
-/obj/machinery/announcement_system/proc/announce(message_type, user, rank, list/channels)
+/obj/machinery/announcement_system/proc/announce(message_type, user, rank, displayed_rank, list/channels)
 	if(!is_operational())
 		return
 
 	var/message
 
 	if(message_type == "ARRIVAL" && arrivalToggle)
-		message = CompileText(arrival, user, rank)
+		message = CompileText(arrival, user, rank, displayed_rank)
 	else if(message_type == "NEWHEAD" && newheadToggle)
-		message = CompileText(newhead, user, rank)
+		message = CompileText(newhead, user, rank, displayed_rank)
 	//CITADEL EDIT for cryopods
 	else if(message_type == "CRYOSTORAGE")
-		message = CompileText("%PERSON, %RANK has been moved to cryo storage.", user, rank)
+		message = CompileText("%PERSON, %DISP_RANK (%RANK) has been moved to cryo storage.", user, rank, displayed_rank)
 	//END EDIT
 	else if(message_type == "ARRIVALS_BROKEN")
 		message = "The arrivals shuttle has been damaged. Docking for repairs..."

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -27,8 +27,12 @@ Captain
 	return get_all_accesses()
 
 /datum/job/captain/announce(mob/living/carbon/human/H)
-	..()
-	SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, .proc/minor_announce, "Captain [H.nameless ? "" : "[H.real_name] "]on deck!"))
+    ..()
+    var/displayed_rank = H.client.prefs.alt_titles_preferences[title]
+    if(!displayed_rank)
+        displayed_rank = "Captain"
+    SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, .proc/minor_announce, "[displayed_rank] [H.nameless ? "" : "[H.real_name] "]on deck!"))
+
 
 /datum/outfit/job/captain
 	name = "Captain"

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -122,7 +122,7 @@
 /datum/job/proc/announce_head(var/mob/living/carbon/human/H, var/channels) //tells the given channel that the given mob is the new department head. See communications.dm for valid channels.
 	if(H && GLOB.announcement_systems.len)
 		//timer because these should come after the captain announcement
-		SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, .proc/addtimer, CALLBACK(pick(GLOB.announcement_systems), /obj/machinery/announcement_system/proc/announce, "NEWHEAD", H.real_name, H.job, channels), 1))
+		SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, .proc/addtimer, CALLBACK(pick(GLOB.announcement_systems), /obj/machinery/announcement_system/proc/announce, "NEWHEAD", H.real_name, H.job, H.client.prefs.alt_titles_preferences[H.job], channels), 1))
 
 //If the configuration option is set to require players to be logged as old enough to play certain jobs, then this proc checks that they are, otherwise it just returns 1
 /datum/job/proc/player_old_enough(client/C)

--- a/modular_citadel/code/game/machinery/cryopod.dm
+++ b/modular_citadel/code/game/machinery/cryopod.dm
@@ -277,6 +277,7 @@
 	// Delete them from datacore.
 
 	var/announce_rank = null
+	var/announce_job_title = null
 	for(var/datum/data/record/R in GLOB.data_core.medical)
 		if((R.fields["name"] == mob_occupant.real_name))
 			qdel(R)
@@ -286,6 +287,7 @@
 	for(var/datum/data/record/G in GLOB.data_core.general)
 		if((G.fields["name"] == mob_occupant.real_name))
 			announce_rank = G.fields["rank"]
+			announce_job_title = G.fields["job_title"]
 			qdel(G)
 
 	for(var/obj/machinery/computer/cloning/cloner in world)
@@ -299,7 +301,7 @@
 
 	if(GLOB.announcement_systems.len)
 		var/obj/machinery/announcement_system/announcer = pick(GLOB.announcement_systems)
-		announcer.announce("CRYOSTORAGE", mob_occupant.real_name, announce_rank, list())
+		announcer.announce("CRYOSTORAGE", mob_occupant.real_name, announce_rank, announce_job_title, list())
 		visible_message("<span class='notice'>\The [src] hums and hisses as it moves [mob_occupant.real_name] into storage.</span>")
 
 


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the announcement system so you can now tell when people show up again. Very carefully implemented so as not to break the cryo sleep announcement system. Captain on deck! announcement has been changed as well.

Alternate job titles are now placed onto the manifest as well, so, enjoy that. Should make for some easier calls in the future.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fewer runtime errors. Bugs fixed. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Arrival announcements.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
