### PR TITLE
Shuttle Loan Fixes

### DIFF
--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -17,6 +17,7 @@
 /datum/round_event/shuttle_loan
 	announceWhen = 1
 	endWhen = 500
+	fakeable = FALSE
 	var/dispatched = 0
 	var/dispatch_type = 0
 	var/bonus_points = 10000
@@ -27,109 +28,43 @@
 
 /datum/round_event/shuttle_loan/announce(fake)
 	SSshuttle.shuttle_loan = src
+	var/message = "Cargo: I just wanna tell you techs good luck, we are all counting on you."
+	var/title = "CentCom Free Real Estate"
 	switch(dispatch_type)
 		if(HIJACK_SYNDIE)
-			if(prob(50))
-				priority_announce("Cargo: The syndicate are trying to infiltrate your station. If you let them hijack your cargo shuttle, you'll save us a headache.","CentCom Counter Intelligence")
-			else
-				priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/ai/commandreport.ogg') // CITADEL EDIT metabreak
-				for(var/obj/machinery/computer/communications/C in GLOB.machines)
-					if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-						var/obj/item/paper/P = new(C.loc)
-						P.name = "Cargo Report"
-						P.info = "Cargo: The syndicate are trying to infiltrate your station. If you let them hijack your cargo shuttle, you'll save us a headache."
-						P.update_icon()
+			message = "Cargo: The syndicate are trying to infiltrate your station. If you let them hijack your cargo shuttle, you'll save us a headache."
+			title = "CentCom Counter Intelligence"
 		if(RUSKY_PARTY)
-			if(prob(50))
-				priority_announce("Cargo: A group of angry Russians want to have a party. Can you send them your cargo shuttle then make them disappear?","CentCom Russian Outreach Program")
-			else
-				priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/ai/commandreport.ogg') // CITADEL EDIT metabreak
-				for(var/obj/machinery/computer/communications/C in GLOB.machines)
-					if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-						var/obj/item/paper/P = new(C.loc)
-						P.name = "Cargo Report"
-						P.info = "Cargo: The syndicate are trying to infiltrate your station. If you let them hijack your cargo shuttle, you'll save us a headache."
-						P.update_icon()
+			message = "Cargo: A group of angry Russians want to have a party. Can you send them your cargo shuttle then make them disappear?"
+			title = "CentCom Russian Outreach Program"
 		if(SPIDER_GIFT)
-			if(prob(50))
-				priority_announce("Cargo: The Spider Clan has sent us a mysterious gift. Can we ship it to you to see what's inside?","CentCom Diplomatic Corps")
-			else
-				priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/ai/commandreport.ogg') // CITADEL EDIT metabreak
-				for(var/obj/machinery/computer/communications/C in GLOB.machines)
-					if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-						var/obj/item/paper/P = new(C.loc)
-						P.name = "Cargo Report"
-						P.info = "Cargo: The Spider Clan has sent us a mysterious gift. Can we ship it to you to see what's inside?"
-						P.update_icon()
+			message = "Cargo: The Spider Clan has sent us a mysterious gift. Can we ship it to you to see what's inside?"
+			title = "CentCom Diplomatic Corps"
 		if(DEPARTMENT_RESUPPLY)
-			if(prob(50))
-				priority_announce("Cargo: Seems we've ordered doubles of our department resupply packages this month. Can we send them to you?","CentCom Supply Department")
-			else
-				priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/ai/commandreport.ogg') // CITADEL EDIT metabreak
-				for(var/obj/machinery/computer/communications/C in GLOB.machines)
-					if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-						var/obj/item/paper/P = new(C.loc)
-						P.name = "Cargo Report"
-						P.info = "Cargo: Seems we've ordered doubles of our department resupply packages this month. Can we send them to you?"
-						P.update_icon()
+			message = "Cargo: Seems we've ordered doubles of our department resupply packages this month. Can we send them to you?"
+			title = "CentCom Supply Department"
 		if(ANTIDOTE_NEEDED)
-			if(prob(50))
-				priority_announce("Cargo: Your station has been chosen for an epidemiological research project. Send us your cargo shuttle to receive your research samples.", "CentCom Research Initiatives")
-			else
-				priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/ai/commandreport.ogg') // CITADEL EDIT metabreak
-				for(var/obj/machinery/computer/communications/C in GLOB.machines)
-					if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-						var/obj/item/paper/P = new(C.loc)
-						P.name = "Cargo Report"
-						P.info = "Cargo: Your station has been chosen for an epidemiological research project. Send us your cargo shuttle to receive your research samples."
-						P.update_icon()
+			message = "Cargo: Your station has been chosen for an epidemiological research project. Send us your cargo shuttle to receive your research samples."
+			title = "CentCom Research Initiatives"
 		if (PIZZA_DELIVERY)
-			if(prob(50))
-				priority_announce("Cargo: It looks like a neighbouring station accidentally delivered their pizza to you instead.", "CentCom Spacepizza Division")
-			else
-				priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/ai/commandreport.ogg') // CITADEL EDIT metabreak
-				for(var/obj/machinery/computer/communications/C in GLOB.machines)
-					if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-						var/obj/item/paper/P = new(C.loc)
-						P.name = "Cargo Report"
-						P.info = "Cargo: It looks like a neighbouring station accidentally delivered their pizza to you instead."
-						P.update_icon()
+			message = "Cargo: It looks like a neighbouring station accidentally delivered their pizza to you instead."
+			title = "CentCom Spacepizza Division"
 		if(ITS_HIP_TO)
