### PR TITLE
Part 1 - Respawning every 30mins.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -61,6 +61,7 @@
 	var/datum/language_holder/language_holder
 	var/unconvertable = FALSE
 	var/late_joiner = FALSE
+	var/lastrespawn = 0
 
 	var/force_escaped = FALSE  // Set by Into The Sunset command of the shuttle manipulator
 

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -222,9 +222,9 @@
 	if(!..())
 		return
 	if(IsStun() || IsKnockdown())	//just while I finish up the new 'fun' suiciding verb. This is to prevent metagaming via suicide
-		to_chat(src, "You can't commit suicide while stunned! ((You can type Ghost instead however.))")
+		to_chat(src, "You can't commit suicide while stunned!")
 		return
 	if(restrained())
-		to_chat(src, "You can't commit suicide while restrained! ((You can type Ghost instead however.))")
+		to_chat(src, "You can't commit suicide while restrained!")
 		return
 	return TRUE

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -269,6 +269,7 @@ Works together with spawning an observer, noted above.
 			ghost.can_reenter_corpse = can_reenter_corpse
 			ghost.can_reenter_round = (can_reenter_corpse && !suiciding)
 			ghost.key = key
+			ghost.client.lastrespawn = world.time + 1800 SECONDS
 			return ghost
 
 /*
@@ -282,8 +283,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 // CITADEL EDIT
 	if(istype(loc, /obj/machinery/cryopod))
-		var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you won't be able to re-enter this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
+		var/response = alert(src, "Are you -sure- you want to ghost?\n(If you ghost now, you will have to wait 30 minutes before you are able to respawn!)","Are you sure you want to ghost?","Ghost","Stay in body")
 		if(response != "Ghost")//darn copypaste
+			client.lastrespawn = world.time + 1800 SECONDS //set respawn time
 			return
 		var/obj/machinery/cryopod/C = loc
 		C.despawn_occupant()
@@ -295,11 +297,16 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(stat == DEAD)
 		ghostize(1)
 	else
+		//Low RP, removing.
+		/*
 		var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you won't be able to re-enter this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
 		if(response != "Ghost")
 			return	//didn't want to ghost after-all
 		ghostize(0)						//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 		suicide_log(TRUE)
+		*/
+		to_chat(usr, "<span class='boldnotice'>You cannot ghost, if you wish to remove yourself from the round, please locate a cryogenic freezer.</span>")
+		message_admins("[usr] attempted to ghost.")
 
 /mob/camera/verb/ghost()
 	set category = "OOC"

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -84,6 +84,7 @@
 
 	if (client)
 		client.move_delay = initial(client.move_delay)
+		client.lastrespawn = world.time + 1800 SECONDS //on death, 30 min respawn time.
 
 	for(var/s in ownedSoullinks)
 		var/datum/soullink/S = s

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -423,9 +423,15 @@
 		to_chat(usr, "<span class='boldnotice'>You must be dead to use this!</span>")
 		return
 
+	if(usr.client.lastrespawn <= world.time)
+		usr.client.lastrespawn = world.time + 1800 SECONDS
+	else
+		to_chat(usr, "<span class='warning'>You must wait [DisplayTimeText(usr.client.lastrespawn - world.time)] before respawning!</span>")
+		return
+
 	log_game("[key_name(usr)] used abandon mob.")
 
-	to_chat(usr, "<span class='boldnotice'>Please roleplay correctly!</span>")
+	to_chat(usr, "<span class='boldnotice'>Please roleplay correctly, do not meta-game, and use information from a different character or characters, to influence your actions!</span>")
 
 	if(!client)
 		log_game("[key_name(usr)] AM failed due to disconnect.")
@@ -442,6 +448,7 @@
 		qdel(M)
 		return
 
+	message_admins("[client.ckey] respawned.")
 	M.key = key
 //	M.Login()	//wat
 	return
@@ -530,7 +537,7 @@
 
 /mob/proc/is_muzzled()
 	return 0
-	
+
 
 /mob/Stat()
 	..()

--- a/modular_citadel/code/modules/client/client_defines.dm
+++ b/modular_citadel/code/modules/client/client_defines.dm
@@ -1,2 +1,3 @@
 /client
 	var/cryo_warned = -3000//when was the last time we warned them about not cryoing without an ahelp, set to -5 minutes so that rounstart cryo still warns
+	var/lastrespawn = 0 //when the last time they respawned.


### PR DESCRIPTION
Allow people to use the verb: respawn

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

30mins after death, or ghost. there are currently no restrictions to it, meaning people can join as the same character, but this will be fixed later (part 2), at the moment, I think its okay to allow users to respawn. Part 2 will have the ability for admins to ban a user respawns. 

Will require a config change to allow respawns.

Also removes the ability for people to ghost, outside of a cryo freezer. 

## Why It's Good For The Game

Rounds are long, sometimes even spanning to 5 hours, this will allow people to join later in the round if they so wish. 