### PR TITLE
Oh boy, it's another one of Archie's mini packs. - Energy Harvester, HoS Pet Port and a micro carp buff.

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1003,6 +1003,15 @@
 	contains = list(/obj/item/circuitboard/computer/sat_control)
 	crate_name= "shield control board crate"
 
+/datum/supply_pack/engine/energy_harvester
+	name = "Energy Harvesting Module"
+	desc = "A Device which upon connection to a node, will harvest the energy and send it to engineerless stations in return for credits, derived from a syndicate powersink model."
+	cost = 7500
+	access = ACCESS_CE
+	contains = list(/obj/item/energy_harvester)
+	crate_name = "energy harvesting module crate"
+	crate_type = /obj/structure/closet/crate/secure/engineering
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////// Engine Construction /////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -106,6 +106,12 @@
 	obj_damage = 70
 	melee_damage_lower = 15
 	melee_damage_upper = 18
+	var/held_icon = "carp"
+	
+/mob/living/simple_animal/hostile/carp/cayenne/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/wuv, "bloops happily!", EMOTE_AUDIBLE, /datum/mood_event/pet_animal, "gnashes!", EMOTE_AUDIBLE)
+	AddElement(/datum/element/mob_holder, held_icon)
 
 /mob/living/simple_animal/hostile/carp/cayenne/lia
 	name = "Lia"
@@ -118,5 +124,6 @@
 	icon_living = "magicarp"
 	icon_state = "magicarp"
 	maxHealth = 200
+	held_icon = "magicarp"
 
 #undef REGENERATION_DELAY

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -17,8 +17,8 @@
 	emote_taunt = list("gnashes")
 	taunt_chance = 30
 	speed = 0
-	maxHealth = 25
-	health = 25
+	maxHealth = 35
+	health = 35
 	spacewalk = TRUE
 	harm_intent_damage = 8
 	obj_damage = 50
@@ -106,5 +106,17 @@
 	obj_damage = 70
 	melee_damage_lower = 15
 	melee_damage_upper = 18
+
+/mob/living/simple_animal/hostile/carp/cayenne/lia
+	name = "Lia"
+	real_name = "Lia"
+	desc = "A failed experiment of Nanotrasen to create weaponised carp technology, now acquired by Kinaris. This less than intimidating carp now serves as the Head of Security's pet."
+	faction = list("neutral", "carp")
+	health = 200
+	icon_dead = "magicarp_dead"
+	icon_gib = "magicarp_gib"
+	icon_living = "magicarp"
+	icon_state = "magicarp"
+	maxHealth = 200
 
 #undef REGENERATION_DELAY

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -17,8 +17,8 @@
 	emote_taunt = list("gnashes")
 	taunt_chance = 30
 	speed = 0
-	maxHealth = 35
-	health = 35
+	maxHealth = 25
+	health = 25
 	spacewalk = TRUE
 	harm_intent_damage = 8
 	obj_damage = 50

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3215,4 +3215,5 @@
 #include "modular_citadel\code\modules\vore\eating\voreitems.dm"
 #include "modular_citadel\code\modules\vore\eating\vorepanel_vr.dm"
 #include "modular_citadel\interface\skin.dmf"
+#include "yogstation\code\modules\power\energyharvester.dm"
 // END_INCLUDE

