### PR TITLE
Hey that round showed something funky so i went and nerfed midround spawns, and medical benefits from something

### DIFF
--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -4,6 +4,7 @@
 	weight = 10
 	max_occurrences = 1
 	min_players = 20
+	earliest_start = 45 MINUTES
 	gamemode_blacklist = list("nuclear","wizard","revolution")
 
 /datum/round_event/ghost_role/abductor

--- a/code/modules/events/nightmare.dm
+++ b/code/modules/events/nightmare.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/ghost_role/nightmare
 	max_occurrences = 1
 	min_players = 20
+	earliest_start = 30 MINUTES
 
 /datum/round_event/ghost_role/nightmare
 	minimum_required = 1

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -73,7 +73,7 @@
 	id = "synthtissue"
 	results = list("synthtissue" = 0.05)
 	required_reagents = list("synthflesh" = 0.01)
-	required_catalysts = list("nutriment" = 0.1)
+	required_catalysts = list("sugar" = 0.1)
 	//FermiChem vars:
 	OptimalTempMin 		= 305		// Lower area of bell curve for determining heat based rate reactions
 	OptimalTempMax 		= 315 		// Upper end for above
@@ -92,7 +92,7 @@
 
 /datum/chemical_reaction/synthtissue/FermiCreate(datum/reagents/holder, added_volume, added_purity)
 	var/datum/reagent/synthtissue/St = holder.has_reagent("synthtissue")
-	var/datum/reagent/N = holder.has_reagent("nutriment")
+	var/datum/reagent/N = holder.has_reagent("sugar")
 	if(!St)
 		return
 	if(holder.chem_temp > 320)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Abductors spawned 20 minutes into the round, why?

i hope a minor fix doesn't fuck up

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Abductors is 45 minutes to start spawning
tweak: Nightmare is 30 minutes to start spawning
tweak: Synthtissue can be grown with sugar instead of nutriment
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
