### PR TITLE
Adjust Midround Antag chance

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -35,6 +35,8 @@
 #define ROLE_LAVALAND               "lavaland"
 #define ROLE_INTERNAL_AFFAIRS		"internal affairs agent"
 #define ROLE_GANG					"gangster"
+//Hyper
+#define ROLE_LEWD_TRAITOR			"lewd traitor"
 
 //Missing assignment means it's not a gamemode specific role, IT'S NOT A BUG OR ERROR.
 //The gamemode specific ones are just so the gamemodes can query whether a player is old enough

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -82,11 +82,11 @@ GLOBAL_VAR_INIT(dynamic_chaos_level, 1.5)
 	  * If it is seven the range is:
 	  * 0-6, 7-13, 14-20, 21-27, 28-34, 35-41, 42-48, 49-55, 56-62, 63+
 	  */
-	var/pop_per_requirement = 6
+	var/pop_per_requirement = 5
 	/// The requirement used for checking if a second rule should be selected.
-	var/list/second_rule_req = list(101, 101, 100, 90, 80, 70, 60, 50, 40, 30)
+	var/list/second_rule_req = list(101, 100, 80, 60, 50, 40, 30, 30, 30, 30)
 	/// The requirement used for checking if a third rule should be selected.
-	var/list/third_rule_req = list(101, 101, 101, 101, 100, 90, 80, 70, 60, 50)
+	var/list/third_rule_req = list(101, 101, 101, 90, 80, 70, 60, 50, 50, 50)
 	/// Threat requirement for a second ruleset when high pop override is in effect.
 	var/high_pop_second_rule_req = 40
 	/// Threat requirement for a third ruleset when high pop override is in effect.
@@ -330,7 +330,7 @@ GLOBAL_VAR_INIT(dynamic_chaos_level, 1.5)
 	var/midround_injection_cooldown_middle = 0.5*(GLOB.dynamic_midround_delay_max + GLOB.dynamic_midround_delay_min)
 	midround_injection_cooldown = round(CLAMP(EXP_DISTRIBUTION(midround_injection_cooldown_middle), GLOB.dynamic_midround_delay_min, GLOB.dynamic_midround_delay_max)) + world.time
 
-	event_injection_cooldown = (rand(GLOB.dynamic_event_delay_min, GLOB.dynamic_event_delay_max) + world.time + (10 MINUTES)) //Add a delay to the first event so people get settled in
+	event_injection_cooldown = (rand(GLOB.dynamic_event_delay_min, GLOB.dynamic_event_delay_max) + world.time + (3 MINUTES)) //Add a delay to the first event so people get settled in
 
 	threat_injection_cooldown = (GLOB.dynamic_threat_delay + world.time)
 
@@ -727,7 +727,7 @@ GLOBAL_VAR_INIT(dynamic_chaos_level, 1.5)
 			chance += 25-10*(max_pop_per_antag-current_pop_per_antag)
 	*/
 	//Hyper change - Base injection chance based on chaos. 
-	chance = (GLOB.dynamic_chaos_level * 7) //Base chance from 0 to 35
+	chance = (GLOB.dynamic_chaos_level * 10) //Base chance from 0 to 50
 	if (current_players[CURRENT_DEAD_PLAYERS].len > current_players[CURRENT_LIVING_PLAYERS].len)
 		chance -= 30 // More than half the crew died? ew, let's calm down on antags
 	if (threat > 70)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -179,7 +179,7 @@
 	required_candidates = 1
 	weight = 7
 	cost = 10
-	requirements = list(101,101,60,55,50,45,40,35,30,25)
+	requirements = list(101,101,40,30,30,30,25,20,20,15)
 	repeatable = TRUE
 	high_population_requirement = 10
 	flags = TRAITOR_RULESET
@@ -193,8 +193,8 @@
 	protected_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")
 	required_candidates = 1
 	weight = 7
-	cost = 10
-	requirements = list(50,45,40,35,30,25,20,15,10,5)
+	cost = 5
+	requirements = list(30,30,30,25,20,15,10,10,5,5)
 	repeatable = TRUE
 	high_population_requirement = 10
 	flags = TRAITOR_RULESET
@@ -252,7 +252,7 @@
 	required_candidates = 1
 	weight = 3
 	cost = 35
-	requirements = list(101,101,80,70,60,50,40,30,20,20)
+	requirements = list(101,101,60,55,50,45,40,35,25,20)
 	high_population_requirement = 35
 	required_type = /mob/living/silicon/ai
 	var/ion_announce = 33
