### PR TITLE
Part 2 - Respawning, Stops players respawning of the same character.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -61,7 +61,6 @@
 	var/datum/language_holder/language_holder
 	var/unconvertable = FALSE
 	var/late_joiner = FALSE
-	var/lastrespawn = 0
 
 	var/force_escaped = FALSE  // Set by Into The Sunset command of the shuttle manipulator
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -123,6 +123,10 @@
 			LateChoices()
 			return
 
+		if(client.prefs.real_name in client.pastcharacters) //if character has been spawned before
+			to_chat(usr, "<span class='notice'>You have played that character before this round, please select a new one!</span>")
+			return
+
 		if(SSticker.queued_players.len || (relevant_cap && living_player_count() >= relevant_cap && !(ckey(key) in GLOB.admin_datums)))
 			to_chat(usr, "<span class='danger'>[CONFIG_GET(string/hard_popcap_message)]</span>")
 
@@ -272,7 +276,7 @@
 		ready = PLAYER_NOT_READY
 		return FALSE
 
-	var/this_is_like_playing_right = alert(src,"Are you sure you wish to observe? You will not be able to play this round!","Player Setup","Yes","No")
+	var/this_is_like_playing_right = alert(src,"Are you sure you wish to observe?","Player Setup","Yes","No")
 
 	if(QDELETED(src) || !src.client || this_is_like_playing_right != "Yes")
 		ready = PLAYER_NOT_READY
@@ -284,6 +288,8 @@
 	spawning = TRUE
 
 	observer.started_as_observer = TRUE
+	src.client.respawn_observing = 1
+	src.client.lastrespawn = world.time + 1800 SECONDS //reset respawn.
 	close_spawn_windows()
 	var/obj/effect/landmark/observer_start/O = locate(/obj/effect/landmark/observer_start) in GLOB.landmarks_list
 	to_chat(src, "<span class='notice'>Now teleporting.</span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -423,15 +423,17 @@
 		to_chat(usr, "<span class='boldnotice'>You must be dead to use this!</span>")
 		return
 
-	if(usr.client.lastrespawn <= world.time)
-		usr.client.lastrespawn = world.time + 1800 SECONDS
-	else
+	if(usr.client.lastrespawn >= world.time)
 		to_chat(usr, "<span class='warning'>You must wait [DisplayTimeText(usr.client.lastrespawn - world.time)] before respawning!</span>")
 		return
 
-	log_game("[key_name(usr)] used abandon mob.")
+	//if they didnt join as a observer, add their name to the past character list so they cannot play them again.
 
-	to_chat(usr, "<span class='boldnotice'>Please roleplay correctly, do not meta-game, and use information from a different character or characters, to influence your actions!</span>")
+	if(!usr.client.respawn_observing)
+		var/responserespawn = alert(src,"If you respawn now, you cannot rejoin the game as your current character! Are you sure you want to respawn?","Warning","Yes","No")
+		if(responserespawn != "Yes")
+			return
+		usr.client.pastcharacters += usr.real_name
 
 	if(!client)
 		log_game("[key_name(usr)] AM failed due to disconnect.")
@@ -447,6 +449,10 @@
 		log_game("[key_name(usr)] AM failed due to disconnect.")
 		qdel(M)
 		return
+
+	to_chat(usr, "<span class='boldnotice'>Please roleplay correctly, do not meta-game, and use information from a different character or characters, to influence your actions!</span>")
+	usr.client.lastrespawn = world.time + 1800 SECONDS
+	usr.client.respawn_observing = 0
 
 	message_admins("[client.ckey] respawned.")
 	M.key = key

--- a/modular_citadel/code/modules/client/client_defines.dm
+++ b/modular_citadel/code/modules/client/client_defines.dm
@@ -1,3 +1,7 @@
 /client
 	var/cryo_warned = -3000//when was the last time we warned them about not cryoing without an ahelp, set to -5 minutes so that rounstart cryo still warns
+
+	//respawn
 	var/lastrespawn = 0 //when the last time they respawned.
+	var/list/pastcharacters = list() //to stop players spawning back in with the same character.
+	var/respawn_observing = 0


### PR DESCRIPTION
Fixes and now cannot respawn as the same character for roleplay reasons.

## Why It's Good For The Game
It's a bit weird having the same character show up, after getting killed via "fun". So now if people choose to respawn, they will need to pick a new character or at least one with a different name. 

If players observe, they can still join the game with that character's name. But still, have to wait for the 30min respawn cooldown.

## Changelog
Fixes to my shitty code from part 1
A Yes/No warning when attempting to respawn
some bug fixes, and warning text altered. 
When respawning, you can no longer rejoin the round as the character that you first joined with.
