### PR TITLE
Reworks Dwarfism, Adds Giantism, Bluespace Compression Shrinking, and Makes Sizechems Craftable

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -12,6 +12,7 @@
 #define MUTATE		/datum/mutation/human/bad_dna
 #define COUGH		/datum/mutation/human/cough
 #define DWARFISM	/datum/mutation/human/dwarfism
+#define GIANTISM	/datum/mutation/human/giantism
 #define CLOWNMUT	/datum/mutation/human/clumsy
 #define TOURETTES	/datum/mutation/human/tourettes
 #define DEAFMUT		/datum/mutation/human/deaf

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -71,7 +71,7 @@
 //Dwarfism shrinks your body.
 /datum/mutation/human/dwarfism
 	name = "Dwarfism"
-	desc = "A mutation believed to be the cause of dwarfism."
+	desc = "A mutation believed to be the cause of dwarfism. May not work on smaller things properly."
 	quality = POSITIVE
 	difficulty = 16
 	instability = 5
@@ -96,7 +96,7 @@
 //Giantism grows your body.
 /datum/mutation/human/giantism
 	name = "Giantism"
-	desc = "A mutation believed to be the cause of giantism."
+	desc = "A mutation believed to be the cause of giantism. May not work on larger things properly."
 	quality = POSITIVE
 	difficulty = 14
 	instability = 5

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -68,7 +68,7 @@
 			owner.throw_at(target, cough_range, GET_MUTATION_POWER(src))
 
 
-//Dwarfism shrinks your body and lets you pass tables.
+//Dwarfism shrinks your body.
 /datum/mutation/human/dwarfism
 	name = "Dwarfism"
 	desc = "A mutation believed to be the cause of dwarfism."
@@ -80,17 +80,43 @@
 /datum/mutation/human/dwarfism/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
 		return
-	owner.transform = owner.transform.Scale(1, 0.8)
-	owner.pass_flags |= PASSTABLE
+	if(owner.size_multiplier <= RESIZE_A_TINYMICRO) //Because what's optimization?
+		return
+	owner.resize(owner.size_multiplier-0.2)
 	owner.visible_message("<span class='danger'>[owner] suddenly shrinks!</span>", "<span class='notice'>Everything around you seems to grow..</span>")
 
 /datum/mutation/human/dwarfism/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
-	owner.transform = owner.transform.Scale(1, 1.25)
-	owner.pass_flags &= ~PASSTABLE
+	if(owner.size_multiplier >= RESIZE_A_MACROHUGE)
+		return
+	owner.resize(owner.size_multiplier+0.2)
 	owner.visible_message("<span class='danger'>[owner] suddenly grows!</span>", "<span class='notice'>Everything around you seems to shrink..</span>")
 
+//Giantism grows your body.
+/datum/mutation/human/giantism
+	name = "Giantism"
+	desc = "A mutation believed to be the cause of giantism."
+	quality = POSITIVE
+	difficulty = 14
+	instability = 5
+	locked = TRUE
+
+/datum/mutation/human/giantism/on_acquiring(mob/living/carbon/human/owner)
+	if(..())
+		return
+	if(owner.size_multiplier >= RESIZE_A_MACROHUGE)
+		return
+	owner.resize(owner.size_multiplier+0.2)
+	owner.visible_message("<span class='danger'[owner] expands in size!</span>", "<span class='notice'>Everything around you compresses smaller...</span>")
+
+/datum/mutation/human/giantism/on_losing(mob/living/carbon/human/owner)
+	if(..())
+		return
+	if(owner.size_multiplier <= RESIZE_A_TINYMICRO)
+		return
+	owner.resize(owner.size_multiplier-0.2)
+	owner.visible_message("<span class='danger'>[owner] suddenly shrinks back down!", "<span class='notice'>You shrink back down in size.</span>")
 
 //Clumsiness has a very large amount of small drawbacks depending on item.
 /datum/mutation/human/clumsy

--- a/code/game/objects/items/devices/compressionkit.dm
+++ b/code/game/objects/items/devices/compressionkit.dm
@@ -112,6 +112,18 @@
 							else
 								O.update_size()
 								O.update_appearance()
