### PR TITLE
Functional Ai Target sanity check

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -416,8 +416,16 @@ GLOBAL_LIST_EMPTY(possible_items)
 			for(var/datum/mind/M in owners)
 				if(M.current.mind.assigned_role in possible_item.excludefromjob)
 					continue check_items
-			approved_targets += possible_item
+			if(extraSanityCheck(possible_item.targetitem))
+				approved_targets += possible_item
 	return set_target(safepick(approved_targets))
+
+/datum/objective/steal/proc/extraSanityCheck(objectiveitem)
+	if(objectiveitem == /obj/item/aicard) //Is the item an AI card? (Steal a functional AI)
+		var/list/ais = active_ais() //Check if we have active AIs.
+		if(!ais.len)
+			return FALSE //No AIs, returns false, disallowing the AI card objective from being added to the approved target list
+	return TRUE //All checks successful, add this item to the approved target list
 
 /datum/objective/steal/proc/set_target(datum/objective_item/item)
 	if(item)
@@ -875,6 +883,3 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 /datum/objective/changeling_team_objective/impersonate_department/impersonate_heads
 	explanation_text = "Have X or more heads of staff escape on the shuttle disguised as heads, while the real heads are dead"
 	command_staff_only = TRUE
-
-
-


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a sanity check that prevents traitors from getting the "Steal a functional AI" objective if there is no active AI in the first place.

## Why It's Good For The Game

Little bit annoying for the Ts to get AI objectives when there's no AI around.

## Changelog
:cl:
fix: Prevents the steal a functional AI objective when there's no AI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
