### PR TITLE
Makes Events Less Chaotic

### DIFF
--- a/code/modules/antagonists/revenant/revenant_spawn_event.dm
+++ b/code/modules/antagonists/revenant/revenant_spawn_event.dm
@@ -3,9 +3,9 @@
 /datum/round_event_control/revenant
 	name = "Spawn Revenant" // Did you mean 'griefghost'?
 	typepath = /datum/round_event/ghost_role/revenant
-	weight = 7
+	weight = 5
 	max_occurrences = 1
-	min_players = 5
+	min_players = 20
 
 
 /datum/round_event/ghost_role/revenant

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -2,7 +2,7 @@
 	name = "Disease Outbreak"
 	typepath = /datum/round_event/disease_outbreak
 	max_occurrences = 1
-	min_players = 10
+	min_players = 15
 	weight = 5
 
 /datum/round_event/disease_outbreak

--- a/code/modules/events/grid_check.dm
+++ b/code/modules/events/grid_check.dm
@@ -2,7 +2,7 @@
 	name = "Grid Check"
 	typepath = /datum/round_event/grid_check
 	weight = 10
-	max_occurrences = 3
+	max_occurrences = 2
 
 /datum/round_event/grid_check
 	announceWhen	= 1

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -7,7 +7,7 @@
 	name = "Meteor Wave: Normal"
 	typepath = /datum/round_event/meteor_wave
 	weight = 4
-	min_players = 15
+	min_players = 20
 	max_occurrences = 3
 	earliest_start = 25 MINUTES
 
@@ -66,9 +66,9 @@
 /datum/round_event_control/meteor_wave/threatening
 	name = "Meteor Wave: Threatening"
 	typepath = /datum/round_event/meteor_wave/threatening
-	weight = 5
+	weight = 4
 	min_players = 20
-	max_occurrences = 3
+	max_occurrences = 2
 	earliest_start = 35 MINUTES
 
 /datum/round_event/meteor_wave/threatening
@@ -77,9 +77,9 @@
 /datum/round_event_control/meteor_wave/catastrophic
 	name = "Meteor Wave: Catastrophic"
 	typepath = /datum/round_event/meteor_wave/catastrophic
-	weight = 7
+	weight = 4
 	min_players = 25
-	max_occurrences = 3
+	max_occurrences = 1
 	earliest_start = 45 MINUTES
 
 /datum/round_event/meteor_wave/catastrophic

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -2,8 +2,8 @@
 	name = "Portal Storm: Syndicate Shocktroops"
 	typepath = /datum/round_event/portal_storm/syndicate_shocktroop
 	weight = 2
-	min_players = 15
-	earliest_start = 30 MINUTES
+	min_players = 25
+	earliest_start = 50 MINUTES
 
 /datum/round_event/portal_storm/syndicate_shocktroop
 	boss_types = list(/mob/living/simple_animal/hostile/syndicate/melee/space/stormtrooper = 2)

--- a/code/modules/events/processor_overload.dm
+++ b/code/modules/events/processor_overload.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/processor_overload
 	name = "Processor Overload"
 	typepath = /datum/round_event/processor_overload
-	weight = 15
+	weight = 10
 	min_players = 20
 
 /datum/round_event/processor_overload

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -1,8 +1,8 @@
 /datum/round_event_control/vent_clog
 	name = "Clogged Vents: Normal"
 	typepath = /datum/round_event/vent_clog
-	weight = 10
-	max_occurrences = 3
+	weight = 8
+	max_occurrences = 1
 	min_players = 25
 
 /datum/round_event/vent_clog
@@ -44,10 +44,10 @@
 		"tiresolution",
 		"sodiumchloride",
 		"beer",
-		"hair_dye",
 		"sugar",
 		"white_glitter",
-		"growthserum",
+		"growthchem",
+		"shrinkchem",
 		"cornoil",
 		"uranium",
 		"carpet",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As of right now, events are absolutely whooping the ass of the very unrobust newbie crew, and some of these numbers outright are questionable for an environment like our own-- we're funny sex server with occasional mechanics, we don't want every round turning into a chaotic moshpit.
Also cleared the hair_dye and growthserum from scrubber events, replaced with shrinkchem and growthchem (sizecode)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Not exactly what we have in mind for server direction, really. Blatant hugboxing, but that's what horny furries will do. Also getting your hair color changed cannot be fixed and it's really cringe.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: weights and players_required of a few events
remove: hair_dye and growthserum from scrubber backsurge
add: growthchem and shrinkchem into scrubber backsurge
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