+							return
+			else //shrink them overall
+				playsound(get_turf(src), 'sound/weapons/flash.ogg', 50, 1)
+				victim.visible_message("<span class='warning'>[user] is preparing to shrink [victim] with their bluespace compression kit!</span>")
+				if(do_mob(user, victim, 40) && charges > 0 && victim.size_multiplier > RESIZE_A_TINYMICRO)
+					victim.visible_message("<span class='warning'>[user] has shrunk [victim]!")
+					playsound(get_turf(src), 'sound/weapons/emitter2.ogg', 50, 1)
+					sparks()
+					flash_lighting_fx(3, 3, LIGHT_COLOR_CYAN)
+					charges -= 1
+					victim.resize(victim.size_multiplier-0.2)
+					return
 
 
 

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -148,6 +148,7 @@
 /obj/item/dnainjector/giant
 	name = "\improper DNA injector (Giantism)"
 	desc = "Makes you bigger."
+	add_mutations = list(GIANTISM)
 
 /obj/item/dnainjector/clumsymut
 	name = "\improper DNA injector (Clumsy)"

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -140,6 +140,15 @@
 	desc = "It's a small world after all."
 	add_mutations = list(DWARFISM)
 
+/obj/item/dnainjector/antigiant
+	name = "\improper DNA injector (Anti-Giantism)"
+	desc = "Makes you small and weak."
+	remove_mutations = list(GIANTISM)
+
+/obj/item/dnainjector/giant
+	name = "\improper DNA injector (Giantism)"
+	desc = "Makes you bigger."
+
 /obj/item/dnainjector/clumsymut
 	name = "\improper DNA injector (Clumsy)"
 	desc = "Makes clown minions."

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1929,37 +1929,12 @@
 	if((ismonkey(M) || ishuman(M)) && current_cycle >= 10)
 		M.gorillize()
 
-/datum/reagent/growthserum
+/datum/reagent/growthserum //neutered to use as a chemical base for sizecode shit
 	name = "Growth Serum"
 	id = "growthserum"
 	description = "A commercial chemical designed to help older men in the bedroom."//not really it just makes you a giant
 	color = "#ff0000"//strong red. rgb 255, 0, 0
-	var/current_size = 1
 	taste_description = "bitterness" // apparently what viagra tastes like
-
-/datum/reagent/growthserum/on_mob_life(mob/living/carbon/H)
-	var/newsize = current_size
-	switch(volume)
-		if(0 to 19)
-			newsize = 1.25
-		if(20 to 49)
-			newsize = 1.5
-		if(50 to 99)
-			newsize = 2
-		if(100 to 199)
-			newsize = 2.5
-		if(200 to INFINITY)
-			newsize = 3.5
-
-	H.resize = newsize/current_size
-	current_size = newsize
-	H.update_transform()
-	..()
-
-/datum/reagent/growthserum/on_mob_end_metabolize(mob/living/M)
-	M.resize = 1/current_size
-	M.update_transform()
-	..()
 
 /datum/reagent/plastic_polymers
 	name = "plastic polymers"

--- a/hyperstation/code/modules/resize/sizechems.dm
+++ b/hyperstation/code/modules/resize/sizechems.dm
@@ -1,5 +1,42 @@
 //Size Chemicals, now with better and less cringy names.
+//TO DO: USE BETTER FERMICHEM TO MAKE ALL OF THESE CHEMICALS MORE INTERACTIVE
 
