### PR TITLE
Makes Blood Deficiency, Brain Tumor, and Apathetic quirks less bad

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -9,23 +9,6 @@
 	gain_text = "<span class='notice'>You feel like you could drink a whole keg!</span>"
 	lose_text = "<span class='danger'>You don't feel as resistant to alcohol anymore. Somehow.</span>"
 
-/datum/quirk/apathetic
-	name = "Apathetic"
-	desc = "You just don't care as much as other people. That's nice to have in a place like this, I guess."
-	value = 1
-	mood_quirk = TRUE
-
-/datum/quirk/apathetic/add()
-	GET_COMPONENT_FROM(mood, /datum/component/mood, quirk_holder)
-	if(mood)
-		mood.mood_modifier = 0.8
-
-/datum/quirk/apathetic/remove()
-	if(quirk_holder)
-		GET_COMPONENT_FROM(mood, /datum/component/mood, quirk_holder)
-		if(mood)
-			mood.mood_modifier = 1 //Change this once/if species get their own mood modifiers.
-
 /datum/quirk/drunkhealing
 	name = "Drunken Resilience"
 	desc = "Nothing like a good drink to make you feel on top of the world. Whenever you're drunk, you slowly recover from injuries."

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -13,7 +13,7 @@
 	if(NOBLOOD in H.dna.species.species_traits) //can't lose blood if your species doesn't have any
 		return
 	else
-		quirk_holder.blood_volume -= 0.275
+		quirk_holder.blood_volume -= 0.22
 
 /datum/quirk/depression
 	name = "Depression"
@@ -119,7 +119,7 @@
 	medical_record_text = "Patient has a tumor in their brain that is slowly driving them to brain death."
 
 /datum/quirk/brainproblems/on_process()
-	quirk_holder.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.2)
+	quirk_holder.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.12)
 
 /datum/quirk/nearsighted //t. errorage
 	name = "Nearsighted"

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -10,6 +10,18 @@
 	lose_text = "<span class='notice'>You can taste again!</span>"
 	medical_record_text = "Patient suffers from ageusia and is incapable of tasting food or reagents."
 
+/datum/quirk/apathetic
+	name = "Apathetic"
+	desc = "You just don't care as much as other people. That's nice to have in a place like this, I guess."
+	value = 0
+	mood_quirk = TRUE
+
+/datum/quirk/apathetic/remove()
+	if(quirk_holder)
+		GET_COMPONENT_FROM(mood, /datum/component/mood, quirk_holder)
+		if(mood)
+			mood.mood_modifier = 1 //Change this once/if species get their own mood modifiers.
+
 /datum/quirk/pineapple_liker
 	name = "Ananas Affinity"
 	desc = "You find yourself greatly enjoying fruits of the ananas genus. You can't seem to ever get enough of their sweet goodness!"


### PR DESCRIPTION
## About The Pull Request
Decreases blood removal from -.275 to -.22 for blood deficiency and brain damage from .2 to .12 for brain tumor, along with putting apathetic back into neutral quirks at 0 cost.

## Why It's Good For The Game
Brain Tumor and Blood Deficiency is a death sentence in 20 minutes. This significantly increases that time, making them less objectively terrible.

## Changelog
:cl:
tweak: Blood Deficiency blood removal from -.275 to -.22
tweak: Brain Tumor damage from .2 to .12
tweak: Apathetic changed to 0 cost and moved to neutral quirks.
/:cl: