### PR TITLE
Status Tab Investigation Part 2 - Electric frameratearoo

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -534,7 +534,6 @@
 /var/list/sList
 /mob/Stat()
 	..()
-	
 	//This is where I try and add a temporary solution to the issue of the status tab. This solution is bad and I should feel bad, but it should mitigate some of the client lag.
 	if(statpanel("Status") && tickrefresh == 0)
 		sList = list()
@@ -548,7 +547,7 @@
 		sList+= "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]"
 		sList+= "Round Time: [WORLDTIME2TEXT("hh:mm:ss")]"
 		sList+= "Station Time: [STATION_TIME_TIMESTAMP("hh:mm:ss")]"
-		sList+= "Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)"
+		//sList+= "Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)"
 		if(SSshuttle.emergency)
 			var/ETA = SSshuttle.emergency.getModeStr()
 			if(ETA)
@@ -557,7 +556,7 @@
 		stat(null, sList)
 
 	else if(statpanel("Status") && tickrefresh != 0)
-		if(tickrefresh == 5)
+		if(tickrefresh == 10)
 			tickrefresh = 0
 		else
 			tickrefresh++


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removing the Time Dilation calculation from the status tab and increasing the tickrefresh threshold to 10 seemingly increased the tab's performance during my tests.

## Why It's Good For The Game

Muh frames v2

## Changelog
:cl:
Tweaked the status tab fix
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
