### PR TITLE
Pink and Milk Seeds to Xenoarch

### DIFF
--- a/code/modules/hydroponics/grown/chili.dm
+++ b/code/modules/hydroponics/grown/chili.dm
@@ -15,7 +15,7 @@
 	icon_grow = "chili-grow" // Uses one growth icons set for all the subtypes
 	icon_dead = "chili-dead" // Same for the dead icon
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list(/obj/item/seeds/chili/ice, /obj/item/seeds/chili/ghost, /obj/item/seeds/chili/pink)
+	mutatelist = list(/obj/item/seeds/chili/ice, /obj/item/seeds/chili/ghost)
 	reagents_add = list("capsaicin" = 0.25, "vitamin" = 0.04, "nutriment" = 0.04)
 
 /obj/item/reagent_containers/food/snacks/grown/chili

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -112,7 +112,6 @@
 	icon_grow = "lime-grow"
 	icon_dead = "lime-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list(/obj/item/seeds/firelemon)
 	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.05)
 
 /obj/item/reagent_containers/food/snacks/grown/citrus/lemon

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -11,7 +11,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	icon_dead = "watermelon-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list(/obj/item/seeds/watermelon/holy, /obj/item/seeds/watermelon/milk)
+	mutatelist = list(/obj/item/seeds/watermelon/holy)
 	reagents_add = list("water" = 0.2, "vitamin" = 0.04, "nutriment" = 0.2)
 
 /obj/item/seeds/watermelon/suicide_act(mob/user)

--- a/code/modules/research/xenoarch/artifact.dm
+++ b/code/modules/research/xenoarch/artifact.dm
@@ -88,6 +88,7 @@
 								/obj/item/seeds/chili/pink,
 								/obj/item/seeds/cherry/bomb,
 								/obj/item/seeds/gatfruit,
+								/obj/item/seeds/kudzu,
 								/obj/item/seeds/random
 								))
 

--- a/code/modules/research/xenoarch/artifact.dm
+++ b/code/modules/research/xenoarch/artifact.dm
@@ -84,6 +84,8 @@
 								/obj/item/seeds/thaadra,
 								/obj/item/seeds/vale,
 								/obj/item/seeds/vaporsac,
+								/obj/item/seeds/watermelon/milk,
+								/obj/item/seeds/chili/pink,
 								/obj/item/seeds/random
 								))
 

--- a/code/modules/research/xenoarch/artifact.dm
+++ b/code/modules/research/xenoarch/artifact.dm
@@ -86,6 +86,8 @@
 								/obj/item/seeds/vaporsac,
 								/obj/item/seeds/watermelon/milk,
 								/obj/item/seeds/chili/pink,
+								/obj/item/seeds/cherry/bomb,
+								/obj/item/seeds/gatfruit,
 								/obj/item/seeds/random
 								))
 

--- a/code/modules/research/xenoarch/artifact.dm
+++ b/code/modules/research/xenoarch/artifact.dm
@@ -89,6 +89,7 @@
 								/obj/item/seeds/cherry/bomb,
 								/obj/item/seeds/gatfruit,
 								/obj/item/seeds/kudzu,
+								/obj/item/seeds/firelemon,
 								/obj/item/seeds/random
 								))
 


### PR DESCRIPTION
## About The Pull Request

This little change is simply removing Pink peppers and Milk Melons away from the unstable mutagen list and instead putting it on the xenoarch artifact being a possible item to discover, compared to drowning a watermelon or pepper in chemicals. Additional note: Added gatfruit, cherry bombs, and kudzu to the rotation to xenoarch seed fossils. Lastly did the same with combustible lemons.

## Why It's Good For The Game

In many cases for incubus draft or succubus milk, a lot of work is needed to either find it from maint through random chance in trash piles or random places, gain it from cargo through the means purchasing lewd crates after making the board broad for contraband, or even struggling to make it through the means of purity 1 through fermichem.

With botany having access to a simple and easy approach of mutating a plant for a random chance to gain these chemicals, it seems like the most effective and best way for a means of getting it for a short cut, making all the other options needless when one can mass produce it on a large scale.

This change making where the seeds can only be found through xenoarch makes it where some effort to be made from the science team, in which cases if they discover it, they can then provide it to botany to give it the best stats through their knowledge of increasing potency and yield of a plant with all their other plant DNA they gather, making it more focused on teamwork with other departments, like botany making growth serum for size chemicals.

In this case finding or gaining the seeds in the round would be more impact when found, making it a sudden bit of excitement compared to an easy guarantee of having it every round.

Additional note: With xenoarch's seed drop table not having much aside from special mutation toxins, this little bit for gatfruit, cherry bombs, kudzu and combustible has been added to give more variety into the table as of @Dahlular 's suggestion to add in more funny seeds to bring in interest to xenobotany.

## Changelog
:cl:
add: Added milk melons, pink peppers, and combustible lemons to xenoarch seed table.
del: Removed milk melons and pink peppers from the mutation list in botany. Along with Combustible lemons.
add: Additionally added gatfruit, cherry bombs, and kudzu to the xenoarch seed table.
/:cl:
