### PR TITLE
Stop Catsplosion

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -104,22 +104,24 @@
 	var/list/family = list()//var restored from savefile, has count of each child type
 	var/list/children = list()//Actual mob instances of children
 	var/cats_deployed = 0
-	var/memory_saved = FALSE
+	//var/memory_saved = FALSE
 
 /mob/living/simple_animal/pet/cat/Runtime/Initialize()
 	if(prob(5))
 		icon_state = "original"
 		icon_living = "original"
 		icon_dead = "original_dead"
-	Read_Memory()
+	//Read_Memory()
 	. = ..()
 
 /mob/living/simple_animal/pet/cat/Runtime/Life()
+	/*
 	if(!cats_deployed && SSticker.current_state >= GAME_STATE_SETTING_UP)
 		Deploy_The_Cats()
 	if(!stat && SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)
 		Write_Memory()
 		memory_saved = TRUE
+	*/
 	..()
 
 /mob/living/simple_animal/pet/cat/Runtime/make_babies()
@@ -129,9 +131,11 @@
 		return baby
 
 /mob/living/simple_animal/pet/cat/Runtime/death()
+/*
 	if(!memory_saved)
 		Write_Memory(TRUE)
 	..()
+*/
 
 /mob/living/simple_animal/pet/cat/Runtime/proc/Read_Memory()
 	if(fexists("data/npc_saves/Runtime.sav")) //legacy compatability to convert old format to new
@@ -146,7 +150,8 @@
 		family = json["family"]
 	if(isnull(family))
 		family = list()
-
+//All you people can't fucking control yourselves and keep letting runtime breed his own children, so it's time to at -LEAST- take the function that saves cats for the next round out the back and shoot it with a 12 gauge
+/*
 /mob/living/simple_animal/pet/cat/Runtime/proc/Write_Memory(dead)
 	var/json_file = file("data/npc_saves/Runtime.json")
 	var/list/file_data = list()
@@ -169,6 +174,7 @@
 		if(family[cat_type] > 0)
 			for(var/i in 1 to min(family[cat_type],100)) //Limits to about 500 cats, you wouldn't think this would be needed (BUT IT IS)
 				new cat_type(loc)
+*/
 
 /mob/living/simple_animal/pet/cat/Proc
 	name = "Proc"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -368,7 +368,7 @@
 /mob/living/simple_animal/proc/make_babies() // <3 <3 <3
 	if(gender != FEMALE || stat || next_scan_time > world.time || !childtype || !animal_species || !SSticker.IsRoundInProgress())
 		return
-	next_scan_time = world.time + 400
+	next_scan_time = world.time + 2000 //Please stop making it so they multiply like rabbits
 	var/alone = 1
 	var/mob/living/simple_animal/partner
 	var/children = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alright. So I took the base function that exists in TG code to let runtime have a family of cats that is always ported to the next round out the back, gave it a little pat on the back, loaded my 12 gauge and shot it. Not only that, I also increased the delay to check for breeding. No more catsplosion. While it can still happen, cargo will have to make an effort to do so and I'm more than sure that considering how much lag that causes, people would get lynched really quickly.

## Why It's Good For The Game

Please stop the cats

## Changelog
:cl:
fix: fuck you, runtime.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
