### PR TITLE
Digging Soil Patches returns construction amount

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -931,6 +931,8 @@
 	use_power = NO_POWER_USE
 	flags_1 = NODECONSTRUCT_1
 	unwrenchable = FALSE
+	var/buildstacktype = /obj/item/stack/sheet/mineral/sandstone
+	var/buildstackamount = 3
 
 /obj/machinery/hydroponics/soil/update_icon_hoses()
 	return // Has no hoses
@@ -941,6 +943,7 @@
 /obj/machinery/hydroponics/soil/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/shovel) && !istype(O, /obj/item/shovel/spade)) //Doesn't include spades because of uprooting plants
 		to_chat(user, "<span class='notice'>You clear up [src]!</span>")
+		new buildstacktype(loc,buildstackamount)
 		qdel(src)
 	else
 		return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Because resources shouldn't magically disappear.

## Why It's Good For The Game

This simply returns the construction value of soil patches (3 sandstone)

## Changelog
:cl:
tweak: digging soil now returns its sandstone value.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
