### PR TITLE
Size up and down with a chemical and items.

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -724,6 +724,7 @@ datum/status_effect/stabilized/blue/on_remove()
 		C.real_name = O.real_name
 		O.dna.transfer_identity(C)
 		C.updateappearance(mutcolor_update=1)
+		C.size_multiplier = O.size_multiplier
 	return ..()
 
 /datum/status_effect/stabilized/cerulean/tick()

--- a/code/modules/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/ruins/objects_and_mobs/sin_ruins.dm
@@ -141,5 +141,6 @@
 			H.dna.transfer_identity(user, transfer_SE=1)
 			user.updateappearance(mutcolor_update=1)
 			user.domutcheck()
+			user.size_multiplier = H.size_multiplier
 			user.visible_message("<span class='warning'>[user]'s appearance shifts into [H]'s!</span>", \
 			"<span class='boldannounce'>[H.p_they(TRUE)] think[H.p_s()] [H.p_theyre()] <i>sooo</i> much better than you. Not anymore, [H.p_they()] won't.</span>")

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
@@ -81,6 +81,7 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 					SM.real_name = M.real_name
 					M.dna.transfer_identity(SM)
 					SM.updateappearance(mutcolor_update=1)
+					SM.size_multiplier = M.size_multiplier
 				var/mob/dead/observer/C = pick(candies)
 				message_admins("Ghost candidate found! [C] key [C.key] is becoming a clone of [M] key: [M.key] (They agreed to respect the character they're becoming, and agreed to not ERP without express permission from the original.)")
 				SM.key = C.key
@@ -171,6 +172,7 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 								C.real_name = M.real_name
 								M.dna.transfer_identity(C, transfer_SE=1)
 								C.updateappearance(mutcolor_update=1)
+								C.size_multiplier = M.size_multiplier
 							C.apply_status_effect(/datum/status_effect/chem/SGDF)
 							var/datum/status_effect/chem/SGDF/S = C.has_status_effect(/datum/status_effect/chem/SGDF)
 							S.original = M
@@ -231,6 +233,7 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 			SM.real_name = M.real_name
 			M.dna.transfer_identity(SM)
 			SM.updateappearance(mutcolor_update=1)
+			SM.size_multiplier = M.size_multiplier
 		M.mind.transfer_to(SM)
 		M.visible_message("<span class='warning'>[M]'s body shudders, the growth factor rapidly splitting into a new clone of [M].</span>")
 


### PR DESCRIPTION
## About The Pull Request

Added a variable that copies with size of the person you strike the envy knife with, along with having S.D.G.F. and stabilized cerulean extracts make a clone that copies the holders size.

https://i.gyazo.com/425281bdf8e7a99f9f344863c8263509.mp4

## Why It's Good For The Game

This gives more of a sense of realism when you take someone's appearance with an envy knife. or when a clone of you is made outside of a cloning pod such as SDGF for both empty clone and player controlled, and stabilized cerulean.

## Changelog
:cl:
add: Added size code into a chemical and items.
code: changed some code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
