### PR TITLE
Final Status Tab Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -59,7 +59,7 @@
 	//...and display them.
 	add_to_all_human_data_huds()
 
-/var/list/sList2
+
 /mob/living/carbon/human/Stat()
 	..()
 	//Same thing from mob
@@ -80,7 +80,8 @@
 				if(changeling)
 					sList2 += "Chemical Storage: " + "[changeling.chem_charges]/[changeling.chem_storage]"
 					sList2 += "Absorbed DNA: "+ "[changeling.absorbedcount]"
-		stat(null, "[sList2.Join("\n\n")]")
+		if (sList2 != null)
+			stat(null, "[sList2.Join("\n\n")]")
 
 	//NINJACODE
 	if(istype(wear_suit, /obj/item/clothing/suit/space/space_ninja)) //Only display if actually a ninja.

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -59,15 +59,12 @@
 	//...and display them.
 	add_to_all_human_data_huds()
 
-/var/tickrefreshThr2 = 20
-/var/tickrefresh2 = 0
 /var/list/sList2
-
 /mob/living/carbon/human/Stat()
 	..()
 	//Same thing from mob
 	if(statpanel("Status"))
-		if(tickrefresh2 == 0)
+		if(tickrefresh == 1)
 			sList2 = list()
 			sList2 += "Intent: [a_intent]"
 			sList2 += "Move Mode: [m_intent]"
@@ -83,11 +80,6 @@
 				if(changeling)
 					sList2 += "Chemical Storage: " + "[changeling.chem_charges]/[changeling.chem_storage]"
 					sList2 += "Absorbed DNA: "+ "[changeling.absorbedcount]"
-			tickrefresh2++
-		else if(tickrefresh2 >= tickrefreshThr2)
-			tickrefresh2 = 0
-		else
-			tickrefresh2++
 		stat(null, "[sList2.Join("\n\n")]")
 
 	//NINJACODE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -531,9 +531,7 @@
 /mob/proc/is_muzzled()
 	return 0
 	
-/var/tickrefreshThr = 20
-/var/tickrefresh = 0
-/var/list/sList
+
 /mob/Stat()
 	..()
 	//This is where I try and add a temporary solution to the issue of the status tab. This solution is bad and I should feel bad, but it should mitigate some of the client lag.
@@ -553,7 +551,8 @@
 			tickrefresh = 0
 		else
 			tickrefresh++
-		stat(null, "[sList.Join("\n\n")]")
+		if (sList != null)
+			stat(null, "[sList.Join("\n\n")]")
 
 	if(client && client.holder)
 		if(statpanel("MC"))

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -16,6 +16,11 @@
 
 	var/stat = CONSCIOUS //Whether a mob is alive or dead. TODO: Move this to living - Nodrak
 
+
+	var/list/sList = list()
+	var/list/sList2 = list()
+	var/tickrefreshThr = 20
+	var/tickrefresh = 0
 	/*A bunch of this stuff really needs to go under their own defines instead of being globally attached to mob.
 	A variable should only be globally attached to turfs/objects/whatever, when it is in fact needed as such.
 	The current method unnecessarily clusters up the variable list, especially for humans (although rearranging won't really clean it up a lot but the difference will be noticable for other mobs).


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tested with multiple players on my local test server. The status tab no longer blinks, each player is assigned their own lists for which the status tab now takes information from. No more blinking. No cross-client weird interaction for atmospherics.
It done. ye.

## Why It's Good For The Game

Because fix

## Changelog
:cl:
Status Tab Blinking Fix
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
