### PR TITLE
Floor Cluwne Forced Targeting / Cluwne Smite

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -68,6 +68,7 @@
 #define ADMIN_PUNISHMENT_GIB "Gib"
 #define ADMIN_PUNISHMENT_BSA "Bluespace Artillery Device"
 #define ADMIN_PUNISHMENT_FIREBALL "Fireball"
+#define ADMIN_PUNISHMENT_CLUWNE "Floor Cluwne"
 #define ADMIN_PUNISHMENT_ROD "Immovable Rod"
 #define ADMIN_PUNISHMENT_SUPPLYPOD "Supply Pod"
 #define ADMIN_PUNISHMENT_MAZING "Puzzle"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1249,7 +1249,7 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 	if(!check_rights(R_ADMIN) || !check_rights(R_FUN))
 		return
 
-	var/list/punishment_list = list(ADMIN_PUNISHMENT_PIE, ADMIN_PUNISHMENT_FIREBALL, ADMIN_PUNISHMENT_LIGHTNING, ADMIN_PUNISHMENT_BRAINDAMAGE, ADMIN_PUNISHMENT_BSA, ADMIN_PUNISHMENT_GIB, ADMIN_PUNISHMENT_SUPPLYPOD, ADMIN_PUNISHMENT_MAZING, ADMIN_PUNISHMENT_ROD)
+	var/list/punishment_list = list(ADMIN_PUNISHMENT_PIE, ADMIN_PUNISHMENT_FIREBALL, ADMIN_PUNISHMENT_CLUWNE, ADMIN_PUNISHMENT_LIGHTNING, ADMIN_PUNISHMENT_BRAINDAMAGE, ADMIN_PUNISHMENT_BSA, ADMIN_PUNISHMENT_GIB, ADMIN_PUNISHMENT_SUPPLYPOD, ADMIN_PUNISHMENT_MAZING, ADMIN_PUNISHMENT_ROD)
 
 	var/punishment = input("Choose a punishment", "DIVINE SMITING") as null|anything in punishment_list
 
@@ -1271,6 +1271,13 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 			bluespace_artillery(target)
 		if(ADMIN_PUNISHMENT_FIREBALL)
 			new /obj/effect/temp_visual/target(get_turf(target))
+		if(ADMIN_PUNISHMENT_CLUWNE)
+			var/mob/living/simple_animal/hostile/floor_cluwne/FC = new /mob/living/simple_animal/hostile/floor_cluwne(get_turf(target))
+			FC.Acquire_Victim(target)
+			FC.current_victim = target
+			FC.interest = 5000;
+			FC.maxHealth = 5000
+			FC.health = 5000
 		if(ADMIN_PUNISHMENT_ROD)
 			var/turf/T = get_turf(target)
 			var/startside = pick(GLOB.cardinals)

--- a/code/modules/admin/verbs/spawnfloorcluwne.dm
+++ b/code/modules/admin/verbs/spawnfloorcluwne.dm
@@ -7,12 +7,13 @@
 	if(!check_rights(R_FUN))
 		return
 
-	var/turf/T = get_turf(usr)
 	target = input("Any specific target in mind? Please note only live, non cluwned, human targets are valid.", "Target", target) as null|anything in GLOB.player_list
 	if(target && ishuman(target))
+		var/turf/T = get_turf(target)
 		var/mob/living/carbon/human/H = target
 		var/mob/living/simple_animal/hostile/floor_cluwne/FC = new /mob/living/simple_animal/hostile/floor_cluwne(T)
 		FC.Acquire_Victim(H)
+		FC.current_victim = H
 		log_admin("[key_name(usr)] spawned floor cluwne.")
 		message_admins("[key_name(usr)] spawned floor cluwne.")
 		deadchat_broadcast("<span class='deadsay'><b>Floor Cluwne</b> has just been spawned!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/floor_cluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/floor_cluwne.dm
@@ -19,9 +19,9 @@ GLOBAL_VAR_INIT(floor_cluwnes, 0)
 	attacktext = "attacks"
 	attack_sound = 'sound/items/bikehorn.ogg'
 	del_on_death = TRUE
-	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB | LETPASSTHROW | PASSGLASS | PASSBLOB | PASSMACHINES //it's practically a ghost when unmanifested (under the floor)
+	pass_flags = PASSDOOR | PASSTABLE | PASSGRILLE | PASSMOB | LETPASSTHROW | PASSGLASS | PASSBLOB | PASSMACHINES //it's practically a ghost when unmanifested (under the floor)
 	wander = FALSE
-	minimum_distance = 2
+	minimum_distance = 1
 	move_to_delay = 1
 	environment_smash = FALSE
 	lose_patience_timeout = FALSE
@@ -109,7 +109,7 @@ GLOBAL_VAR_INIT(floor_cluwnes, 0)
 		do_teleport(src, T)
 
 	interest++
-	if(interest >= switch_stage * 4)
+	if(interest >= switch_stage * 3)
 		stage = STAGE_ATTACK
 
 	else if(interest >= switch_stage * 2)
@@ -380,7 +380,10 @@ GLOBAL_VAR_INIT(floor_cluwnes, 0)
 
 /mob/living/simple_animal/hostile/floor_cluwne/proc/Kill(mob/living/carbon/human/H)
 	if(!istype(H) || !H.client)
-		Acquire_Victim()
+		//Acquire_Victim()
+		message_admins("Target is either not human and/or not a client. Deleting floor cluwne.")
+		H.invisibility = 0
+		Destroy()
 		return
 	playsound(H, 'yogstation/sound/effects/cluwne_feast.ogg', 100, 0, -4)
 	var/red_splash = list(1,0,0,0.8,0.2,0, 0.8,0,0.2,0.1,0,0)
@@ -400,6 +403,7 @@ GLOBAL_VAR_INIT(floor_cluwnes, 0)
 
 	interest = 0
 	stage = STAGE_HAUNT
+	message_admins("Target killed. Deleting floor cluwne.")
 	Destroy()
 
 //manifestation animation


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tries to stop the cluwne targeting system from losing interest in the current target, adds an admin cluwne smite.

## Why It's Good For The Game

Current unleash floor cluwne targeting was seemingly broken, this aims to fix it. Hopefully... Hopefully.

## Changelog
:cl:
tweak: Floor Cluwne. But we don't talk about it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
