### PR TITLE
NarNar Shuttle Fix 2.0

### DIFF
--- a/_maps/shuttles/emergency_narnar.dmm
+++ b/_maps/shuttles/emergency_narnar.dmm
@@ -7,7 +7,8 @@
 /area/shuttle/escape)
 "c" = (
 /obj/structure/window/plastitanium,
-/turf/open/floor/plating,
+/obj/effect/forcefield/cult,
+/turf/open/floor/plasteel/cult,
 /area/shuttle/escape)
 "d" = (
 /obj/structure/table,
@@ -89,8 +90,11 @@
 /turf/open/floor/plasteel/cult,
 /area/shuttle/escape)
 "q" = (
+/obj/machinery/door/airlock/cult/unruned/glass/friendly{
+	req_access = null;
+	req_access_txt = "19"
+	},
 /obj/effect/decal/remains/human,
-/obj/machinery/door/airlock/cult/unruned/glass/friendly,
 /turf/open/floor/plasteel/cult,
 /area/shuttle/escape)
 "r" = (
@@ -126,7 +130,7 @@
 "x" = (
 /obj/machinery/door/airlock/cult/friendly,
 /obj/structure/fans/tiny,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/cult,
 /area/shuttle/escape)
 "y" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
@@ -163,7 +167,7 @@
 	name = "shuttle 667"
 	},
 /obj/structure/fans/tiny,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/cult,
 /area/shuttle/escape)
 "F" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
@@ -184,17 +188,18 @@
 /area/shuttle/escape)
 "I" = (
 /obj/effect/rune/narsie,
+/obj/item/candle/infinite,
 /obj/effect/fun_balloon/sentience/emergency_shuttle{
 	effect_range = 5;
 	group_name = "horrible monsters on Shuttle 667"
 	},
-/obj/item/toy/toy_dagger,
+/obj/item/melee/cultblade/dagger,
 /turf/open/floor/plasteel/cult,
 /area/shuttle/escape)
 "J" = (
 /obj/effect/forcefield/cult,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/cult,
 /area/shuttle/escape)
 "L" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -394,7 +399,7 @@ c
 f
 j
 j
-q
+b
 j
 r
 z
@@ -418,7 +423,7 @@ c
 e
 j
 j
-b
+q
 j
 j
 j


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the command access for the nar nar shuttle and also replaces some leftover plating with runes.

## Why It's Good For The Game

Fix shuttle gud

**Also please, please remember to possibly add this shuttle to the buyable list config file or remove it from unbuyables.**

## Changelog
:cl:
fix: Shuttle 667 Command Accesss
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
