### PR TITLE
[SPEEDMERGE] Fixes misaligned HE pipes & Listening Post Duplicates + TEG Burn chamber Optimizations

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -1171,8 +1171,6 @@
 /obj/structure/closet/secure_closet/hydroponics{
 	req_access = null
 	},
-/obj/item/cultivator,
-/obj/item/plant_analyzer,
 /obj/item/reagent_containers/spray/pestspray{
 	pixel_x = 3;
 	pixel_y = 4
@@ -1182,7 +1180,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/storage/bag/plants/portaseeder,
+/obj/item/storage/bag/plants,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "ki" = (
@@ -1194,6 +1192,19 @@
 /obj/item/toy/plush/narplush,
 /turf/closed/mineral/random,
 /area/ruin/unpowered/no_grav)
+"kT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/smartfridge/disks{
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/glass/bottle/nutrient/rh{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/listeningstation)
 "lZ" = (
 /obj/structure/cable,
 /obj/structure/cable{
@@ -1275,11 +1286,7 @@
 /area/ruin/space/has_grav/listeningstation)
 "Bd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/smartfridge/disks{
-	pixel_x = -4;
-	pixel_y = 11
-	},
+/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "Bs" = (
@@ -2035,7 +2042,7 @@ ab
 ac
 zq
 Gb
-XM
+kT
 Bs
 tU
 Bs

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -641,6 +641,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "aW" = (
@@ -788,11 +791,9 @@
 /turf/open/floor/plasteel/white/side,
 /area/ruin/space/has_grav/listeningstation)
 "bh" = (
-/obj/machinery/vending/cola/random{
-	extended_inventory = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/cola/shamblers,
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
@@ -1072,10 +1073,10 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/wrench,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/item/storage/toolbox/syndicate,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
 "bD" = (
@@ -1385,8 +1386,8 @@
 	pixel_x = 3;
 	pixel_y = 11
 	},
-/obj/item/lighter/slime{
-	pixel_x = 6
+/obj/item/lighter{
+	pixel_x = 9
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -2566,9 +2567,9 @@ ab
 ag
 ag
 an
-ac
+ag
 aE
-ac
+ag
 aY
 bh
 ag

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -419,6 +419,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	dir = 4;
 	name = "Food Court"
@@ -959,11 +960,7 @@
 "bu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/iv_drip,
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
+/obj/machinery/chem_dispenser/fullupgrade,
 /turf/open/floor/plasteel/white/side{
 	dir = 5
 	},
@@ -1059,7 +1056,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/chem_dispenser/fullupgrade,
+/obj/machinery/iv_drip,
+/obj/structure/sink{
+	dir = 1;
+	pixel_x = -9;
+	pixel_y = -1
+	},
 /turf/open/floor/plasteel/white/side,
 /area/ruin/space/has_grav/listeningstation)
 "bC" = (
@@ -1270,7 +1272,7 @@
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = -12;
-	pixel_y = 2
+	pixel_y = 12
 	},
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/cleanable/dirt,
@@ -1303,6 +1305,10 @@
 /area/ruin/space/has_grav/listeningstation)
 "DL" = (
 /obj/structure/chair/stool,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 25
+	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "Et" = (
@@ -1421,7 +1427,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "TK" = (
-/obj/machinery/chem_master/condimaster,
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "XM" = (

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_teg.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_teg.dmm
@@ -1,4 +1,12 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aq" = (
+/obj/structure/table/reinforced,
+/obj/item/paper{
+	desc = "Charlie, remember to reconnect the gas mix monitor if it's having issues, by the way, if the heat gets too high, don't be afraid to space this part of engineering and use a voidsuit or a hardsuit. There's one in the crates.";
+	name = "TEG Chamber Note"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "av" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -88,13 +96,8 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "dq" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/engineering/glass{
-	dir = 4;
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
-	},
-/turf/open/floor/engine/vacuum,
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "ds" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -127,24 +130,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ek" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/door/poddoor{
-	id = "TEG_Vent"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
 	},
-/turf/open/space,
+/turf/open/floor/engine/vacuum,
 /area/engine/engineering)
 "en" = (
-/obj/machinery/button/ignition/incinerator{
-	id = "TEG_igniter";
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/obj/machinery/button/door{
-	id = "TEG_Vent";
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/turf/closed/wall/r_wall,
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "ev" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -179,8 +172,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "fO" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
+/obj/machinery/computer/atmos_control/tank/mix_tank{
+	dir = 8;
+	input_tag = "teg_in";
+	name = "TEG Mix Tank Control";
+	output_tag = null;
+	sensors = list("teg_sensor" = "TEG Mix Tank")
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "go" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -198,8 +197,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "gA" = (
-/obj/machinery/igniter{
-	id = "TEG_igniter"
+/obj/machinery/atmospherics/components/unary/outlet_injector{
+	dir = 1;
+	id = "teg_in"
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/engineering)
@@ -331,20 +331,26 @@
 /turf/open/space,
 /area/space/nearstation)
 "kK" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = 32
+/obj/machinery/button/ignition/incinerator{
+	id = "TEG_igniter";
+	pixel_x = -5;
+	pixel_y = 10
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/button/door{
+	id = "TEG_Vent";
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "kS" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/engine/vacuum,
 /area/engine/engineering)
 "le" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/item/clothing/head/hardhat,
+/turf/open/floor/engine/vacuum,
 /area/engine/engineering)
 "lw" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -357,6 +363,9 @@
 /obj/machinery/camera{
 	c_tag = "TEG - South East";
 	dir = 8
+	},
+/obj/structure/sign/warning/securearea{
+	pixel_x = 29
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -398,20 +407,26 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "nc" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/obj/machinery/air_sensor/atmos{
+	id_tag = "teg_sensor"
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/engineering)
 "nk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/engineering/glass/critical{
+	dir = 4;
+	heat_proof = 1;
+	name = "TEG Burn Chamber";
+	req_access_txt = "10"
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/engine/vacuum,
 /area/engine/engineering)
 "nD" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/engineering)
@@ -469,10 +484,8 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "oQ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/mob/living/carbon/monkey,
-/obj/item/clothing/head/hardhat,
-/turf/open/floor/engine/vacuum,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "oS" = (
 /obj/machinery/door/firedoor,
@@ -482,6 +495,11 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"oZ" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
 "pY" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
@@ -532,8 +550,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qv" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/mob/living/carbon/monkey{
+	desc = "When the candle is lit, you know the burn is good.";
+	name = "Candle"
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/engineering)
@@ -862,9 +882,10 @@
 /turf/open/space/basic,
 /area/space)
 "Am" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/igniter{
+	id = "TEG_igniter"
 	},
+/obj/item/wrench,
 /turf/open/floor/engine/vacuum,
 /area/engine/engineering)
 "An" = (
@@ -1071,6 +1092,12 @@
 "EL" = (
 /turf/closed/wall,
 /area/engine/engineering)
+"EM" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
 "EN" = (
 /obj/machinery/atmospherics/components/binary/valve/digital,
 /obj/effect/decal/cleanable/dirt,
@@ -1101,6 +1128,13 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
+/area/engine/engineering)
+"Fl" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/door/poddoor{
+	id = "TEG_Vent"
+	},
+/turf/open/space,
 /area/engine/engineering)
 "FG" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -1219,11 +1253,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "IA" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
-/turf/open/floor/engine/vacuum,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "IP" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -1248,9 +1281,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "Jj" = (
-/obj/machinery/vending/snack/random,
-/obj/structure/sign/warning/securearea{
-	pixel_x = 29
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26;
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -1309,9 +1342,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "Kx" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/floor/engine/vacuum,
 /area/engine/engineering)
 "KA" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -1504,6 +1538,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/clothing/suit/space/orange,
+/obj/item/clothing/head/helmet/space/orange,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "Qu" = (
@@ -1646,8 +1685,10 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "TE" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/floor/engine/vacuum,
 /area/engine/engineering)
 "TH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -1773,10 +1814,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "WB" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "Xe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -1818,7 +1858,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "XM" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
@@ -1939,8 +1979,7 @@
 /area/engine/engineering)
 "ZC" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
-/obj/item/wrench,
-/turf/open/floor/engine/vacuum,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "ZT" = (
 /turf/template_noop,
@@ -2202,7 +2241,7 @@ Rh
 Rh
 Rh
 Rh
-yf
+Rh
 "}
 (10,1,1) = {"
 ZT
@@ -2228,9 +2267,9 @@ yf
 yf
 yf
 yf
-Rh
-yf
-yf
+YZ
+oZ
+YZ
 "}
 (11,1,1) = {"
 oC
@@ -2255,10 +2294,10 @@ MP
 MP
 MP
 Rh
-WB
-YZ
-WB
 yf
+oZ
+Oj
+oZ
 "}
 (12,1,1) = {"
 cS
@@ -2282,11 +2321,11 @@ Eo
 Mf
 BT
 MP
+tw
 yf
 YZ
 Oj
 YZ
-yf
 "}
 (13,1,1) = {"
 ME
@@ -2310,11 +2349,11 @@ lw
 NP
 Ef
 MP
+tw
 yf
 YZ
 Oj
 YZ
-yf
 "}
 (14,1,1) = {"
 Ne
@@ -2339,10 +2378,10 @@ Wc
 tv
 MP
 Rh
+yf
 YZ
 Oj
 YZ
-Rh
 "}
 (15,1,1) = {"
 iP
@@ -2366,11 +2405,11 @@ lw
 lw
 XK
 MP
+tw
 yf
 YZ
 Oj
 YZ
-yf
 "}
 (16,1,1) = {"
 MP
@@ -2392,13 +2431,13 @@ pY
 BI
 Et
 Ok
-TE
+OP
 MP
 Rh
+yf
 YZ
 Oj
 YZ
-yf
 "}
 (17,1,1) = {"
 oS
@@ -2422,11 +2461,11 @@ sH
 sH
 Uq
 MP
+tw
 yf
 YZ
 Oj
 YZ
-yf
 "}
 (18,1,1) = {"
 iD
@@ -2450,11 +2489,11 @@ IW
 wC
 Pp
 MP
+tw
 yf
 YZ
 Oj
 YZ
-yf
 "}
 (19,1,1) = {"
 oS
@@ -2479,10 +2518,10 @@ sH
 EH
 MP
 Rh
+yf
 YZ
 Oj
 YZ
-yf
 "}
 (20,1,1) = {"
 MP
@@ -2499,18 +2538,18 @@ wR
 Zm
 OK
 Ok
-OP
+Ok
 rr
-kK
+Ok
 Jj
 eD
 lD
 MP
 Rh
-YZ
+yf
+yf
 Oj
 YZ
-yf
 "}
 (21,1,1) = {"
 MP
@@ -2526,19 +2565,19 @@ PK
 cK
 Ok
 OK
-PK
-en
-MP
-dq
-MP
-MP
-MP
 fO
-Rh
-Rh
+aq
+kK
+MP
+nk
+MP
+MP
+MP
+WB
+yf
+yf
 Oj
 YZ
-yf
 "}
 (22,1,1) = {"
 iD
@@ -2555,18 +2594,18 @@ aR
 ZY
 QH
 Hp
-Kx
+sH
 oQ
-kS
-kS
-kS
+le
 qv
+kS
+kS
 ek
+Fl
 Le
-Rh
+yf
 Oj
 YZ
-Rh
 "}
 (23,1,1) = {"
 iD
@@ -2583,18 +2622,18 @@ LD
 wv
 mj
 SE
-le
+wv
 ZC
 nc
 gA
 Am
 XM
-ek
+Kx
+Fl
 Le
-Rh
+yf
 Oj
 YZ
-yf
 "}
 (24,1,1) = {"
 mH
@@ -2611,18 +2650,18 @@ sH
 sH
 gq
 FW
-Kx
+sH
+oQ
 kS
 BY
 kS
-IA
 nD
-ek
+TE
+Fl
 Le
-Rh
+yf
 Oj
 YZ
-yf
 "}
 (25,1,1) = {"
 iD
@@ -2643,14 +2682,14 @@ yN
 yN
 yN
 yN
-nk
+yN
+IA
 MP
-fO
-Rh
-Rh
-YZ
-YZ
+WB
 yf
+yf
+Oj
+YZ
 "}
 (26,1,1) = {"
 wt
@@ -2676,9 +2715,9 @@ yf
 yf
 yf
 yf
-Rh
 yf
-yf
+EM
+YZ
 "}
 (27,1,1) = {"
 ZT
@@ -2693,7 +2732,7 @@ eh
 zx
 XW
 ST
-Ok
+en
 MP
 dw
 dw
@@ -2720,7 +2759,7 @@ Ok
 SB
 Fi
 tQ
-Ok
+dq
 BT
 MP
 yf

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
@@ -16,7 +16,7 @@
 
 	var/mutable_appearance/center
 
-/obj/machinery/atmospherics/pipe/manifold/Initialize()
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/Initialize()
 	icon_state = ""
 	center = mutable_appearance(icon, "manifold_center")
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the misaligned HE pipes, also removes duplicate un-needed items in the syndicate listening outpost in favor of a water tank, alongside some much needed re-organizing, a missing firelock a machine replacement. Also exchanged the slime lighter for a zippo, re-added a secondary toolbox and another poster.

Also updates the TEG engine by isolating the heat a little bit more. Also adds a gas chamber, a control computer and heat proofs the burn chamber door, alongside a single emergency space suit and notes on how to use the chamber if the heat is too excessive.

## Why It's Good For The Game

Because pipes looking like this once again is good.
![image](https://user-images.githubusercontent.com/53913550/96519504-86496d80-1243-11eb-96ca-c6ea8552c3c7.png)

Instead of

![image](https://user-images.githubusercontent.com/53913550/96519537-95302000-1243-11eb-99ff-bb6e63072327.png)



## Changelog
:cl:
fix: Misaligned HE pipes
tweak: Remove duplicate un-needed items in the syndicate listening outpost in favor of a water tank
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
