### PR TITLE
Beach Biodome + Operatives can now load character appearance

### DIFF
--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -22,21 +22,21 @@
 
 /datum/antagonist/nukeop/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current
+	M.mirrorcanloadappearance = TRUE //Also gives them the option to use a mirror to load their custom character. Good luck if they use a plasma.
 	update_synd_icons_added(M)
 
 /datum/antagonist/nukeop/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current
+	M.mirrorcanloadappearance = FALSE
 	update_synd_icons_removed(M)
 
 /datum/antagonist/nukeop/proc/equip_op()
 	if(!ishuman(owner.current))
 		return
 	var/mob/living/carbon/human/H = owner.current
-
 	H.set_species(/datum/species/human) //Plasamen burn up otherwise, and lizards are vulnerable to asimov AIs
-
 	H.equipOutfit(nukeop_outfit)
-	H.mirrorcanloadappearance = TRUE //Also gives them the option to use a mirror to load their custom character. Good luck if they use a plasma.
+	H.checkloadappearance()
 	return TRUE
 
 /datum/antagonist/nukeop/greet()

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -396,6 +396,7 @@
 	flavour_text = "<span class='big bold'>You are a space bartender!</span><b> Time to mix drinks and change lives. Smoking space drugs makes it easier to understand your patrons' odd dialect.</b>"
 	assignedrole = "Space Bartender"
 	id_job = "Bartender"
+	mirrorcanloadappearance = TRUE
 
 /datum/outfit/spacebartender
 	name = "Space Bartender"
@@ -408,6 +409,7 @@
 
 /obj/effect/mob_spawn/human/beach
 	outfit = /datum/outfit/beachbum
+	mirrorcanloadappearance = TRUE
 
 /obj/effect/mob_spawn/human/beach/alive
 	death = FALSE

--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -32,7 +32,6 @@
 	Mind.active = 1
 	Mind.transfer_to(operative)
 	Mind.add_antag_datum(/datum/antagonist/nukeop/lone)
-	operative.mirrorcanloadappearance = TRUE //If they can get to a mirror in time, good luck partner
 
 	message_admins("[ADMIN_LOOKUPFLW(operative)] has been made into lone operative by an event.")
 	log_game("[key_name(operative)] was spawned as a lone operative by an event.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is a fix. These roles should've had this enabled in the first place.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/53913550/94314876-ddfffc00-ff57-11ea-87b7-9777dc4f7c70.png)

## Changelog
:cl:
fix: Appearance load for operatives & beach biodome roles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
