### PR TITLE
Cursed Blood Trait (fixed)

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -122,6 +122,7 @@
 #define	TRAIT_STRONG_GRABBER	"strong_grabber"
 #define	TRAIT_CALCIUM_HEALER	"calcium_healer"
 #define TRAIT_ALCOHOL_LIGHTWEIGHT	"alcohol_lightweight" //Skyrat port
+#define TRAIT_CURSED_BLOOD	"cursed_blood" //Yo dawg I heard you like bloodborne references so I put a
 
  //non-mob traits
 #define TRAIT_PARALYSIS			"paralysis" //Used for limb-based paralysis, where replacing the limb will fix it

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -119,3 +119,12 @@
 	gain_text = "<span class='notice'>You feel woozy thinking of alcohol.</span>"
 	lose_text = "<span class='notice'>You regain your stomach for drinks.</span>"
 //Skyrat port stop
+
+/datum/quirk/cursed_blood
+	name = "Cursed Blood"
+	desc = "Your lineage is cursed with the paleblood curse. Best to stay away from holy water... Hell water, on the other hand..."
+	value = 0
+	mob_trait = TRAIT_CURSED_BLOOD
+	gain_text = "<span class='notice'>A curse from a land where men return as beasts runs deep in your blood. Best to stay away from holy water... Hell water, on the other hand...</span>"
+	lose_text = "<span class='notice'>You feel the weight of the curse in your blood finally gone.</span>"
+	medical_record_text = "Patient from an unknown type of aversion to holy reagents. Keep them away from a chaplain."

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -144,6 +144,8 @@ Difficulty: Medium
 		wander = TRUE
 		transform_weapon()
 		INVOKE_ASYNC(src, .proc/quick_attack_loop)
+		if(HAS_TRAIT(target, TRAIT_CURSED_BLOOD))
+			say(pick("Hunter, you must accept your death, be freed from the night.","The night, and the dream, were long...","Beasts all over the shop... You'll be one of them, sooner or later...","The night blocks all sight..."))
 
 /mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/OpenFire()
 	Goto(target, move_to_delay, minimum_distance)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -248,6 +248,18 @@
 					"You can't save him. Nothing can save him now", "It seems that Nar'Sie will triumph after all")].</span>")
 				if("emote")
 					M.visible_message("<span class='warning'>[M] [pick("whimpers quietly", "shivers as though cold", "glances around in paranoia")].</span>")
+		else if(HAS_TRAIT(M, TRAIT_CURSED_BLOOD) && prob(12))
+			M.say(pick("Somebody help me...","Unshackle me please...","Anybody... I've had enough of this dream...","The night blocks all sight...","Oh, somebody, please..."), forced = "holy water")
+			if(prob(10))
+				M.visible_message("<span class='danger'>[M] starts having a seizure!</span>", "<span class='userdanger'>You have a seizure!</span>")
+				M.Unconscious(120)
+				to_chat(M, "<span class='cultlarge'>[pick("The moon is close. It will be a long hunt tonight.", "Ludwig, why have you forsaken me?", \
+				"The night is near its end...", "Fear the blood...")]</span>")
+				if(prob(25)) //Prob of a prob.. Shouldn't happen too often but hey, that's what you get.
+					M.IgniteMob()
+				else
+					M.adjustToxLoss(1, 0)
+					M.adjustFireLoss(1, 0)	
 	if(data >= 60)	// 30 units, 135 seconds
 		if(iscultist(M, FALSE, TRUE) || is_servant_of_ratvar(M, FALSE, TRUE))
 			if(iscultist(M))
@@ -304,20 +316,28 @@
 	holder.remove_reagent(id, 1)
 	return TRUE
 
-/datum/reagent/hellwater			//if someone has this in their system they've really pissed off an eldrich god
+/datum/reagent/hellwater			//if someone has this in their system they've really pissed off an eldritch god
 	name = "Hell Water"
 	id = "hell_water"
 	description = "YOUR FLESH! IT BURNS!"
 	taste_description = "burning"
 
 /datum/reagent/hellwater/on_mob_life(mob/living/carbon/M)
-	M.fire_stacks = min(5,M.fire_stacks + 3)
-	M.IgniteMob()			//Only problem with igniting people is currently the commonly availible fire suits make you immune to being on fire
-	M.adjustToxLoss(1, 0)
-	M.adjustFireLoss(1, 0)		//Hence the other damages... ain't I a bastard?
-	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5, 150)
-	holder.remove_reagent(id, 1)
-	pH = 0.1
+	if(HAS_TRAIT(M, TRAIT_CURSED_BLOOD))
+		M.adjustToxLoss(-0.75*REM, 0)
+		M.adjustOxyLoss(-0.75*REM, 0)
+		M.adjustBruteLoss(-0.75*REM, 0)
+		M.adjustFireLoss(-0.75*REM, 0)
+		M.ExtinguishMob()
+		holder.remove_reagent(id, 1)
+	else
+		M.fire_stacks = min(5,M.fire_stacks + 3)
+		M.IgniteMob()			//Only problem with igniting people is currently the commonly availible fire suits make you immune to being on fire
+		M.adjustToxLoss(1, 0)
+		M.adjustFireLoss(1, 0)		//Hence the other damages... ain't I a bastard?
+		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5, 150)
+		holder.remove_reagent(id, 1)
+		pH = 0.1
 
 /datum/reagent/fuel/holyoil		//Its oil
 	name = "Zelus Oil"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a neutral (0 point) trait that heals you when you use hellwater (which is an incredibly rare spawn) but gives you seizures, dizziness and stutters when someone tries to use holy water on you, as well as a chance to literally set you on fire and damage you.

Also, a certain miner might recognize this curse...

## Why It's Good For The Game

RP and variety.

## Changelog
:cl:
add: Cursed Blood trait
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
