### PR TITLE
Update cigs_lighters.dm

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -266,6 +266,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/clothing/mask/cigarette/dromedary
 	desc = "A DromedaryCo brand cigarette."
 	list_reagents = list("nicotine" = 7.5, "silicon" = 7.5)
+	
 /obj/item/clothing/mask/cigarette/uplift
 	desc = "An Uplift Smooth brand cigarette."
 	list_reagents = list("nicotine" = 7.5, "menthol" = 7.5)
@@ -280,7 +281,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/carp
 	desc = "A Carp Classic brand cigarette."
-	list_reagents = list("nicotine" = 7.5, "water" = 7.25, "sodiumchloride" = 0.25)
+	list_reagents = list("nicotine" = 7.5, "sodiumchloride" = 7.5)
+	
 /obj/item/clothing/mask/cigarette/syndicate
 	desc = "An unknown brand cigarette."
 	list_reagents = list("nicotine" = 15, "omnizine" = 15)

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -265,13 +265,14 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/dromedary
 	desc = "A DromedaryCo brand cigarette."
-
+	list_reagents = list("nicotine" = 7.5, "silicon" = 7.5)
 /obj/item/clothing/mask/cigarette/uplift
 	desc = "An Uplift Smooth brand cigarette."
 	list_reagents = list("nicotine" = 7.5, "menthol" = 7.5)
 
 /obj/item/clothing/mask/cigarette/robust
 	desc = "A Robust brand cigarette."
+	list_reagents = list("nicotine" = 7.5, "grenadine" = 7.5)
 
 /obj/item/clothing/mask/cigarette/robustgold
 	desc = "A Robust Gold brand cigarette."
@@ -279,7 +280,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/carp
 	desc = "A Carp Classic brand cigarette."
-
+	list_reagents = list("nicotine" = 7.5, "water" = 7.25, "sodiumchloride" = 0.25)
 /obj/item/clothing/mask/cigarette/syndicate
 	desc = "An unknown brand cigarette."
 	list_reagents = list("nicotine" = 15, "omnizine" = 15)
@@ -911,7 +912,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if (O.heat > 500)
 		if (reagents && reagents.total_volume) //if there's stuff in the bong
 			var/lighting_text = O.ignition_effect(src, user)
-			if(lighting_text) 
+			if(lighting_text)
 				//Logic regarding igniting it on
 				if (firecharges == 0)
 					user.show_message("<span class='notice'>You light the [src] with the [O]!</span>", 1)
@@ -1020,7 +1021,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 				var/datum/effect_system/smoke_spread/chem/smoke_machine/s = new
 				s.set_up(reagents, hit_strength, 18, user.loc)
-				s.start()	
+				s.start()
 
 				reagents.reaction(user, INGEST, fraction)
 				if(!reagents.trans_to(user, fraction))


### PR DESCRIPTION
## About The Pull Request

added extra regents to  free cigarettes except for midori tobako and space cigarettes

## Why It's Good For The Game

this will make the free cigarettes more unique while not making them any more powerful

## Changelog
:cl:
add: Added 7.5u silicon to dromedary cigarettes
add: Added 7.5u salt to carp cigarettes
add: Added 7.5u Grenadine to robust cigarettes
del: Removed 7.5u nicotine from dromedary cigarettes
del: Removed 7.5u nicotine from carp cigarettes
del: Removed 7.5u nicotine from robust cigarettes
/:cl:


