### PR TITLE
Custom Ghost Role Appearance

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -210,6 +210,7 @@
 	conditions of your makeshift shelter, the hostile creatures, and the ash drakes swooping down from the cloudless skies, all you can wish for is the feel of soft grass between your toes and \
 	the fresh air of Earth. These thoughts are dispelled by yet another recollection of how you got here... "
 	assignedrole = "Hermit"
+	mirrorcanloadappearance = TRUE
 
 /obj/effect/mob_spawn/human/hermit/Initialize(mapload)
 	. = ..()
@@ -258,6 +259,7 @@
 	everyone's gone. One of the cats scratched you just a few minutes ago. That's why you were in the pod - to heal the scratch. The scabs are still fresh; you see them right now. So where is \
 	everyone? Where did they go? What happened to the hospital? And is that <i>smoke</i> you smell? You need to find someone else. Maybe they can tell you what happened.</b>"
 	assignedrole = "Translocated Vet"
+	mirrorcanloadappearance = TRUE
 
 /obj/effect/mob_spawn/human/doctor/alive/lavaland/Destroy()
 	var/obj/structure/fluff/empty_sleeper/S = new(drop_location())
@@ -318,6 +320,7 @@
 	flavour_text = "<span class='big bold'>You are a staff member of a top-of-the-line space hotel!</span><b> Cater to guests and <font size=6><b>DON'T</b></font> leave the hotel, lest the manager fire you for\
 		dereliction of duty!</b>"
 	assignedrole = "Hotel Staff"
+	mirrorcanloadappearance = TRUE
 
 /datum/outfit/hotelstaff
 	name = "Hotel Staff"
@@ -335,6 +338,7 @@
 	flavour_text = "<span class='big bold'>You are a peacekeeper</span><b> assigned to this hotel to protect the interests of the company while keeping the peace between \
 		guests and the staff. Do <font size=6>NOT</font> leave the hotel, as that is grounds for contract termination.</b>"
 	objectives = "Do not leave your assigned hotel. Try and keep the peace between staff and guests, non-lethal force heavily advised if possible."
+	mirrorcanloadappearance = TRUE
 
 /datum/outfit/hotelstaff/security
 	name = "Hotel Secuirty"
@@ -431,6 +435,7 @@
 	<br>\
 	<span class='danger'><b>The armory is not a candy store, and your role is not to assault the station directly, leave that work to the assault operatives.</b></span></font>"
 	outfit = /datum/outfit/syndicate_empty/SBC
+	mirrorcanloadappearance = TRUE
 
 /datum/outfit/syndicate_empty/SBC
 	name = "Syndicate Battlecruiser Ship Operative"
@@ -444,6 +449,7 @@
 	<br>\
 	<span class='danger'><b>Work as a team with your fellow operatives and work out a plan of attack. If you are overwhelmed, escape back to your ship!</b></span></span>"
 	outfit = /datum/outfit/syndicate_empty/SBC/assault
+	mirrorcanloadappearance = TRUE
 
 /datum/outfit/syndicate_empty/SBC/assault
 	name = "Syndicate Battlecruiser Assault Operative"
@@ -463,6 +469,7 @@
 	<span class='danger'><b>As the captain, this whole operation falls on your shoulders.</b></span> You do not need to nuke the station, causing sufficient damage and preventing your ship from being destroyed will be enough.</span>"
 	outfit = /datum/outfit/syndicate_empty/SBC/assault/captain
 	id_access_list = list(150,151)
+	mirrorcanloadappearance = TRUE
 
 /datum/outfit/syndicate_empty/SBC/assault/captain
 	name = "Syndicate Battlecruiser Captain"
@@ -497,6 +504,7 @@
 	l_pocket = /obj/item/assembly/flash/handheld
 	job_description = "Oldstation Crew"
 	assignedrole = "Ancient Crew"
+	mirrorcanloadappearance = TRUE
 
 /obj/effect/mob_spawn/human/oldsec/Destroy()
 	new/obj/structure/showcase/machinery/oldpod/used(drop_location())
@@ -523,6 +531,7 @@
 	gloves = /obj/item/clothing/gloves/color/fyellow/old
 	l_pocket = /obj/item/tank/internals/emergency_oxygen
 	assignedrole = "Ancient Crew"
+	mirrorcanloadappearance = TRUE
 
 /obj/effect/mob_spawn/human/oldeng/Destroy()
 	new/obj/structure/showcase/machinery/oldpod/used(drop_location())
@@ -548,6 +557,7 @@
 	l_pocket = /obj/item/stack/medical/bruise_pack
 	assignedrole = "Ancient Crew"
 	job_description = "Oldstation Crew"
