### PR TITLE
Length times Size

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2070,7 +2070,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							to_chat(user,"<span class='danger'>Invalid color. Your color is not bright enough.</span>")
 
 				if("cock_length")
-					var/new_length = input(user, "Penis length in inches:\n([COCK_SIZE_MIN]-[COCK_SIZE_MAX])", "Character Preference") as num|null
+					var/new_length = input(user, "Penis length in inches:\n([COCK_SIZE_MIN]-[COCK_SIZE_MAX]) Your sprite size will effect your length examine text!\n(When 6in, 50%->3in, 200%->12in)", "Character Preference") as num|null
 					if(new_length)
 						features["cock_length"] = max(min( round(text2num(new_length)), COCK_SIZE_MAX),COCK_SIZE_MIN)
 
@@ -2232,7 +2232,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 //Hyperstation Body Size
 
 				if("bodysize")
-					var/new_bodysize = input(user, "Choose your desired sprite size:\n([MIN_BODYSIZE]-[MAX_BODYSIZE]), Warning: May make your character look distorted!", "Character Preference") as num|null
+					var/new_bodysize = input(user, "Choose your desired sprite size:\n([MIN_BODYSIZE]-[MAX_BODYSIZE]), Warning: May make your character look distorted!\nWill change health pool and speed, while limiting some mechanics (ex: lockers).", "Character Preference") as num|null
 					if (new_bodysize)
 						body_size = max(min( round(text2num(new_bodysize)), MAX_BODYSIZE),MIN_BODYSIZE)
 

--- a/hyperstation/code/modules/resize/resizing.dm
+++ b/hyperstation/code/modules/resize/resizing.dm
@@ -46,6 +46,10 @@ mob/living/get_effective_size()
 	var/healthchange = healthmod_new - healthmod_old //Get ready to apply the new value, and subtract the old one. (Negative values become positive)
 	src.maxHealth += healthchange
 	src.health += healthchange
+	if(iscarbon(src))
+		var/mob/living/carbon/C = src
+		for(var/obj/item/organ/genital/G in C.internal_organs)
+			G.update_appearance()
 	previous_size = size_multiplier //And, change this now that we are finally done.
 
 //handle the big steppy, except nice

--- a/modular_citadel/code/modules/arousal/organs/penis.dm
+++ b/modular_citadel/code/modules/arousal/organs/penis.dm
@@ -72,7 +72,9 @@
 /obj/item/organ/genital/penis/update_appearance()
 	var/string
 	var/lowershape = lowertext(shape)
-	desc = "You see [aroused_state ? "an erect" : "a flaccid"] [lowershape] penis. You estimate it's about [round(length, 0.25)] inch[round(length, 0.25) != 1 ? "es" : ""] long and [round(girth, 0.25)] inch[round(girth, 0.25) != 1 ? "es" : ""] in girth."
+	var/length_new = length*owner.size_multiplier
+	var/girth_new = girth*owner.size_multiplier
+	desc = "You see [aroused_state ? "an erect" : "a flaccid"] [lowershape] penis. You estimate it's about [round(length_new, 0.25)] inch[round(length_new, 0.25) != 1 ? "es" : ""] long and [round(girth_new, 0.25)] inch[round(girth_new, 0.25) != 1 ? "es" : ""] in girth."
 
 	if(owner)
 		if(owner.dna.species.use_skintones && owner.dna.features["genitals_use_skintone"])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is more so a change to examine text and flavor text revolving around our size code we have in game, ultimately if one were to be 50% sprite size (Which is roughly three feet tall as we're doing 6ft for basic height reference), and sporting a rod that's just the same size in comparison. It should instead be half the amount based off sprite size, ending up being a foot and six inches versus three feet (and yes this does effect girth too).

Additionally sprite size and penis length info boxes have been updated, telling players what occurs when you change sprite size from 100% along with how sprite size effects length examine flavor text.

![image](https://user-images.githubusercontent.com/67985407/92988317-4abac700-f47f-11ea-9fc9-7020436ba2f2.png)

![image](https://user-images.githubusercontent.com/67985407/92988326-527a6b80-f47f-11ea-810e-cf0b695a5f85.png)

Special thanks to Jay-Sparrow for some coding help.

## Why It's Good For The Game

This adds a bit more realism to when someone's character changes in size respectively, if one were to be 100% sprite size and sporting three feet worth of meat, it would grow or shrink respectively with the owner rather than being a constant value (unless an outside force changes it as well). Personally i find it weird when a micro who's a few inches tall have a schlong ten times their current size, unless it was like that 'before' shrinking.

## Changelog
:cl:
add: More descriptions to pop ups when adding values to Sprite Size and Penis Length
tweak: Size code to work with dick sizes
code: changed and added a new variable to define the multiplication of length times owner size multiplier within examine text.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
