### PR TITLE
Space Carp Updates

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -17,10 +17,9 @@
 	emote_taunt = list("gnashes")
 	taunt_chance = 30
 	speed = 0
-	maxHealth = 25
-	health = 25
+	maxHealth = 35
+	health = 35
 	spacewalk = TRUE
-
 	harm_intent_damage = 8
 	obj_damage = 50
 	melee_damage_lower = 15
@@ -28,7 +27,6 @@
 	attacktext = "bites"
 	attack_sound = 'sound/weapons/bite.ogg'
 	speak_emote = list("gnashes")
-
 	//Space carp aren't affected by cold.
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
@@ -37,6 +35,19 @@
 	movement_type = FLYING
 	pressure_resistance = 200
 	gold_core_spawnable = HOSTILE_SPAWN
+	//some carps heal over time
+	var/regen_cooldown = 0 //Used for how long it takes before a healing will take place default in 60 seconds
+	var/regen_amount = 0 //How much is healed pre regen cooldown
+
+/mob/living/simple_animal/hostile/carp/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
+	. = ..()
+	if(regen_amount)
+		regen_cooldown = world.time + REGENERATION_DELAY
+
+/mob/living/simple_animal/hostile/carp/Life()
+	. = ..()
+	if(regen_amount && regen_cooldown < world.time)
+		heal_overall_damage(regen_amount)
 
 /mob/living/simple_animal/hostile/carp/AttackingTarget()
 	. = ..()
@@ -59,8 +70,10 @@
 	icon_living = "megacarp"
 	icon_dead = "megacarp_dead"
 	icon_gib = "megacarp_gib"
-	maxHealth = 20
-	health = 20
+	regen_amount = 6
+
+	maxHealth = 30
+	health = 30
 	pixel_x = -16
 	mob_size = MOB_SIZE_LARGE
 
@@ -68,35 +81,25 @@
 	melee_damage_lower = 20
 	melee_damage_upper = 20
 
-	var/regen_cooldown = 0
-
 /mob/living/simple_animal/hostile/carp/megacarp/Initialize()
 	. = ..()
 	name = "[pick(GLOB.megacarp_first_names)] [pick(GLOB.megacarp_last_names)]"
-	melee_damage_lower += rand(2, 10)
+	melee_damage_lower += rand(4, 10)
 	melee_damage_upper += rand(10,20)
-	maxHealth += rand(30,60)
+	maxHealth += rand(40,60)
 	move_to_delay = rand(3,7)
-
-/mob/living/simple_animal/hostile/carp/megacarp/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
-	. = ..()
-	if(.)
-		regen_cooldown = world.time + REGENERATION_DELAY
-
-/mob/living/simple_animal/hostile/carp/megacarp/Life()
-	. = ..()
-	if(regen_cooldown < world.time)
-		heal_overall_damage(4)
 
 /mob/living/simple_animal/hostile/carp/cayenne
 	name = "Cayenne"
 	desc = "A failed Syndicate experiment in weaponized space carp technology, it now serves as a lovable mascot."
 	gender = FEMALE
+	regen_amount = 8
+
 	speak_emote = list("squeaks")
 	maxHealth = 90
 	health = 90
 	gold_core_spawnable = NO_SPAWN
-	faction = list(ROLE_SYNDICATE)
+	faction = list(ROLE_SYNDICATE, "carp") //They are still a carp
 	AIStatus = AI_OFF
 
 	harm_intent_damage = 12

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -17,8 +17,8 @@
 	emote_taunt = list("gnashes")
 	taunt_chance = 30
 	speed = 0
-	maxHealth = 35
-	health = 35
+	maxHealth = 25
+	health = 25
 	spacewalk = TRUE
 	harm_intent_damage = 8
 	obj_damage = 50
@@ -37,7 +37,7 @@
 	gold_core_spawnable = HOSTILE_SPAWN
 	//some carps heal over time
 	var/regen_cooldown = 0 //Used for how long it takes before a healing will take place default in 60 seconds
-	var/regen_amount = 0 //How much is healed pre regen cooldown
+	var/regen_amount = 1 //How much is healed pre regen cooldown
 
 /mob/living/simple_animal/hostile/carp/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so shark carps aren't that shitty by porting updates directly from citadel. Also slightly buffs regular carp HP.

## Why It's Good For The Game

Balance, updates. Regular carps are still not allowed to regen, if that's the question. Only mega. Cayenne also gets a fix which tags it as a carp, so that other carps won't attack it.

## Changelog
:cl:
tweak: carpy bois
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