-			if(prob(50))
-				priority_announce("Cargo: One of our freighters carrying a bee shipment has been attacked by eco-terrorists. Can you clean up the mess for us?", "CentCom Janitorial Division")
-			else
-				priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/ai/commandreport.ogg') // CITADEL EDIT metabreak
-				for(var/obj/machinery/computer/communications/C in GLOB.machines)
-					if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-						var/obj/item/paper/P = new(C.loc)
-						P.name = "Cargo Report"
-						P.info = "Cargo: One of our freighters carrying a bee shipment has been attacked by eco-terrorists. Can you clean up the mess for us?."
-						P.update_icon()
+			message = "Cargo: One of our freighters carrying a bee shipment has been attacked by eco-terrorists. Can you clean up the mess for us?"
+			title = "CentCom Janitorial Division"
 			bonus_points = 20000 //Toxin bees can be unbeelievably lethal
 		if(MY_GOD_JC)
-			if(prob(50))
-				priority_announce("Cargo: We have discovered an active Syndicate bomb near our VIP shuttle's fuel lines. If you feel up to the task, we will pay you for defusing it.", "CentCom Security Division")
-			else
-				priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/ai/commandreport.ogg') // CITADEL EDIT metabreak
-				for(var/obj/machinery/computer/communications/C in GLOB.machines)
-					if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-						var/obj/item/paper/P = new(C.loc)
-						P.name = "Cargo Report"
-						P.info = "Cargo: We have discovered an active Syndicate bomb near our VIP shuttle's fuel lines. If you feel up to the task, we will pay you for defusing it."
-						P.update_icon()
+			message = "Cargo: We have discovered an active Syndicate bomb near our VIP shuttle's fuel lines. If you feel up to the task, we will pay you for defusing it."
+			title = "CentCom Security Division"
 			bonus_points = 45000 //If you mess up, people die and the shuttle gets turned into swiss cheese
 		if(DELTA_CRATES)
-			if(prob(50))
-				priority_announce("Cargo: We have discovered a warehouse of DELTA locked crates, we cant store any more of them at CC can you take them for us?.", "CentCom Security Division")
-			else
-				priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/ai/commandreport.ogg') // CITADEL EDIT metabreak
-				for(var/obj/machinery/computer/communications/C in GLOB.machines)
-					if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-						var/obj/item/paper/P = new(C.loc)
-						P.name = "Cargo Report"
-						P.info = "Cargo: We have discovered a warehouse of DELTA locked crates, we cant store any more of them at CC can you take them for us?."
-						P.update_icon()
+			message = "Cargo: We have discovered a warehouse of DELTA locked crates, we cant store any more of them at CC can you take them for us?."
+			title = "CentCom Security Division"
 			bonus_points = 25000 //If you mess up, people die and the shuttle gets turned into swiss cheese
+	if(prob(50))
+		priority_announce(message, title)
+	else
+		print_command_report(message, "Cargo report")
 
 /datum/round_event/shuttle_loan/proc/loan_shuttle()
 	priority_announce(thanks_msg, "Cargo shuttle commandeered by CentCom.")

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -24,8 +24,13 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/effect/portal,
 		/obj/item/shared_storage,
 		/obj/structure/extraction_point,
-		/obj/item/hilbertshotel,
-		/obj/machinery/syndicatebomb
+		/obj/machinery/syndicatebomb,
+		/obj/item/hilbertshotel
+	)))
+
+GLOBAL_LIST_INIT(cargo_shuttle_leave_behind_typecache, typecacheof(list(
+	/mob/living/simple_animal/revenant,
+	/mob/living/simple_animal/slaughter
 	)))
 
 /obj/docking_port/mobile/supply
@@ -50,16 +55,27 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 
 /obj/docking_port/mobile/supply/canMove()
 	if(is_station_level(z))
-		return check_blacklist(shuttle_areas)
+		return check_blacklist(shuttle_areas, GLOB.blacklisted_cargo_types - GLOB.cargo_shuttle_leave_behind_typecache)
 	return ..()
 
-/obj/docking_port/mobile/supply/proc/check_blacklist(areaInstances)
+/obj/docking_port/mobile/supply/enterTransit()
+	var/list/leave_behind = list()
+	for(var/i in check_blacklist(shuttle_areas, GLOB.cargo_shuttle_leave_behind_typecache))
+		var/atom/movable/AM = i
+		leave_behind[AM] = AM.loc
+	. = ..()
+	for(var/kicked in leave_behind)
+		var/atom/movable/victim = kicked
+		var/atom/oldloc = leave_behind[victim]
+		victim.forceMove(oldloc)
+
+/obj/docking_port/mobile/supply/proc/check_blacklist(areaInstances, list/typecache)
 	for(var/place in areaInstances)
 		var/area/shuttle/shuttle_area = place
 		for(var/trf in shuttle_area)
 			var/turf/T = trf
 			for(var/a in T.GetAllContents())
-				if(is_type_in_typecache(a, GLOB.blacklisted_cargo_types))
+				if(is_type_in_typecache(a, typecache))
 					return FALSE
 				if(istype(a, /obj/structure/closet))//Prevents eigenlockers from ending up at CC
 					var/obj/structure/closet/c = a


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes it so (hopefully) the shuttle loan isn't empty anymore. Also prevents revenants and slaughter demons from being sent to centcom, because that is bad.

## Why It's Good For The Game

yes

## Changelog
:cl:
fix: shuttle loan fixes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
