### PR TITLE
Fixes Pouring Mannitol on Brains that had the Mannitol tooltip

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -105,8 +105,8 @@
 	if((organ_flags & ORGAN_FAILING) && O.is_drainable() && O.reagents.has_reagent("neurine")) //Neurine fixes dead brains
 		. = TRUE //don't do attack animation.
 		var/cached_Bdamage = brainmob?.health
-		var/datum/reagent/medicine/neurine/N = reagents.has_reagent("neurine")
-		var/datum/reagent/medicine/mannitol/M1 = reagents.has_reagent("mannitol")
+		var/datum/reagent/medicine/neurine/N = O.reagents.has_reagent("neurine")
+		var/datum/reagent/medicine/mannitol/M1 = O.reagents.has_reagent("mannitol")
 
 		if(O.reagents.has_reagent("mannitol"))//Just a quick way to bolster the effects if someone mixes up a batch.
 			N.volume *= (M1.volume*0.5)
@@ -136,7 +136,7 @@
 
 	if((organ_flags & ORGAN_FAILING) && O.is_drainable() && O.reagents.has_reagent("mannitol")) //attempt to heal the brain
 		. = TRUE //don't do attack animation.
-		var/datum/reagent/medicine/mannitol/M = reagents.has_reagent("mannitol")
+		var/datum/reagent/medicine/mannitol/M = O.reagents.has_reagent("mannitol")
 		if(brain_death || brainmob?.health <= HEALTH_THRESHOLD_DEAD) //if the brain is fucked anyway, do nothing
 			to_chat(user, "<span class='warning'>[src] is far too damaged, you'll have to use neurine on it!</span>")
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Okay so for whatever reason when this rework was ported the variable to pull reagents from wasn't declared. Now it is. Now it works.
Bam.

## Why It's Good For The Game

Fixes are good.

## Changelog
:cl:
fix: Pouring mannitol on fucked up brains brains
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
