### PR TITLE
Listening Post Mini-Overhal

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -421,6 +421,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock{
+	dir = 4;
 	name = "Food Court"
 	},
 /turf/open/floor/plasteel/dark,
@@ -564,6 +565,7 @@
 	pixel_y = 5
 	},
 /obj/machinery/door/airlock{
+	dir = 4;
 	name = "Personal Quarters"
 	},
 /turf/open/floor/plasteel,

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -236,6 +236,10 @@
 /obj/item/paper_bin,
 /obj/item/paper/fluff/ruins/listeningstation/reports/november,
 /obj/item/pen,
+/obj/item/stock_parts/cell/high/plus{
+	pixel_x = -8;
+	pixel_y = -3
+	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "aw" = (
@@ -294,17 +298,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/ruin/space/has_grav/listeningstation)
 "az" = (
-/obj/structure/filingcabinet,
-/obj/item/paper/fluff/ruins/listeningstation/reports/april,
-/obj/item/paper/fluff/ruins/listeningstation/reports/may,
-/obj/item/paper/fluff/ruins/listeningstation/reports/june,
-/obj/item/paper/fluff/ruins/listeningstation/reports/july,
-/obj/item/paper/fluff/ruins/listeningstation/reports/august,
-/obj/item/paper/fluff/ruins/listeningstation/reports/september,
-/obj/item/paper/fluff/ruins/listeningstation/reports/october,
-/obj/item/paper/fluff/ruins/listeningstation/receipt,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/paper/fluff/ruins/listeningstation/odd_report,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "aA" = (
@@ -330,8 +324,14 @@
 /obj/structure/rack{
 	dir = 8
 	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/integrated_circuit_printer/upgraded,
 /obj/item/multitool,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stock_parts/cell/high/plus{
+	pixel_x = 9;
+	pixel_y = -3
+	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "aC" = (
@@ -339,44 +339,19 @@
 	dir = 8;
 	layer = 2.9
 	},
+/obj/item/storage/bag/ore,
 /obj/item/mining_scanner,
 /obj/item/pickaxe,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/shovel,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "aD" = (
-/obj/structure/table,
 /obj/machinery/light/small{
 	brightness = 3;
 	dir = 8
 	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/food/snacks/chocolatebar,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall,
 /area/ruin/space/has_grav/listeningstation)
 "aE" = (
 /obj/effect/turf_decal/stripes/line{
@@ -414,12 +389,6 @@
 /area/ruin/space/has_grav/listeningstation)
 "aH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -430,10 +399,14 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/door/airlock{
+	name = "Food Court"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "aI" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "aJ" = (
@@ -514,23 +487,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "aN" = (
-/obj/structure/table,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/obj/machinery/microwave,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall,
 /area/ruin/space/has_grav/listeningstation)
 "aO" = (
 /obj/machinery/light/small{
@@ -556,9 +516,11 @@
 /area/ruin/space/has_grav/listeningstation)
 "aP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "aQ" = (
@@ -721,46 +683,30 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "aZ" = (
-/obj/structure/table,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -30
-	},
-/obj/item/reagent_containers/food/drinks/beer{
-	pixel_x = -4;
-	pixel_y = 14
-	},
-/obj/item/reagent_containers/food/drinks/beer{
-	pixel_x = 3;
-	pixel_y = 11
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
-	pixel_x = -3
-	},
-/obj/item/lighter{
-	pixel_x = 7;
-	pixel_y = -3
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
-"ba" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4;
 	piping_layer = 3;
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/turf/closed/wall,
+/area/ruin/space/has_grav/listeningstation)
+"ba" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "bb" = (
@@ -845,7 +791,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/listeningstation)
 "bj" = (
-/obj/machinery/computer/arcade/orion_trail,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -856,6 +801,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "bk" = (
@@ -1102,6 +1054,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/wrench,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
 "bD" = (
@@ -1165,6 +1120,241 @@
 	},
 /turf/template_noop,
 /area/template_noop)
+"cE" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/rtg/advanced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"eA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall,
+/area/ruin/space/has_grav/listeningstation)
+"fs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
+"fJ" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
+"gz" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
+"hJ" = (
+/obj/structure/closet/secure_closet/hydroponics{
+	req_access = null
+	},
+/obj/item/cultivator,
+/obj/item/plant_analyzer,
+/obj/item/reagent_containers/spray/pestspray{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/shovel/spade,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
+"lZ" = (
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/sign/warning/radiation{
+	pixel_y = -31
+	},
+/obj/machinery/power/rtg/advanced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"tU" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
+"uB" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"xe" = (
+/obj/structure/filingcabinet,
+/obj/item/paper/fluff/ruins/listeningstation/reports/april,
+/obj/item/paper/fluff/ruins/listeningstation/reports/may,
+/obj/item/paper/fluff/ruins/listeningstation/reports/june,
+/obj/item/paper/fluff/ruins/listeningstation/reports/july,
+/obj/item/paper/fluff/ruins/listeningstation/reports/august,
+/obj/item/paper/fluff/ruins/listeningstation/reports/september,
+/obj/item/paper/fluff/ruins/listeningstation/reports/october,
+/obj/item/paper/fluff/ruins/listeningstation/receipt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper/fluff/ruins/listeningstation/odd_report,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/listeningstation)
+"za" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
+"zq" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
+"zD" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
+"Bd" = (
+/obj/item/seeds/apple,
+/obj/item/seeds/banana,
+/obj/item/seeds/cocoapod,
+/obj/item/seeds/grape,
+/obj/item/seeds/orange,
+/obj/item/seeds/sugarcane,
+/obj/item/seeds/wheat,
+/obj/item/seeds/watermelon,
+/obj/structure/table/glass,
+/obj/item/seeds/tower,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/item/storage/bag/plants/portaseeder,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
+"Bs" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
+"DC" = (
+/obj/machinery/airalarm/syndicate{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/structure/table,
+/obj/item/kitchen/rollingpin{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/machinery/reagentgrinder/constructed,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
+"DL" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = -4;
+	pixel_y = 14
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = 3;
+	pixel_y = 11
+	},
+/obj/item/lighter/slime{
+	pixel_x = 6
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
+"Et" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/kitchen/knife/combat/survival,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"Gb" = (
+/obj/item/reagent_containers/glass/bottle/nutrient/rh{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
+"IH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
+"Lx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"Mh" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/food/snacks/chocolatebar,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
+"Ns" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
+"NQ" = (
+/obj/item/mop/advanced{
+	pixel_x = -11
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"QM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
+"TK" = (
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
+"XM" = (
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
 
 (1,1,1) = {"
 aa
@@ -1697,12 +1887,12 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
+ac
+ac
+ac
+ac
+ac
+ac
 ab
 ab
 ab
@@ -1736,14 +1926,14 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+ac
+hJ
+zD
+Bd
+Ns
+fJ
+DC
+ac
 ab
 ab
 ab
@@ -1776,14 +1966,14 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+ac
+zq
+Gb
+XM
+Bs
+Bs
+Mh
+ac
 ab
 ab
 ab
@@ -1816,14 +2006,14 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+ac
+zq
+gz
+Bs
+fs
+za
+tU
+ac
 ab
 ab
 ab
@@ -1858,11 +2048,11 @@ ab
 ab
 ac
 ac
-ac
-ac
-ac
-ac
-ac
+TK
+Bs
+IH
+QM
+DL
 ac
 ab
 ab
@@ -1943,7 +2133,7 @@ aI
 aP
 ba
 bj
-ac
+eA
 bv
 ac
 ac
@@ -2018,7 +2208,7 @@ ac
 ac
 ah
 as
-ac
+xe
 ac
 aR
 ac
@@ -2026,8 +2216,8 @@ bl
 ac
 bx
 bD
-ac
-ab
+ag
+ag
 ab
 ab
 ab
@@ -2062,13 +2252,13 @@ az
 ac
 aS
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ab
+ag
+ag
+ag
+ag
+ag
+cE
+ag
 ab
 ab
 ab
@@ -2102,13 +2292,13 @@ aA
 aK
 aT
 bc
-ac
+ag
 bq
 by
 aO
 bC
-ac
-ab
+lZ
+ag
 ab
 ab
 ab
@@ -2147,8 +2337,8 @@ br
 bz
 bF
 bH
-ac
-ab
+Lx
+ag
 ab
 ab
 ab
@@ -2182,13 +2372,13 @@ ac
 aL
 aV
 be
-ac
-ac
-ac
-ac
-ac
-ac
-ab
+ag
+ag
+ag
+uB
+Et
+NQ
+ag
 ab
 ab
 ab
@@ -2214,8 +2404,8 @@ ab
 ab
 ab
 ab
-ac
-ac
+ag
+ag
 al
 aw
 aC
@@ -2225,9 +2415,9 @@ bf
 bn
 bs
 bA
-ac
-ab
-ab
+ag
+ag
+ag
 ab
 ab
 ab
@@ -2254,7 +2444,7 @@ aa
 ab
 ab
 ab
-ac
+ag
 af
 am
 ax
@@ -2265,7 +2455,7 @@ bg
 bo
 bt
 bB
-ac
+ag
 ab
 ab
 ab
@@ -2294,18 +2484,18 @@ aa
 aa
 ab
 ab
-ac
-ac
+ag
+ag
 an
 ac
 aE
 ac
 aY
 bh
-ac
+ag
 bu
-ac
-ac
+ag
+ag
 ab
 ab
 ab
@@ -2341,10 +2531,10 @@ ag
 aF
 ag
 ac
-ac
-ac
-ac
-ac
+ag
+ag
+ag
+ag
 ab
 ab
 ab

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -34,12 +34,13 @@
 /obj/structure/rack{
 	dir = 8
 	},
+/obj/item/clothing/suit/space/syndicate,
+/obj/item/clothing/head/helmet/space/syndicate,
 /obj/item/clothing/mask/gas{
 	pixel_x = -3;
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/item/clothing/mask/gas,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/listeningstation)
 "ag" = (
@@ -92,10 +93,17 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "ak" = (
-/obj/machinery/telecomms/relay/preset/ruskie{
-	use_power = 0
-	},
+/obj/structure/filingcabinet,
+/obj/item/paper/fluff/ruins/listeningstation/reports/april,
+/obj/item/paper/fluff/ruins/listeningstation/reports/may,
+/obj/item/paper/fluff/ruins/listeningstation/reports/june,
+/obj/item/paper/fluff/ruins/listeningstation/reports/july,
+/obj/item/paper/fluff/ruins/listeningstation/reports/august,
+/obj/item/paper/fluff/ruins/listeningstation/reports/september,
+/obj/item/paper/fluff/ruins/listeningstation/reports/october,
+/obj/item/paper/fluff/ruins/listeningstation/receipt,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/paper/fluff/ruins/listeningstation/odd_report,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "al" = (
@@ -233,12 +241,25 @@
 	pixel_x = 25
 	},
 /obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/paper/fluff/ruins/listeningstation/reports/november,
-/obj/item/pen,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/paper/fluff/ruins/listeningstation/reports/november{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = -4;
+	pixel_y = 5
+	},
 /obj/item/stock_parts/cell/high/plus{
 	pixel_x = -8;
 	pixel_y = -3
+	},
+/obj/item/integrated_electronics/wirer{
+	pixel_x = 7;
+	pixel_y = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
@@ -496,10 +517,8 @@
 	dir = 8
 	},
 /obj/structure/closet/crate,
-/obj/item/stack/sheet/metal/twenty,
-/obj/item/stack/sheet/glass{
-	amount = 10
-	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/rods/ten,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -805,7 +824,9 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/structure/closet/crate/bin,
+/obj/structure/closet/firecloset/full{
+	anchored = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "bk" = (
@@ -931,17 +952,20 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/white/side{
-	dir = 5
+	dir = 1
 	},
 /area/ruin/space/has_grav/listeningstation)
 "bu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/medical1{
-	req_access = null;
-	req_access_txt = "150"
+/obj/machinery/iv_drip,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side{
+	dir = 5
+	},
 /area/ruin/space/has_grav/listeningstation)
 "bv" = (
 /obj/structure/bookcase/random,
@@ -1025,11 +1049,6 @@
 	},
 /area/ruin/space/has_grav/listeningstation)
 "bB" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/machinery/iv_drip,
 /obj/machinery/light/small,
 /obj/machinery/airalarm/syndicate{
 	dir = 1;
@@ -1039,9 +1058,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 6
-	},
+/obj/machinery/chem_dispenser/fullupgrade,
+/turf/open/floor/plasteel/white/side,
 /area/ruin/space/has_grav/listeningstation)
 "bC" = (
 /obj/structure/cable,
@@ -1169,6 +1187,16 @@
 /obj/machinery/power/rtg/advanced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
+"na" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/medical1{
+	req_access = null;
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 6
+	},
+/area/ruin/space/has_grav/listeningstation)
 "tU" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -1178,21 +1206,19 @@
 /obj/machinery/microwave,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
+"ux" = (
+/obj/machinery/telecomms/relay/preset/ruskie{
+	use_power = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/listeningstation)
 "uB" = (
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
 "xe" = (
-/obj/structure/filingcabinet,
-/obj/item/paper/fluff/ruins/listeningstation/reports/april,
-/obj/item/paper/fluff/ruins/listeningstation/reports/may,
-/obj/item/paper/fluff/ruins/listeningstation/reports/june,
-/obj/item/paper/fluff/ruins/listeningstation/reports/july,
-/obj/item/paper/fluff/ruins/listeningstation/reports/august,
-/obj/item/paper/fluff/ruins/listeningstation/reports/september,
-/obj/item/paper/fluff/ruins/listeningstation/reports/october,
-/obj/item/paper/fluff/ruins/listeningstation/receipt,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/paper/fluff/ruins/listeningstation/odd_report,
+/obj/machinery/autolathe/hacked,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "za" = (
@@ -2320,7 +2346,7 @@ ab
 ab
 ab
 ac
-ac
+ux
 ak
 av
 aB
@@ -2359,7 +2385,7 @@ ab
 ab
 ab
 ab
-ab
+ag
 ac
 ac
 ac
@@ -2489,7 +2515,7 @@ aY
 bh
 ag
 bu
-ag
+na
 ag
 ab
 ab

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -405,7 +405,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "aI" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
@@ -515,7 +514,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
 "aP" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -26
@@ -1132,7 +1130,6 @@
 /turf/closed/wall,
 /area/ruin/space/has_grav/listeningstation)
 "fs" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
@@ -1140,10 +1137,7 @@
 /area/ruin/space/has_grav/listeningstation)
 "fJ" = (
 /obj/structure/chair/stool,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
-"gz" = (
-/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "hJ" = (
@@ -1158,6 +1152,10 @@
 	},
 /obj/item/shovel/spade,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/storage/bag/plants/portaseeder,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "lZ" = (
@@ -1198,7 +1196,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "za" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4;
 	piping_layer = 3;
@@ -1220,34 +1217,20 @@
 	},
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 9;
+	pixel_y = 11
+	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "Bd" = (
-/obj/item/seeds/apple,
-/obj/item/seeds/banana,
-/obj/item/seeds/cocoapod,
-/obj/item/seeds/grape,
-/obj/item/seeds/orange,
-/obj/item/seeds/sugarcane,
-/obj/item/seeds/wheat,
-/obj/item/seeds/watermelon,
-/obj/structure/table/glass,
-/obj/item/seeds/tower,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/vending/hydroseeds{
+	slogan_delay = 700
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/item/storage/bag/plants/portaseeder,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "Bs" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "DC" = (
@@ -1288,9 +1271,14 @@
 /area/ruin/space/has_grav/listeningstation)
 "Gb" = (
 /obj/item/reagent_containers/glass/bottle/nutrient/rh{
-	pixel_x = 2;
-	pixel_y = 1
+	pixel_x = -4;
+	pixel_y = -3
 	},
+/obj/item/reagent_containers/glass/bottle/nutrient/rh{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "IH" = (
@@ -1328,6 +1316,7 @@
 /area/ruin/space/has_grav/listeningstation)
 "Ns" = (
 /obj/machinery/biogenerator,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "NQ" = (
@@ -1336,6 +1325,11 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"Qp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "QM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1353,6 +1347,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "XM" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 
@@ -1970,7 +1965,7 @@ ac
 zq
 Gb
 XM
-Bs
+Qp
 Bs
 Mh
 ac
@@ -2008,7 +2003,7 @@ ab
 ab
 ac
 zq
-gz
+XM
 Bs
 fs
 za


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Overhauled the space syndicate listening outpost by adding it a proper food court, making it feel more lived in alongside some highly requested machinery changes. Some of these include, 2 RTEGs, (which I still do not know how to manually upgrade using the mapping tool! Hit me up if you do!), a chem dispenser, a little lathe, seed extractor and a biogenerator.

![image](https://user-images.githubusercontent.com/53913550/95157304-fc8f9f80-076e-11eb-8412-1becebf94ba4.png)

## Why It's Good For The Game

It's already a really rare role and a lot of people asked for it to receive a bit more love, such as a circuit printer, basic hydroponics and a proper food court, alongside a slightly decent source of power. I hope this helps.

## Changelog
:cl:
tweak: Space syndie listening post.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
