### PR TITLE
Language Diversity / Racial fixes

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -233,3 +233,63 @@
 /datum/quirk/slimespeaker/remove()
 	var/mob/living/M = quirk_holder
 	M.remove_language(/datum/language/slime)
+
+/datum/quirk/narsianspeaker
+	name = "Nar-Sian speaker"
+	desc = "Obsessed with the inner workings of the blood cult, you've learned how to speak their ancient language."
+	value = 1
+	gain_text = "<span class='notice'>Your mind feels sensitive to the slurred, ancient language of Nar'Sian cultists.</span>"
+	lose_text = "<span class='notice'>You forget how to speak Nar'Sian!</span>"
+
+/datum/quirk/narsianspeaker/add()
+	var/mob/living/M = quirk_holder
+	M.grant_language(/datum/language/narsie)
+
+/datum/quirk/narsianspeaker/remove()
+	var/mob/living/M = quirk_holder
+	M.remove_language(/datum/language/narsie)
+
+/datum/quirk/ratvarianspeaker
+	name = "Ratvarian speaker"
+	desc = "Obsessed with forbidden knowledge regarding the clock cult, you've learned how to speak their language."
+	value = 1
+	gain_text = "<span class='notice'>Your mind feels sensitive to the ancient language of Ratvarian cultists.</span>"
+	lose_text = "<span class='notice'>You forget how to speak Ratvarian!</span>"
+
+/datum/quirk/ratvarianspeaker/add()
+	var/mob/living/M = quirk_holder
+	M.grant_language(/datum/language/ratvar)
+
+/datum/quirk/ratvarianspeaker/remove()
+	var/mob/living/M = quirk_holder
+	M.remove_language(/datum/language/ratvar)
+
+/datum/quirk/encodedspeaker
+	name = "Encoded Audio speaker"
+	desc = "You've been augmented with language encoders, allowing you to understand encoded audio."
+	value = 1
+	gain_text = "<span class='notice'>Your mouth feels a little weird for a moment as your language encoder kicks in.</span>"
+	lose_text = "<span class='notice'>You feel your encoded audio chip malfunction. You can no longer speak or understand the language of fax machines.</span>"
+
+/datum/quirk/encodedspeaker/add()
+	var/mob/living/M = quirk_holder
+	M.grant_language(/datum/language/machine)
+
+/datum/quirk/encodedspeaker/remove()
+	var/mob/living/M = quirk_holder
+	M.remove_language(/datum/language/machine)
+
+/datum/quirk/xenospeaker
+	name = "Xenocommon speaker"
+	desc = "Through time observing and interacting with xenos and xeno hybrids, you've learned the intricate hissing patterns of their language."
+	value = 1
+	gain_text = "<span class='notice'>You feel that you are now able to hiss in the same way xenomorphs do.</span>"
+	lose_text = "<span class='notice'>You seem to no longer know how to speak xenocommon.</span>"
+
+/datum/quirk/xenospeaker/add()
+	var/mob/living/M = quirk_holder
+	M.grant_language(/datum/language/xenocommon)
+
+/datum/quirk/xenospeaker/remove()
+	var/mob/living/M = quirk_holder
+	M.remove_language(/datum/language/xenocommon)

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -236,7 +236,7 @@
 
 /datum/quirk/narsianspeaker
 	name = "Nar-Sian speaker"
-	desc = "Obsessed with the inner workings of the blood cult, you've learned how to speak their ancient language."
+	desc = "Obsessed with forbidden knowledge regarding the blood cult, you've learned how to speak their ancient language."
 	value = 1
 	gain_text = "<span class='notice'>Your mind feels sensitive to the slurred, ancient language of Nar'Sian cultists.</span>"
 	lose_text = "<span class='notice'>You forget how to speak Nar'Sian!</span>"
@@ -251,7 +251,7 @@
 
 /datum/quirk/ratvarianspeaker
 	name = "Ratvarian speaker"
-	desc = "Obsessed with forbidden knowledge regarding the clock cult, you've learned how to speak their language."
+	desc = "Obsessed with the inner workings of the clock cult, you've learned how to speak their language."
 	value = 1
 	gain_text = "<span class='notice'>Your mind feels sensitive to the ancient language of Ratvarian cultists.</span>"
 	lose_text = "<span class='notice'>You forget how to speak Ratvarian!</span>"