@@ -304,7 +304,7 @@
 	required_candidates = 1
 	weight = 1
 	cost = 20
-	requirements = list(101,90,80,70,60,50,40,30,30,30)
+	requirements = list(101,101,80,70,60,50,40,30,30,30)
 	high_population_requirement = 50
 	repeatable = FALSE //WE DON'T NEED MORE THAN ONE WIZARD
 	chaos_min = 3.5
@@ -380,8 +380,8 @@
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
 	weight = 4
-	cost = 10
-	requirements = list(101,100,90,80,70,60,50,40,30,20)
+	cost = 20
+	requirements = list(101,101,70,60,60,60,50,40,30,20)
 	high_population_requirement = 50
 	repeatable = TRUE
 	chaos_min = 3.5
@@ -405,7 +405,7 @@
 	required_candidates = 1
 	weight = 3
 	cost = 10
-	requirements = list(101,101,100,80,70,70,60,50,40,30)
+	requirements = list(101,101,100,80,70,60,50,40,30,20)
 	high_population_requirement = 50
 	repeatable = TRUE
 	var/list/vents = list()
@@ -453,7 +453,7 @@
 	required_candidates = 1
 	weight = 3
 	cost = 10
-	requirements = list(100,90,80,70,50,40,30,20,15,10)
+	requirements = list(101,50,40,30,20,20,20,20,15,10)
 	high_population_requirement = 50
 	repeatable = TRUE
 	var/list/spawn_locs = list()
@@ -542,7 +542,7 @@
 	required_candidates = 1
 	weight = 4
 	cost = 15
-	requirements = list(101,101,101,90,80,70,60,50,40,30)
+	requirements = list(101,101,101,40,35,30,25,20,20,20)
 	high_population_requirement = 30
 	//property_weights = list("story_potential" = 1, "extended" = -2, "valid" = 2)
 	var/list/spawn_locs = list()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -32,7 +32,7 @@
 	//required_candidates = 1
 	//weight = 5
 	cost = 0
-	requirements = list(40,35,30,25,20,15,15,10,10,5)
+	requirements = list(40,30,30,25,20,15,15,10,10,5)
 	high_population_requirement = 10
 	//var/autotraitor_cooldown = 450 // 15 minutes (ticks once per 2 sec)
 	chaos_min = 2.0
@@ -58,6 +58,62 @@
 		message_admins("Checking if we can turn someone into a traitor.")
 		log_game("DYNAMIC: Checking if we can turn someone into a traitor.")
 		mode.picking_specific_rule(/datum/dynamic_ruleset/midround/autotraitor)
+*/
+
+/* //Not currently functional
+//////////////////////////////////////////
+//                                      //
+//                LEWD                  //
+//                                      //
+//////////////////////////////////////////
+
+/datum/dynamic_ruleset/roundstart/traitor/lewd
+	name = "Horny Traitor"
+	persistent = TRUE
+	antag_flag = ROLE_LEWD_TRAITOR
+	antag_datum = /datum/antagonist/traitor/lewd
+	minimum_required_age = 7
+	protected_roles = list("AI","Cyborg")
+	restricted_roles = list("Cyborg","AI")
+	required_candidates = 1
+	weight = 5
+	cost = 0
+	requirements = list(10,10,10,10,10,10,10,10,10,10)
+	high_population_requirement = 10
+	chaos_min = 0.1
+	chaos_max = 2.0
+	admin_required = TRUE
+	//vars for execution
+	var/list/mob/living/carbon/human/lewd_candidates = list()
+	var/numTraitors = 0
+
+
+/datum/dynamic_ruleset/roundstart/traitor/lewd/pre_execute()
+	var/list/mob/living/carbon/human/targets = list()
+
+	for(var/mob/living/carbon/human/target in GLOB.player_list)
+		if(target.client.prefs.noncon)
+			if(!(target.job in restricted_roles))
+				targets += target
+
+	if(candidates.len)
+		var/numTraitors = min(candidates.len, targets.len, 1) //This number affects the maximum number of traitors. We want 1 for right now.
+		if(numTraitors == 0)
+			to_chat(GLOB.admins, "No lewd traitors created. Are there any valid targets?")
+			return 0
+		return 1
+
+	return 0
+
+/datum/dynamic_ruleset/roundstart/traitor/lewd/execute()
+	var/mob/living/carbon/human/H = null
+	if(numTraitors)
+		for(var/i = 0, i<numTraitors, i++)
+			H = pick(candidates)
+			candidates.Remove(H)
+			H.mind.make_LewdTraitor()
+		return TRUE
+	return FALSE
 */
 
 //////////////////////////////////////////

