### PR TITLE
X-01 MultiPhase Energy Gun Buff

### DIFF
--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -13,7 +13,7 @@
 	e_cost = 100
 
 /obj/item/ammo_casing/energy/electrode/hos
-	e_cost = 200
+	e_cost = 100
 
 /obj/item/ammo_casing/energy/electrode/old
 	e_cost = 1000

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -54,6 +54,7 @@
 	name = "\improper X-01 MultiPhase Energy Gun"
 	desc = "This is an expensive, modern recreation of an antique laser gun. This gun has several unique firemodes, but lacks the ability to recharge over time."
 	icon_state = "hoslaser"
+	cell_type = /obj/item/stock_parts/cell{charge = 1600; maxcharge = 1600; chargerate = 160}
 	force = 10
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode/hos, /obj/item/ammo_casing/energy/laser/hos, /obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 4


### PR DESCRIPTION
## About The Pull Request

Increased the charge capacity of the X-01's blaster by 60% along with it's charge capacity, allowing 16 lethal shots, 40 disabler, or 16 stun shots. Originally the stun energy cost was at a whole 200 charge reduction , now being 100 to represent the power in comparison to a tactical energy gun that spent half the amount of energy in comparison.

## Why It's Good For The Game

The X-01 is the signature weapon for the Head of Security, while also being sought out as a theft objective. In many situations I'm told people rather hold it for an objective compared to being a tool of trade (for being slightly underwhelming for it's power compared to the advanced energy gun that's self charging and has all the three laser energy functions). This little buff will provide the little push needed for it to be on par with the self charging advanced energy gun when used in combat environments.

## Changelog
:cl:
tweak: tweaked a few few variables with the power cell in the X-01 and the energy cost for the electrode.
balance: Buffed a traitor objective item.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
