### PR TITLE
Synthliz EAL fix

### DIFF
--- a/modular_citadel/code/modules/mob/living/carbon/human/species_types/furrypeople.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/species_types/furrypeople.dm
@@ -296,6 +296,14 @@
 		mutant_bodyparts -= "mam_waggingtail"
 		mutant_bodyparts |= "mam_tail"
 	H.update_body()
+
+/datum/species/synthliz/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
+	..()
+	H.grant_language(/datum/language/machine)
+
+/datum/species/synthliz/on_species_loss(mob/living/carbon/human/H)
+	H.remove_language(/datum/language/machine)
+	..()
 //Praise the Omnissiah, A challange worthy of my skills - HS
 
 //EXOTIC//


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds EAL for Synthlizards as well.

## Why It's Good For The Game

Bugfix, this was supposed to work on the earlier PR.

## Changelog
:cl:
fix: Synthliz now has EAL as a racial.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