--- a/yogstation/code/modules/power/energyharvester.dm
+++ b/yogstation/code/modules/power/energyharvester.dm
@@ -1,0 +1,88 @@
+/obj/item/energy_harvester
+	desc = "A Device which upon connection to a node, will harvest the energy and send it to engineerless stations in return for credits, derived from a syndicate powersink model."
+	name = "Energy Harvesting Module"
+	icon_state = "powersink0"
+	icon = 'icons/obj/device.dmi'
+	item_state = "electronic"
+	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
+	w_class= WEIGHT_CLASS_BULKY
+	flags_1 = CONDUCT_1
+	throwforce = 1
+	throw_speed = 1
+	throw_range = 1
+	materials = list(MAT_METAL=750)
+	var/drain_rate = 100000000
+	var/power_drained = 0
+	var/obj/structure/cable/attached
+	var/datum/looping_sound/generator/soundloop
+	var/active = 0
+	var/lastprocessed = 0
+
+
+/obj/item/energy_harvester/attackby(obj/item/I, mob/user, params)
+	if(I.tool_behaviour == TOOL_SCREWDRIVER)
+		if(!anchored)
+			var/turf/T = loc
+			if(isturf(T) && !T.intact)
+				attached = locate() in T
+				if(!attached)
+					to_chat(user, "<span class='warning'>This device must be placed over an exposed, powered cable node!</span>")
+				else
+					I.play_tool_sound(src)
+					START_PROCESSING(SSobj, src)
+					anchored = 1
+					density = 1
+					user.visible_message( \
+						"[user] attaches \the [src] to the cable.", \
+						"<span class='notice'>You attach \the [src] to the cable.</span>",
+						"<span class='italics'>You hear some wires being connected to something.</span>")
+			else
+				to_chat(user, "<span class='warning'>This device must be placed over an exposed, powered cable node!</span>")
+		else
+			I.play_tool_sound(src)
+			STOP_PROCESSING(SSobj, src)
+			anchored = 0
+			density = 0
+			user.visible_message( \
+				"[user] detaches \the [src] from the cable.", \
+				"<span class='notice'>You detach \the [src] from the cable.</span>",
+				"<span class='italics'>You hear some wires being disconnected from something.</span>")
+
+/obj/item/energy_harvester/process()
+	if(!attached || !anchored)
+		return PROCESS_KILL
+
+	var/datum/powernet/PN = attached.powernet
+	if(PN)
+		set_light(1,1,LIGHT_COLOR_ORANGE)
+		var/power_avaliable = PN.netexcess
+		if(power_avaliable <= 0)
+			soundloop.stop()
+			active = 0
+			return
+		soundloop.start()
+		active = 1
+		power_avaliable = min(power_avaliable, drain_rate)
+		attached.add_delayedload(power_avaliable)
+		lastprocessed = (power_avaliable * 0.00001)
+		SSshuttle.points += lastprocessed
+
+/obj/item/energy_harvester/Initialize()
+	. = ..()
+	new /obj/item/gps/internal/energy_harvester(src)
+	soundloop = new(list(src), FALSE)
+
+/obj/item/energy_harvester/Destroy()
+	QDEL_NULL(soundloop)
+	return ..()
+
+/obj/item/energy_harvester/examine(mob/user)
+	. = ..()
+	if(active)
+		. += "<span class='notice'>The [src]'s display states that it is processing approximately <b>[lastprocessed*60]</b> credits per minute.</span>"
+	else
+		. += "<span class='notice'><b>The [src]'s display is currently offline.</b></span>"
+
+/obj/item/gps/internal/energy_harvester
+	gpstag = "Energy Harvester"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://i.imgur.com/Wo4a7oS.gif)

Heyo. This is a mini pack of little features that ports the following things:

A new item that can be purchased through cargo, the **Energy Harvester.**
![image](https://user-images.githubusercontent.com/53913550/96978605-e9adf680-14f4-11eb-9332-43f818f9e37c.png)

Its function is to take excess energy from the grid and draw it in pulses, converting that to a sum of credits. Originally from yogstation, I modified it to work with hyper code, have sound feedback and a proper examine, telling you how many credits you're making per minute, approximately. Time to get those ZWs!

Ports Lia, the head of security space carp directly from https://github.com/tgstation/tgstation/pull/52717 and allowing mappers to place her.

Also partially ports the carp buff from https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10894

![image](https://user-images.githubusercontent.com/53913550/96547281-36d66200-1282-11eb-906f-c7642424023d.png)

## Why It's Good For The Game

For the pet, I think it's about time we got the HoS the pet they should've always had.

Carp hp buff: They still go down in 2-3 hits with a spear/tool box and are still not that much of a threat to anyone in space, especially your usual engineer or miner holding the default, out of the box 40 damage PKA. This is more of a change to try and remedy the fact that any space carp that attacks a door has the chance of being one shot by the door's zap mechanics.

And as for the energy harvester... Well, It's one way to make power generation more goon-like, giving you a reason to go absolutely **bonkers mad** with energy setups in order to get more credits for the station.

## Changelog
:cl:
add: Carps have evolved to take more damage
tweak: Kinaris' pet budget has increased, and the HoS's missing pet has been found.
add: Energy Harvester! Purchase it through cargo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