+//Sizechem reagent
+/datum/reagent/sizechem
+	name = "Cell-Volume Altering Base"
+	id = "sizechem"
+	description = "A stabilized compound liquid, used as a basis for increasing or decreasing the size of living matter with more recipes."
+	color = "#C900CC"
+	taste_description = "regret"
+	can_synth = FALSE
+	metabolization_rate = 0.25
+
+//Sizechem reaction
+/datum/chemical_reaction/sizechem
+	name = "Cell-Volume Altering Base"
+	id = "sizechem"
+	mix_message = "the reaction rapidly alters in size!"
+	required_reagents = list("growthserum" = 0.15, "clonexadone" = 0.15, "gold" = 0.15, "acetone" = 0.15)
+	results = list("sizechem" = 0.3)
+	required_temp = 1
+	//Fermichem vars
+	OptimalTempMin 		= 600 		// Lower area of bell curve for determining heat based rate reactions
+	OptimalTempMax 		= 630 		// Upper end for above
+	ExplodeTemp 		= 635 		// Temperature at which reaction explodes
+	OptimalpHMin 		= 5 		// Lowest value of pH determining pH a 1 value for pH based rate reactions (Plateu phase)
+	OptimalpHMax 		= 5.5 		// Higest value for above
+	ReactpHLim 			= 2 		// How far out pH wil react, giving impurity place (Exponential phase)
+	CatalystFact 		= 0 		// How much the catalyst affects the reaction (0 = no catalyst)
+	CurveSharpT 		= 4 		// How sharp the temperature exponential curve is (to the power of value)
+	CurveSharppH 		= 4 		// How sharp the pH exponential curve is (to the power of value)
+	ThermicConstant		= -10 		// Temperature change per 1u produced
+	HIonRelease 		= 0.02 		// pH change per 1u reaction (inverse for some reason)
+	RateUpLim 			= 1 		// Optimal/max rate possible if all conditions are perfect
+	FermiChem 			= TRUE		// If the chemical uses the Fermichem reaction mechanics
+	FermiExplode 		= FALSE		// If the chemical explodes in a special way
+	PurityMin 			= 0.2
+
+//Growthchem reagent
 /datum/reagent/growthchem
 	name = "Prospacillin"
 	id = "growthchem"
@@ -10,6 +47,31 @@
 	metabolization_rate = 0.25
 	can_synth = FALSE //DO NOT MAKE THIS SNYTHESIZABLE, THESE CHEMS ARE SUPPOSED TO NOT BE USED COMMONLY
 
+//Growthchem reaction
+/datum/chemical_reaction/growthchem
+	name = "Prospacillin"
+	id = "growthchem"
+	mix_message = "the reaction appears to grow!"
+	required_reagents = list("sizechem" = 0.15, "condensedcapsaicin" = 0.15, "aphro" = 0.2)
+	results = list("growthchem" = 0.25)
+	required_temp = 1
+	OptimalTempMin 		= 700 		// Lower area of bell curve for determining heat based rate reactions
+	OptimalTempMax 		= 730 		// Upper end for above
+	ExplodeTemp 		= 735 		// Temperature at which reaction explodes
+	OptimalpHMin 		= 3 		// Lowest value of pH determining pH a 1 value for pH based rate reactions (Plateu phase)
+	OptimalpHMax 		= 3.5 		// Higest value for above
+	ReactpHLim 			= 2 		// How far out pH wil react, giving impurity place (Exponential phase)
+	CatalystFact 		= 0 		// How much the catalyst affects the reaction (0 = no catalyst)
+	CurveSharpT 		= 4 		// How sharp the temperature exponential curve is (to the power of value)
+	CurveSharppH 		= 4 		// How sharp the pH exponential curve is (to the power of value)
+	ThermicConstant		= -10 		// Temperature change per 1u produced
+	HIonRelease 		= 0.02 		// pH change per 1u reaction (inverse for some reason)
+	RateUpLim 			= 1 		// Optimal/max rate possible if all conditions are perfect
+	FermiChem 			= TRUE		// If the chemical uses the Fermichem reaction mechanics
+	FermiExplode 		= FALSE		// If the chemical explodes in a special way
+	PurityMin 			= 0.2
+
+//Growthchem effects
 /datum/reagent/growthchem/on_mob_add(mob/living/carbon/M)
 	. = ..()
 	if(ishuman(M))
@@ -24,6 +86,7 @@
 	..()
 	. = 1
 
+//Shrinkchem reagent
 /datum/reagent/shrinkchem
 	name = "Diminicillin"
 	id = "shrinkchem"
@@ -31,9 +94,34 @@
 	color = "#0C26E7"
 	taste_description = "a pungent, acidic and jittery flavour"
 	overdose_threshold = 10
-	metabolization_rate = 1
+	metabolization_rate = 0.50
 	can_synth = FALSE //SAME STORY AS ABOVE
 