--- a/hyperstation/code/gamemode/traitor_lewd.dm
+++ b/hyperstation/code/gamemode/traitor_lewd.dm
@@ -2,7 +2,7 @@
 /datum/game_mode
 	var/list/datum/mind/lewd = list()
 
-#define ROLE_LEWD_TRAITOR			"lewd traitor"
+
 
 /datum/mind/
 	var/sexed = FALSE //General flag for completion check
@@ -199,8 +199,6 @@ GLOBAL_LIST_INIT(hyper_special_roles, list(
 
 			owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/tatoralert.ogg', 100, FALSE, pressure_affected = FALSE)
 	greet()
-
-/datum/objective/noncon
 
 /datum/objective/noncon/New(var/datum/mind/_owner)
 	GLOB.objectives += src // CITADEL EDIT FOR CRYOPODS

--- a/hyperstation/code/gamemode/traitor_thief.dm
+++ b/hyperstation/code/gamemode/traitor_thief.dm
@@ -1,20 +1,6 @@
 //Jay Sparrow
 //A less murder traitor for low chaos dynamic rounds.
 
-///datum/game_mode
-//	var/list/datum/mind/traitor = list()
-
-
-
-///datum/mind/
-	//var/sexed = FALSE //General flag for completion check
-
-//TODO - Move this somewhere else
-//GLOBAL_LIST_INIT(hyper_special_roles, list(
-	//ROLE_LEWD_TRAITOR = /datum/game_mode/traitor/lewd
-//))
-
-
 /datum/game_mode/traitor/thief
 	name = "thief traitor"
 	config_tag = "thief traitor"
@@ -57,49 +43,6 @@
 	if(!(has_antag_datum(/datum/antagonist/traitor/thief)))
 		add_antag_datum(/datum/antagonist/traitor/thief)
 
-/*
-/datum/admins/proc/makeLewdtraitors()
-	to_chat(GLOB.admins, "makeLewd_traitors called")
-	var/datum/game_mode/traitor/lewd/temp = new
-
-	//if(CONFIG_GET(flag/protect_roles_from_antagonist))
-		//continue
-
-	//if(CONFIG_GET(flag/protect_assistant_from_antagonist))
-		//continue
-
-	var/list/mob/living/carbon/human/candidates = list()
-	var/mob/living/carbon/human/H = null
-	var/list/mob/living/carbon/human/targets = list()
-	//var/mob/living/carbon/human/T = null
-
-	for(var/mob/living/carbon/human/applicant in GLOB.player_list)
-		if(isReadytoRumble(applicant, ROLE_LEWD_TRAITOR))
-			if(temp.age_check(applicant.client))
-				if(!(applicant.job in temp.restricted_jobs))
-					candidates += applicant
-
-	for(var/mob/living/carbon/human/target in GLOB.player_list)
-		if(target.client.prefs.noncon)
-			if(!(target.job in temp.restricted_jobs))
-				targets += target
-
-	if(candidates.len)
-		var/numTraitors = min(candidates.len, targets.len, 1) //This number affects the maximum number of traitors. We want 1 for right now.
-		if(numTraitors == 0)
-			to_chat(GLOB.admins, "No lewd traitors created. Are there any valid targets?")
-			return 0
-		for(var/i = 0, i<numTraitors, i++)
-			H = pick(candidates)
-			H.mind.make_LewdTraitor()
-			candidates.Remove(H)
-
-
-		return 1
-
-
-	return 0
-*/
 
 /datum/antagonist/traitor/thief/proc/forge_objectives()
 	forge_single_objective()


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adjusts costs and weights for several events for Dynamic mode. 
Adjusts costs for a number of midround antags.
Adjusts injection chance for midround antags.
Adjusts population scaling. 

Overall, midrounds should have a higher chance of showing up. Keep in mind, threat cost scales with population, so midrounds are still going to be very unlikely at anything below 15 pop.

Makes a few other adjustments, cleans up some code. Adds some variables and a proc to the event handler for future use.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Midrounds haven't dropped yet. They might be a litttttle more restricted than I thought.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Midround chance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
