### PR TITLE
Round start Warden shotgun

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -30,7 +30,7 @@
 
 /obj/item/ammo_box/magazine/internal/shot/com/compact
 	name = "compact combat shotgun internal magazine"
-	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
+	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
 	max_ammo = 4
 
 /obj/item/ammo_box/magazine/internal/shot/dual

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -215,7 +215,7 @@
 	desc = "A modified version of the semi automatic combat shotgun with a collapsible stock. For close encounters."
 	icon_state = "cshotgunc"
 	item_state = "combatshotgun"
-	mag_type = /obj/item/ammo_box/magazine/internal/shot/com
+	mag_type = /obj/item/ammo_box/magazine/internal/shot/com/compact
 	w_class = WEIGHT_CLASS_NORMAL
 	var/stock = FALSE
 	recoil = 5


### PR DESCRIPTION
## About The Pull Request

"Due to unfortunate events with mishandling equipment in the security departments, we have exchanged the munition found in the compact shotgun in the warden's locker with rubber rounds due to a 'workplace hazard for the start of the station shift',"

## Why It's Good For The Game

This helps encourage security on round start of gaining an item to get the impression that non lethal should be approached with first and foremost unless said approach proves ineffective with detaining someone. This helps give a better impression for the atmosphere of the game and limiting the mistakes of wardens/security using the shotgun and thinking 'I thought it was loaded with rubber rounds', Like the riot shotguns found in armory. I can't tell you how many times I've seen how many warden shoot an intruder in armory until they go sideways and then some. Meaning if it is to be loaded with buckshots, the intent was intended to kill. 

## Changelog
:cl:
tweak: tweaked the wardens shotgun to be loaded with rubber shotgun rounds at the start of shift compared to having lethals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
