### PR TITLE
More dynamic

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -351,8 +351,8 @@ GLOBAL_VAR_INIT(dynamic_chaos_level, 1.5)
 				if (ruleset.weight)
 					midround_rules += ruleset
 			if ("Event")
-				if(ruleset.weight)
-					event_rules += ruleset
+				//if(ruleset.weight)
+				event_rules += ruleset
 	for(var/mob/dead/new_player/player in GLOB.player_list)
 		if(player.ready == PLAYER_READY_TO_PLAY && player.mind)
 			roundstart_pop_ready++
@@ -644,7 +644,7 @@ GLOBAL_VAR_INIT(dynamic_chaos_level, 1.5)
 		if (prob(get_injection_chance()))
 			var/list/drafted_rules = list()
 			for (var/datum/dynamic_ruleset/midround/rule in midround_rules)
-				if (rule.acceptable(current_players[CURRENT_LIVING_PLAYERS].len, threat_level) && threat >= rule.cost)
+				if (rule.acceptable(current_players[CURRENT_LIVING_PLAYERS].len, threat_level))
 					// Classic secret : only autotraitor/minor roles
 					if (GLOB.dynamic_classic_secret && !((rule.flags & TRAITOR_RULESET) || (rule.flags & MINOR_RULESET)))
 						continue
@@ -665,10 +665,10 @@ GLOBAL_VAR_INIT(dynamic_chaos_level, 1.5)
 		update_playercounts()
 		var/list/drafted_rules = list()
 		for (var/datum/dynamic_ruleset/event/rule in event_rules)
-			if (rule.acceptable(current_players[CURRENT_LIVING_PLAYERS].len, threat_level) && threat >= rule.cost)
+			if (rule.acceptable(current_players[CURRENT_LIVING_PLAYERS].len, threat_level))
 				// Classic secret : only autotraitor/minor roles
-				if (!GLOB.master_mode == "dynamic")
-					continue
+				//if (!GLOB.master_mode == "dynamic")
+					//continue
 				if (world.time < rule.earliest_start)
 					continue
 				if(rule.occurances_current >= rule.occurances_max && rule.occurances_max)
@@ -676,8 +676,9 @@ GLOBAL_VAR_INIT(dynamic_chaos_level, 1.5)
 				rule.candidates = list()
 				rule.candidates = current_players.Copy()
 				rule.trim_candidates()
-				if (rule.ready() && rule.candidates.len > 0)
-					drafted_rules[rule] = rule.get_weight()
+				//if(rule.needs_players)
+					//if (rule.ready() && rule.candidates.len > 0)
+				drafted_rules[rule] = rule.get_weight()
 		if(drafted_rules.len > 0)
 			picking_midround_latejoin_rule(drafted_rules)
 
@@ -727,13 +728,14 @@ GLOBAL_VAR_INIT(dynamic_chaos_level, 1.5)
 			chance += 25-10*(max_pop_per_antag-current_pop_per_antag)
 	*/
 	//Hyper change - Base injection chance based on chaos. 
-	chance = (GLOB.dynamic_chaos_level * 10) //Base chance from 0 to 50
+	chance = (GLOB.dynamic_chaos_level * 12) //Base chance from 0 to 60
 	if (current_players[CURRENT_DEAD_PLAYERS].len > current_players[CURRENT_LIVING_PLAYERS].len)
 		chance -= 30 // More than half the crew died? ew, let's calm down on antags
-	if (threat > 70)
-		chance += 15
-	if (threat < 30)
-		chance -= 15
+	//if (threat > 70)
+	//	chance += 15
+	//if (threat < 30)
+	//	chance -= 15
+	chance += ((threat-40)*0.4) //threat influence injection chance more gradually
 	if (chance > 100) //I don't know what would happen if we returned a probability greater than 100%
 		return 100 //So I won't
 	return round(max(0,chance))

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -31,8 +31,7 @@
 					continue // Dead players cannot count as opponents
 				if (M.mind && M.mind.assigned_role && (M.mind.assigned_role in enemy_roles) && (!(M in candidates) || (M.mind.assigned_role in restricted_roles)))
 					job_check++ // Checking for "enemies" (such as sec officers). To be counters, they must either not be candidates to that rule, or have a job that restricts them from it
-
-		var/threat = round(mode.threat_level/10)
+		var/threat = min(round(mode.threat_level/10),9)
 		if (job_check < required_enemies[threat])
 			return FALSE
 	return ..()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -360,7 +360,7 @@
 	high_population_requirement = 10
 	pop_per_requirement = 5
 	flags = HIGHLANDER_RULESET
-	var/operative_cap = list(1,1,2,2,2,3,3,3,4,5)
+	var/operative_cap = list(1,1,1,2,2,3,3,3,4,5)
 	var/datum/team/nuclear/nuke_team
 	chaos_min = 4.0
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -61,7 +61,6 @@
 		mode.picking_specific_rule(/datum/dynamic_ruleset/midround/autotraitor)
 */
 
