### PR TITLE
Radiation Affects Mobs Again (And people)

### DIFF
--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -105,7 +105,6 @@
 		// modify the ignored_things list in __HELPERS/radiation.dm instead
 		var/static/list/blacklisted = typecacheof(list(
 			/turf,
-			/mob,
 			/obj/structure/cable,
 			/obj/machinery/atmospherics,
 			/obj/item/ammo_casing,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In my stupidity, when I was fixing the divide by zero in radiation_wave, I accidentally un-merged the correct blacklist for things that are affected by radiation, literally making everyone and every mob immune to radiation. My apologies, this should fix it.


## Why It's Good For The Game

Fix

## Changelog
:cl:
fix: Radiation affects mobs properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
