### PR TITLE
Lets slime damage structures

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -1,4 +1,3 @@
-
 //the essential proc to call when an obj must receive damage of any kind.
 /obj/proc/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0)
 	if(QDELETED(src))
@@ -126,10 +125,19 @@
 		if(. && !play_soundeffect)
 			playsound(src, 'sound/effects/meteorimpact.ogg', 100, 1)
 
+#define BLACKLISTED_OBJECTS list(/obj/machinery/power/apc, /obj/machinery/airalarm, /obj/machinery/power/smes, /obj/structure/cable)
+
 /obj/attack_slime(mob/living/simple_animal/slime/user)
 	if(!user.is_adult)
 		return
 	attack_generic(user, rand(10, 15), "melee", 1)
+	if(src.type in BLACKLISTED_OBJECTS)
+		return
+	if(istype(src, /obj/machinery/atmospherics))
+		return
+	attack_generic(user, rand(10, 15), BRUTE, "melee", 1)
+
+#undef BLACKLISTED_OBJECTS
 
 /obj/mech_melee_attack(obj/mecha/M)
 	M.do_attack_animation(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports https://github.com/Citadel-Station-13/Citadel-Station-13/pull/13267

## Why It's Good For The Game

Seems like a good choice. Xenobios should feed their slimes and people should really, really take those pyroclastics. This is up to debate, however.

## Changelog
:cl:
tweak: Slimes can now damage structures, don't leave them unfed!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
