### PR TITLE
Properly Airtight Lavaland Hermit + low cost

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -1,5 +1,5 @@
 "a" = (/turf/closed/mineral/volcanic/lava_land_surface,/area/lavaland/surface/outdoors)
-"b" = (/turf/closed/mineral/volcanic/lava_land_surface,/area/ruin/powered)
+"b" = (/obj/effect/decal/cleanable/blood/drip,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
 "c" = (/turf/closed/wall/mineral/iron,/area/ruin/powered)
 "d" = (/obj/item/clothing/head/helmet/space/orange,/obj/item/clothing/mask/breath,/turf/open/floor/plating/asteroid{name = "dirt"},/area/ruin/powered)
 "e" = (/obj/item/clothing/suit/space/orange,/turf/open/floor/plating/asteroid{name = "dirt"},/area/ruin/powered)
@@ -37,20 +37,20 @@
 "K" = (/obj/structure/mirror{pixel_x = 28},/turf/open/floor/plating,/area/ruin/powered)
 
 (1,1,1) = {"
-aaaaaaaabbcbaaaa
-aaaaaaabcdebbaaa
-aaaaaaabgghgbaaa
-aaaaaabbijgkcaaa
-aaaaabccgglgbaaa
-aaaabcmffgcbbaaa
+aaaaaaaaaccaaaaa
+aaaaaaaacdecaaaa
+aaaaaaacgghgcaaa
+aaaaaaacijgkcaaa
+aaaaaacfgglgcaaa
+aaaaacmffgfcaaaa
 aaaacnooffpcaaaa
 aaaacnoqofrcaaaa
-saaatttooucbaaaa
+saaatttooucaaaaa
 saaatvwooKcaaaaa
 sssatxyztAcaaaaa
-sssstByCtcbaaaaa
+sssstByCtcaaaaaa
 ssssttDttaaaaaaa
 ssssssssssaEFFGa
-sssssssssssHIIJa
-sssssssssssEFFGa
+ssssssbssssHIIJa
+sssssssssbsEFFGa
 "}

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -199,7 +199,7 @@
 	description = "A place of shelter for a lone hermit, scraping by to live another day."
 	suffix = "lavaland_surface_hermit.dmm"
 	allow_duplicates = FALSE
-	cost = 10
+	cost = 5
 
 /datum/map_template/ruin/lavaland/swarmer_boss
 	name = "Crashed Shuttle"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lowers the cost of spawning lavaland hermit from 10 to 5 and also makes the entire structure airtight. I still couldn't find out what was causing it to not be airtight during round spawn, so I just made the walls rough walls.

## Why It's Good For The Game

Fixes are nice.

## Changelog
:cl:
fix: Lavaland hermit airtight.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
