### PR TITLE
Lightweight trait

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -121,6 +121,7 @@
 #define TRAIT_LAW_ENFORCEMENT_METABOLISM "law-enforcement-metabolism"
 #define	TRAIT_STRONG_GRABBER	"strong_grabber"
 #define	TRAIT_CALCIUM_HEALER	"calcium_healer"
+#define TRAIT_ALCOHOL_LIGHTWEIGHT	"alcohol_lightweight" //Skyrat port
 
  //non-mob traits
 #define TRAIT_PARALYSIS			"paralysis" //Used for limb-based paralysis, where replacing the limb will fix it

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -109,3 +109,13 @@
 	mob_trait = TRAIT_HEADPAT_SLUT
 	value = 0
 	medical_record_text = "Patient seems overly affectionate"
+
+//Skyrat port start
+/datum/quirk/alcohol_lightweight  
+	name = "Alcoholic Lightweight"
+	desc = "Alcohol really goes straight to your head, gotta be careful with what you drink."
+	value = 0
+	mob_trait = TRAIT_ALCOHOL_LIGHTWEIGHT
+	gain_text = "<span class='notice'>You feel woozy thinking of alcohol.</span>"
+	lose_text = "<span class='notice'>You regain your stomach for drinks.</span>"
+//Skyrat port stop

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -40,6 +40,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		var/booze_power = boozepwr
 		if(HAS_TRAIT(C, TRAIT_ALCOHOL_TOLERANCE)) //we're an accomplished drinker
 			booze_power *= 0.7
+		else if(HAS_TRAIT(C, TRAIT_ALCOHOL_LIGHTWEIGHT)) //Skyrat port
+			booze_power *= 2 //Skyrat port
 		C.drunkenness = max((C.drunkenness + (sqrt(volume) * booze_power * ALCOHOL_RATE)), 0) //Volume, power, and server alcohol rate effect how quickly one gets drunk
 		var/obj/item/organ/liver/L = C.getorganslot(ORGAN_SLOT_LIVER)
 		if (istype(L))


### PR DESCRIPTION
## About The Pull Request

A lightweight trait that was ported from skyrats, gives you twice the drunk power from drinks, watch what you down with each swig!

## Why It's Good For The Game

Adds a neutral trait for the purposes of roleplay, for those who can't quite hold their drink compared to the normal crowd or those with a tolerance!

## Changelog
:cl:
add: Added a new trait.
code: changed some files to add or apply the trait with.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