+//Shrinchem reaction
+/datum/chemical_reaction/shrinkchem
+	name = "Diminicillin"
+	id = "shrinkchem"
+	mix_message = "the reaction appears to shrink!"
+	required_reagents = list("sizechem" = 0.15, "frostoil" = 0.15, "aphro" = 0.2)
+	results = list("shrinkchem" = 0.25)
+	required_temp = 1
+	OptimalTempMin 		= 100 		// Lower area of bell curve for determining heat based rate reactions
+	OptimalTempMax 		= 150 		// Upper end for above
+	ExplodeTemp 		= 350 		// Temperature at which reaction explodes
+	OptimalpHMin 		= 3 		// Lowest value of pH determining pH a 1 value for pH based rate reactions (Plateu phase)
+	OptimalpHMax 		= 4.5 		// Higest value for above
+	ReactpHLim 			= 2 		// How far out pH wil react, giving impurity place (Exponential phase)
+	CatalystFact 		= 0 		// How much the catalyst affects the reaction (0 = no catalyst)
+	CurveSharpT 		= 4 		// How sharp the temperature exponential curve is (to the power of value)
+	CurveSharppH 		= 4 		// How sharp the pH exponential curve is (to the power of value)
+	ThermicConstant		= -10 		// Temperature change per 1u produced
+	HIonRelease 		= 0.02 		// pH change per 1u reaction (inverse for some reason)
+	RateUpLim 			= 1 		// Optimal/max rate possible if all conditions are perfect
+	FermiChem 			= TRUE		// If the chemical uses the Fermichem reaction mechanics
+	FermiExplode 		= FALSE		// If the chemical explodes in a special way
+	PurityMin 			= 0.2
+
+//Shrinkchem effects
 /datum/reagent/shrinkchem/on_mob_add(mob/living/carbon/M)
 	. = ..()
 	if(ishuman(M))

--- a/hyperstation/code/modules/resize/sizechems.dm
+++ b/hyperstation/code/modules/resize/sizechems.dm
@@ -52,7 +52,7 @@
 	name = "Prospacillin"
 	id = "growthchem"
 	mix_message = "the reaction appears to grow!"
-	required_reagents = list("sizechem" = 0.15, "condensedcapsaicin" = 0.15, "aphro" = 0.2)
+	required_reagents = list("sizechem" = 0.15, "condensedcapsaicin" = 0.15, "aphro" = 0.30)
 	results = list("growthchem" = 0.25)
 	required_temp = 1
 	OptimalTempMin 		= 700 		// Lower area of bell curve for determining heat based rate reactions
@@ -102,7 +102,7 @@
 	name = "Diminicillin"
 	id = "shrinkchem"
 	mix_message = "the reaction appears to shrink!"
-	required_reagents = list("sizechem" = 0.15, "frostoil" = 0.15, "aphro" = 0.2)
+	required_reagents = list("sizechem" = 0.15, "frostoil" = 0.15, "aphro" = 0.30)
 	results = list("shrinkchem" = 0.25)
 	required_temp = 1
 	OptimalTempMin 		= 100 		// Lower area of bell curve for determining heat based rate reactions


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the pass_table flag from dwarfism and the flat transform; instead applies a size_multiplier change to it. Adds a new genetic trait being Giantism, which is the opposite of dwarfism. 
Removes functionality of Growthserum.
Makes it so Bluespace Compression Kits can shrink people too
As well as that, makes size chemicals craftable through some Fermichem fuckery; recipes and values are subject to change.

RECIPES:
**Cell-Volume Altering Base**
1 part growthserum, 1 part clonexadone, 1 part gold, 1 part acetone. Optimal temperature at 600-300K, explodes above 635. Optimal pH of 5-5.5. No inverse or impure effects yet.

**Prospacillin** (Growth Chem)
1 part cell-volume altering base, 1 part condensed capsaicin, 2 parts aphro. Optimal temperature at  700-730K, explodes above 735. Optimal pH of 3-3.5. No inverse or impure effects yet.

**Diminicillin** (Shrink chem)
1 part cell-volume altering base, 1 part frost oil, 2 parts aphro. Optimal temperature at 100-150K, explodes above 350. optimal pH of 3-4.5. No inverse or impure effects yet.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives people a way to finally change their sizes in-game, albeit through harder to obtain mechanics.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Prospacillin recipe
add: Dimicillin recipe
add: Sizechem
add: Giantism
add: Bluespace compression Kit shrinking people
del: growthserum effects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
