### PR TITLE
WE'LL DO IT LIVE - Ghost Role appearance no longer requires a mirror

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -23,7 +23,7 @@
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		checkloadappearance(H, user)
+		H.checkloadappearance()
 		//see code/modules/mob/dead/new_player/preferences.dm at approx line 545 for comments!
 		//this is largely copypasted from there.
 		//handle facial hair (if necessary)
@@ -44,31 +44,6 @@
 			H.hair_style = new_style
 
 		H.update_hair()
-
-/obj/structure/mirror/proc/checkloadappearance(mob/living/carbon/human/H, mob/user)
-	//Jay's mirror code suggestion
-	//This will be where the person gets to select their appearance instead of the random character
-	if (world.time <= (H.time_initialized + 900) && H.mirrorcanloadappearance == TRUE)
-		to_chat(H, "<span class='boldannounce'>You peer into the mirror. Make sure you have your ID in your ID slot, if you have one.</span>")
-		if(alert(user, "Would you like to load your currently loaded character's appearance?", "This can only be done up until 90s after you spawn.", "Yes", "No") == "Yes" && world.time <= (H.time_initialized + 900))
-			H.client.prefs.copy_to(H)
-			if (H.custom_body_size) //Do they have a custom size set?
-				H.resize(H.custom_body_size * 0.01)
-			H.real_name = H.client.prefs.real_name
-			H.mind.name = H.real_name //Makes sure to change their mind name to their real name.
-			SSquirks.AssignQuirks(H, H.client, TRUE, FALSE, H.job, FALSE)//This Assigns the selected character's quirks
-			H.dna.update_dna_identity() //This makes sure their DNA is updated.
-			var/obj/item/card/id/idCard = user.get_idcard() //Time to change their ID card as well if they have one.
-			if (idCard != null)
-				idCard.update_label(H.real_name, idCard.assignment)
-				idCard.registered_name = H.real_name
-			H.mirrorcanloadappearance = FALSE //Prevents them from using the mirror again.
-			SEND_SOUND(H, 'sound/magic/charge.ogg') //Fluff
-			to_chat(H, "<span class='boldannounce'>Your head aches for a second. You feel like this is how things should have been.</span>")
-			log_game("[key_name(user)] has loaded their default appearance for a ghost role.")
-			message_admins("[ADMIN_LOOKUPFLW(user)] has loaded their default appearance for a ghost role.")
-			return
-		else return
 
 /obj/structure/mirror/examine_status(mob/user)
 	if(broken)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -118,6 +118,7 @@
 			M.mind.assigned_role = assignedrole
 		special(M, name)
 		MM.name = M.real_name
+		M.checkloadappearance()
 	if(uses > 0)
 		uses--
 	if(!permanent && !uses)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -486,3 +486,31 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 
 /mob/proc/can_hear()
 	. = TRUE
+
+mob/proc/checkloadappearance()
+	var/mob/living/carbon/human/H = src
+	//This will be where the person gets to select their appearance instead of the random character
+	if (world.time <= (H.time_initialized + 900) && H.mirrorcanloadappearance == TRUE)
+		SEND_SOUND(H, 'sound/misc/server-ready.ogg')
+		to_chat(H, "<span class='boldannounce'>This ghost role allows you to select your loaded character's appearance. Make sure you have your ID in your ID slot, if you have one.</span>")
+		if(alert(H, "Would you like to load your currently loaded character's appearance?", "This can only be done up until 90s after you spawn.", "Yes", "No") == "Yes" && world.time <= (H.time_initialized + 900))
+			H.client.prefs.copy_to(H)
+			if (H.custom_body_size) //Do they have a custom size set?
+				H.resize(H.custom_body_size * 0.01)
+			H.real_name = H.client.prefs.real_name
+			H.mind.name = H.real_name //Makes sure to change their mind name to their real name.
+			SSquirks.AssignQuirks(H, H.client, TRUE, FALSE, H.job, FALSE)//This Assigns the selected character's quirks
+			H.dna.update_dna_identity() //This makes sure their DNA is updated.
+			var/obj/item/card/id/idCard = H.get_idcard() //Time to change their ID card as well if they have one.
+			if (idCard != null)
+				idCard.update_label(H.real_name, idCard.assignment)
+				idCard.registered_name = H.real_name
+			H.mirrorcanloadappearance = FALSE //Prevents them from using the mirror again.
+			SEND_SOUND(H, 'sound/magic/charge.ogg') //Fluff
+			to_chat(H, "<span class='boldannounce'>Your head aches for a second. You feel like this is how things should have been.</span>")
+			log_game("[key_name(H)] has loaded their default appearance for a ghost role.")
+			message_admins("[ADMIN_LOOKUPFLW(H)] has loaded their default appearance for a ghost role.")
+			return
+		else
+			to_chat(H, "<span class='boldannounce'>You either took too long or chose not to change. Alrighty. Remember, you have 90 seconds from spawn to get to a mirror and still do it if you wish.</span>")
+			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so that ghost roles or antag roles with the mirrorloadappearance flag set to true will receive a single prompt asking if they want to load their current loaded character's appearance.

## Why It's Good For The Game

why not

## Changelog
:cl:
add: better way to let ghosts/certain antags get their appearance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