--- a/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -29,10 +29,12 @@
 	..()
 	assume_disguise(old_species, H)
 	RegisterSignal(H, COMSIG_MOB_SAY, .proc/handle_speech)
+	H.grant_language(/datum/language/machine)
 
 /datum/species/synth/on_species_loss(mob/living/carbon/human/H)
 	. = ..()
 	UnregisterSignal(H, COMSIG_MOB_SAY)
+	H.remove_language(/datum/language/machine)
 
 /datum/species/synth/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	if(chem.id == "synthflesh")

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -22,6 +22,7 @@
 		/datum/language/ratvar,
 		/datum/language/aphasia,
 		/datum/language/slime,
+		/datum/language/xenocommon,
 	))
 	healing_factor = STANDARD_ORGAN_HEALING*5 //Fast!!
 	decay_factor = STANDARD_ORGAN_DECAY/2
@@ -251,6 +252,12 @@
 
 /obj/item/organ/tongue/robot/can_speak_in_language(datum/language/dt)
 	return ..() || electronics_magic
+
+/obj/item/organ/tongue/robot/Initialize(mapload)
+	. = ..()
+	var/static/list/languages_possible_robot = languages_possible_base + typecacheof(list(
+		/datum/language/machine))
+	languages_possible = languages_possible_robot
 
 /obj/item/organ/tongue/robot/handle_speech(datum/source, list/speech_args)
 	speech_args[SPEECH_SPANS] |= SPAN_ROBOT

--- a/modular_citadel/code/modules/mob/living/carbon/human/species_types/furrypeople.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/species_types/furrypeople.dm
@@ -227,6 +227,7 @@
 	liked_food = MEAT
 
 /datum/species/xeno/on_species_gain(mob/living/carbon/human/C, datum/species/old_species)
+	C.grant_language(/datum/language/xenocommon)
 	if(("legs" in C.dna.species.mutant_bodyparts) && C.dna.features["legs"] == "Digitigrade Legs")
 		species_traits += DIGITIGRADE
 	if(DIGITIGRADE in species_traits)
@@ -234,6 +235,7 @@
 	. = ..()
 
 /datum/species/xeno/on_species_loss(mob/living/carbon/human/C, datum/species/new_species)
+	C.remove_language(/datum/language/xenocommon)
 	if(("legs" in C.dna.species.mutant_bodyparts) && C.dna.features["legs"] == "Normal Legs")
 		species_traits -= DIGITIGRADE
 	if(DIGITIGRADE in species_traits)

--- a/modular_citadel/code/modules/mob/living/carbon/human/species_types/ipc.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/species_types/ipc.dm
@@ -24,12 +24,14 @@
 	var/datum/action/innate/monitor_change/screen
 
 /datum/species/ipc/on_species_gain(mob/living/carbon/human/C)
+	C.grant_language(/datum/language/machine)
 	if(isipcperson(C) && !screen)
 		screen = new
 		screen.Grant(C)
 	..()
 
 /datum/species/ipc/on_species_loss(mob/living/carbon/human/C)
+	C.remove_language(/datum/language/machine)
 	if(screen)
 		screen.Remove(C)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This pull request is the combined effort of a fair bit of code dissection and discussion about variety and diversity with the game's languages, as well as some requested racial language fixes for some races.

## Why It's Good For The Game

This gives xeno hybrids the ability to speak the xenocommon language as a racial trait, however, they cannot speak within the hivemind due to the fact that xeno hybrids are disconnected from it. (Unless they acquire the organs for it, that is)
It also gives IPCs and Synths the ability to speak Encoded Audio Language, as well as any other robotic race that inherits tongue/robot or organics that get their tongue replaced with a tongue of robotic origin.

Traits for understanding/speaking Xenocommon/EAL/Ratvarian/Narsian are also introduced. If you meet the pre-requirements for speaking them, you are able to not only understand, but also speak them, although you are not connected to any of the antag communication hiveminds, much like the curator.

Example:

A human picks up the EAL trait. They will be able to understand EAL but not speak it, unless they switch their tongue to a robot tongue. This works kind of like the star wars droid situation, where humans can understand them but cannot speak in beep boops.

## Changelog
:cl:
Synths and IPCs now speak and understand EAL as a racial.
Xeno Hybrids now speak and understand Xenocommon as a racial.
New language traits are available. For the small price of your soul, you can understand some of them.~
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->


![image](https://user-images.githubusercontent.com/53913550/93008320-acdffe80-f549-11ea-9817-241141077917.png)