-/* //Not currently functional
 //////////////////////////////////////////
 //                                      //
 //                LEWD                  //
@@ -77,25 +76,24 @@
 	protected_roles = list("AI","Cyborg")
 	restricted_roles = list("Cyborg","AI")
 	required_candidates = 1
-	weight = 5
+	weight = 3
 	cost = 0
-	requirements = list(10,10,10,10,10,10,10,10,10,10)
+	requirements = list(101,10,10,10,10,10,10,10,10,10)
 	high_population_requirement = 10
 	chaos_min = 0.1
-	chaos_max = 2.0
+	chaos_max = 2.5
 	admin_required = TRUE
 	//vars for execution
 	var/list/mob/living/carbon/human/lewd_candidates = list()
-	var/numTraitors = 0
+	var/numTraitors = 1
 
 
-/datum/dynamic_ruleset/roundstart/traitor/lewd/pre_execute()
+/datum/dynamic_ruleset/roundstart/traitor/lewd/ready()
 	var/list/mob/living/carbon/human/targets = list()
 
-	for(var/mob/living/carbon/human/target in GLOB.player_list)
+	for(var/mob/dead/new_player/target in GLOB.player_list)
 		if(target.client.prefs.noncon)
-			if(!(target.job in restricted_roles))
-				targets += target
+			targets += target
 
 	if(candidates.len)
 		var/numTraitors = min(candidates.len, targets.len, 1) //This number affects the maximum number of traitors. We want 1 for right now.
@@ -105,14 +103,26 @@
 		return 1
 
 	return 0
+	
+/datum/dynamic_ruleset/roundstart/traitor/lewd/pre_execute()
+	var/traitor_scaling_coeff = 10 - max(0,round(mode.threat_level/10)-5) // Above 50 threat level, coeff goes down by 1 for every 10 levels
+	var/num_traitors = min(round(mode.candidates.len / traitor_scaling_coeff) + 1, candidates.len)
+	for (var/i = 1 to num_traitors)
+		var/mob/M = pick(candidates)
+		candidates -= M
+		assigned += M.mind
+		M.mind.special_role = ROLE_LEWD_TRAITOR
+		M.mind.restricted_roles = restricted_roles
+	return TRUE
 
+/*
 /datum/dynamic_ruleset/roundstart/traitor/lewd/execute()
-	var/mob/living/carbon/human/H = null
+	var/datum/mind/M = null
 	if(numTraitors)
 		for(var/i = 0, i<numTraitors, i++)
-			H = pick(candidates)
-			candidates.Remove(H)
-			H.mind.make_LewdTraitor()
+			M = pick(assigned)
+			assigned.Remove(M)
+			M.make_LewdTraitor()
 		return TRUE
 	return FALSE
 */
@@ -350,7 +360,7 @@
 	high_population_requirement = 10
 	pop_per_requirement = 5
 	flags = HIGHLANDER_RULESET
-	var/operative_cap = list(2,2,2,2,2,3,3,3,4,5)
+	var/operative_cap = list(1,1,2,2,2,3,3,3,4,5)
 	var/datum/team/nuclear/nuke_team
 	chaos_min = 4.0
 

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -36,7 +36,6 @@
 	var/mob/living/carbon/human/H = owner.current
 	H.set_species(/datum/species/human) //Plasamen burn up otherwise, and lizards are vulnerable to asimov AIs
 	H.equipOutfit(nukeop_outfit)
-	H.checkloadappearance()
 	return TRUE
 
 /datum/antagonist/nukeop/greet()
@@ -53,6 +52,8 @@
 	memorize_code()
 	if(send_to_spawnpoint)
 		move_to_spawnpoint()
+	var/mob/living/carbon/human/H = owner.current
+	H.checkloadappearance()
 
 /datum/antagonist/nukeop/get_team()
 	return nuke_team


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes LoneOP, which was, uh, apparently broken.
Fixes Nukies, but we knew they were broken.
Adds Lewd antag to the rotation as a roundstart and a sleeper. Has the admin required flag, and is disabled at higher chaos levels.
Fixes camera failure. Camera failure is very important, since it's our main filler event. Was interacting really strangely with a max_occurances of 0, so that has been changed to an impossibly large number. We should see less events overall.
A few tweaks, radiation storms should be less common. Made Malf slightly more common.

I intended to have more fixes and balances in this, but lone OP needs a fix, so the rest of the patches will come later.
LoneOP would have been it's own PR but I forgot to switch branches. Whoops.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the station explode if people lose track of a tiny disk...... wait, that's not good at all.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: LoneOP
tweak: A few odds for events and midrounds
add: LewdOP
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