+	mirrorcanloadappearance = TRUE
 
 /obj/effect/mob_spawn/human/oldsci/Destroy()
 	new/obj/structure/showcase/machinery/oldpod/used(drop_location())

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -23,7 +23,24 @@
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-
+		//Jay's mirror code suggestion
+		//This will be where the person gets to select their appearance instead of the random character
+		if (world.time <= (user.time_initialized + 900) && user.mirrorcanloadappearance == TRUE)
+			to_chat(user, "<span class='boldannounce'>You peer into the mirror. Make sure you have your ID in your ID slot, if you have one.</span>")
+			if(alert(user, "Would you like to load your currently loaded character's appearance?", "This can only be done up until 90s after you spawn.", "Yes", "No") == "Yes" && world.time <= (user.time_initialized + 900))
+				user.client.prefs.copy_to(user)
+				user.real_name = user.client.prefs.real_name
+				var/obj/item/card/id/idCard = user.get_idcard()
+				if (idCard != null)
+					idCard.update_label(user.real_name, idCard.assignment)
+					idCard.registered_name = user.real_name
+				user.mirrorcanloadappearance = FALSE
+				SEND_SOUND(user, 'sound/magic/charge.ogg')
+				to_chat(user, "<span class='boldannounce'>Your head aches for a second. You feel like this is how things should have been.</span>")
+				log_game("[key_name(user)] has loaded their default appearance for a ghost role.")
+				message_admins("[ADMIN_LOOKUPFLW(user)] has loaded their default appearance for a ghost role.")
+				return
+			else return
 		//see code/modules/mob/dead/new_player/preferences.dm at approx line 545 for comments!
 		//this is largely copypasted from there.
 

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -162,6 +162,7 @@
 	var/hair_style
 	var/facial_hair_style
 	var/skin_tone
+	var/mirrorcanloadappearance = FALSE
 
 /obj/effect/mob_spawn/human/Initialize()
 	if(ispath(outfit))
@@ -228,6 +229,8 @@
 			W.assignment = id_job
 		W.registered_name = H.real_name
 		W.update_label()
+	if (mirrorcanloadappearance)
+		H.mirrorcanloadappearance = TRUE
 
 //Instant version - use when spawning corpses during runtime
 /obj/effect/mob_spawn/human/corpse

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -9,6 +9,7 @@
 	verbs += /mob/living/proc/mob_sleep
 	verbs += /mob/living/proc/lay_down
 	verbs += /mob/living/carbon/human/proc/underwear_toggle //fwee
+	time_initialized = world.time
 
 	//initialize limbs first
 	create_bodyparts()

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -119,3 +119,7 @@
 	var/registered_z
 
 	var/mob/audiovisual_redirect //Mob to redirect messages, speech, and sounds to
+
+	var/time_initialized = null
+
+	var/mirrorcanloadappearance = FALSE

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -117,6 +117,7 @@
 	flavour_text = "<span class='big bold'>You are a syndicate agent,</span><b> employed in a top secret research facility developing biological weapons. Unfortunately, your hated enemy, Nanotrasen, has begun mining in this sector. <b>Continue your research as best you can, and try to keep a low profile. <font size=6>DON'T</font> abandon the base without good cause.</b> The base is rigged with explosives should the worst happen, do not let the base fall into enemy hands!</b>"
 	outfit = /datum/outfit/lavaland_syndicate
 	assignedrole = "Lavaland Syndicate"
+	mirrorcanloadappearance = TRUE
 
 /obj/effect/mob_spawn/human/lavaland_syndicate/special(mob/living/new_spawn)
 	new_spawn.grant_language(/datum/language/codespeak)
@@ -143,6 +144,7 @@
 	job_description = "Off-station Syndicate Comms Agent"
 	flavour_text = "<span class='big bold'>You are a syndicate agent,</span><b> employed in a top secret research facility developing biological weapons. Unfortunately, your hated enemy, Nanotrasen, has begun mining in this sector. <b>Monitor enemy activity as best you can, and try to keep a low profile. <font size=6>DON'T</font> abandon the base without good cause.</b> Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands!</b>"
 	outfit = /datum/outfit/lavaland_syndicate/comms
+	mirrorcanloadappearance = TRUE
 
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms/space/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alright. This is an odd one but hear me out. The folks and I were brainstorming ideas on how to keep a custom appearance within ghost roles and limit them to only specific ghost roles.

The code, based on @Jay-Sparrow 's original idea does the following:

Upon spawning with a ghost role (and only a ghost role) the ghost role will check if that role has the flag **mirrorcanloadappearance** set to **true** and allow the player for up to 90 seconds to get to a mirror and load their currently loaded character slot appearance. Non ghost roles and any ghost role without that flag set to true **cannot** change their appearances. This also changes their ID, if any, to reflect their name.

## Why It's Good For The Game

A lot of people dislike playing the generic humans. This does not remove the option to play as a generic human, but rather allows them to choose, if the ghost role in question has a mirror wherever they spawn and has the flag in question set to true. It is quite easy for any devs and/or hosts/maintainers to set that flag to true for any ghost role they wish to have it on.

With this PR, the following ghost roles have it enabled:

All Oldstation
All Lavaland Syndicate Roles
Hotel Staff
Lavaland Vet
Hermits
Syndicate Battlecruiser

## Changelog
:cl:
add: Custom Ghost Role Appearances enabled. Visit a mirror!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
