### PR TITLE
Milking Machine Speed V2: Electric Boogaloo

### DIFF
--- a/hyperstation/code/obj/milking machine.dm
+++ b/hyperstation/code/obj/milking machine.dm
@@ -10,7 +10,7 @@
 	var/on = FALSE
 	var/obj/item/reagent_containers/glass/inserted_item = null
 
-	var/transfer_rate = 0.5 // How much we transfer every 2 seconds
+	var/transfer_rate = 0.50 // How much we transfer every 2 seconds
 	var/target_organ  = "breasts" // What organ we are transfering from
 
 /obj/item/milking_machine/examine(mob/user)

--- a/hyperstation/code/obj/milking machine.dm
+++ b/hyperstation/code/obj/milking machine.dm
@@ -10,7 +10,7 @@
 	var/on = FALSE
 	var/obj/item/reagent_containers/glass/inserted_item = null
 
-	var/transfer_rate = 0.25 // How much we transfer every 2 seconds
+	var/transfer_rate = 0.5 // How much we transfer every 2 seconds
 	var/target_organ  = "breasts" // What organ we are transfering from
 
 /obj/item/milking_machine/examine(mob/user)


### PR DESCRIPTION
## About The Pull Request

Increases the Milking Machine speed from 0.25 to 0.50
I fucked up the last once since byond apparently dislikes having only one number after the decimal point

## Why It's Good For The Game

I thought that 0.25 every two seconds is a bit slow so I increased it to 0.50 (not 0.5 this time since byond apparently requires two decimals)
## Changelog
:cl:
config: Changed 0.25 to 0.50 in the milking machine config
/:cl:
