### PR TITLE
Removes Malfunctioning AI's Robot Army Objective

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -286,7 +286,7 @@ GLOBAL_LIST_EMPTY(objectives)
 			if(H.dna.species.id != "human")
 				return FALSE
 	return TRUE
-
+/*
 /datum/objective/robot_army
 	explanation_text = "Have at least eight active cyborgs synced to you."
 	martyr_compatible = 0
@@ -302,7 +302,7 @@ GLOBAL_LIST_EMPTY(objectives)
 			if(R.stat != DEAD)
 				counter++
 	return counter >= 8
-
+*/
 /datum/objective/escape
 	explanation_text = "Escape on the shuttle or an escape pod alive and without being in custody."
 	team_explanation_text = "Have all members of your team escape on a shuttle or pod alive, without being in custody."

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -172,7 +172,7 @@
 
 /datum/antagonist/traitor/proc/forge_single_AI_objective()
 	.=1
-	var/special_pick = rand(1,4)
+	var/special_pick = rand(1,3)
 	switch(special_pick)
 		if(1)
 			var/datum/objective/block/block_objective = new
@@ -182,11 +182,7 @@
 			var/datum/objective/purge/purge_objective = new
 			purge_objective.owner = owner
 			add_objective(purge_objective)
-		if(3)
-			var/datum/objective/robot_army/robot_objective = new
-			robot_objective.owner = owner
-			add_objective(robot_objective)
-		if(4) //Protect and strand a target
+		if(3) //Protect and strand a target
 			var/datum/objective/protect/yandere_one = new
 			yandere_one.owner = owner
 			add_objective(yandere_one)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I'll be honest, this objective single-handedly ruined a lot of peoples' rounds earlier today. That makes sense, considering it is outright too chaotic for hyper's interest. The objective is removed, but the items are still present; meaning that it should be used with caution instead of "let's just convert the whole station and plasmaflood it, honk!"
I wasn't actually there for the round, but I think it's just too chaotic.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stated above. This is simply too chaotic for our playerbase's interest. Lone/team antags are our focus, not conversion antags.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: robot_army objective
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
