### PR TITLE
Ports selectable prostethic limbs from Yog + quirk blacklist and two o…

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -12,10 +12,13 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	var/list/quirk_names_by_path = list()
 	var/list/quirk_points = list()	//Assoc. list of quirk names and their "point cost"; positive numbers are good traits, and negative ones are bad
 	var/list/quirk_objects = list()	//A list of all quirk objects in the game, since some may process
+	var/list/quirk_blacklist = list() //A list a list of quirks that can not be used with each other. Format: list(quirk1,quirk2),list(quirk3,quirk4)
 
 /datum/controller/subsystem/processing/quirks/Initialize(timeofday)
 	if(!quirks.len)
 		SetupQuirks()
+
+	quirk_blacklist = list(list("Blind","Nearsighted"),list("Jolly","Depression","Apathetic","Hypersensitive"),list("Ageusia","Vegetarian","Deviant Tastes"),list("Ananas Affinity","Ananas Aversion"),list("Alcohol Tolerance","Light Drinker"),list("Prosthetic Limb (Left Arm)","Prosthetic Limb (Right Arm)","Prosthetic Limb (Left Leg)","Prosthetic Limb (Right Leg)","Prosthetic Limb"),list("Social Anxiety","Mute"))
 	return ..()
 
 /datum/controller/subsystem/processing/quirks/proc/SetupQuirks()

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -91,8 +91,8 @@
 		mood += event.mood_change
 		if(!event.hidden)
 			shown_mood += event.mood_change
-		mood *= mood_modifier
-		shown_mood *= mood_modifier
+	mood *= mood_modifier
+	shown_mood *= mood_modifier
 
 	switch(mood)
 		if(-INFINITY to MOOD_LEVEL_SAD4)

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -119,6 +119,17 @@
 	mood_quirk = TRUE //yogs
 	medical_record_text = "Patient demonstrates a high level of emotional volatility."
 
+/datum/quirk/hypersensitive/add()
+	var/datum/component/mood/mood = quirk_holder.GetComponent(/datum/component/mood)
+	if(mood)
+		mood.mood_modifier += 0.5
+
+/datum/quirk/hypersensitive/remove()
+	if(quirk_holder)
+		var/datum/component/mood/mood = quirk_holder.GetComponent(/datum/component/mood)
+		if(mood)
+			mood.mood_modifier -= 0.5
+
 /datum/quirk/brainproblems
 	name = "Brain Tumor"
 	desc = "You have a little friend in your brain that is slowly destroying it. Better bring some mannitol!"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -110,6 +110,15 @@
 	lose_text = "<span class='notice'>You feel awake again.</span>"
 	medical_record_text = "Patient has abnormal sleep study results and is difficult to wake up."
 
+/datum/quirk/hypersensitive
+	name = "Hypersensitive"
+	desc = "For better or worse, everything seems to affect your mood more than it should."
+	value = -1
+	gain_text = "<span class='danger'>You seem to make a big deal out of everything.</span>"
+	lose_text = "<span class='notice'>You don't seem to make a big deal out of everything anymore.</span>"
+	mood_quirk = TRUE //yogs
+	medical_record_text = "Patient demonstrates a high level of emotional volatility."
+
 /datum/quirk/brainproblems
 	name = "Brain Tumor"
 	desc = "You have a little friend in your brain that is slowly destroying it. Better bring some mannitol!"
@@ -241,6 +250,8 @@
 	desc = "An accident caused you to lose one of your limbs. Because of this, you now have a random prosthetic!"
 	value = -1
 	var/slot_string = "limb"
+	var/specific = null
+	medical_record_text = "During physical examination, patient was found to have a prosthetic limb."
 
 /datum/quirk/prosthetic_limb/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
@@ -249,6 +260,9 @@
 		limb_slot = pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)
 	else
 		limb_slot = pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
+		if(specific)
+			limb_slot = specific
+
 	var/obj/item/bodypart/old_part = H.get_bodypart(limb_slot)
 	var/obj/item/bodypart/prosthetic
 	switch(limb_slot)
@@ -296,6 +310,26 @@
 		return
 	to_chat(quirk_holder, "<span class='big bold info'>Please note that your dissociation syndrome does NOT give you the right to attack people or otherwise cause any interference to \
 	the round. You are not an antagonist, and the rules will treat you the same as other crewmembers.</span>")
+
+/datum/quirk/prosthetic_limb/left_arm
+	name = "Prosthetic Limb (Left Arm)"
+	desc = "An accident caused you to lose your left arm. Because of this, it's replaced with a prosthetic!"
+	specific = BODY_ZONE_L_ARM
+
+/datum/quirk/prosthetic_limb/right_arm
+	name = "Prosthetic Limb (Right Arm)"
+	desc = "An accident caused you to lose your right arm. Because of this, it's replaced with a prosthetic!"
+	specific = BODY_ZONE_R_ARM
+
+/datum/quirk/prosthetic_limb/left_leg
+	name = "Prosthetic Limb (Left Leg)"
+	desc = "An accident caused you to lose your left leg. Because of this, it's replaced with a prosthetic!"
+	specific = BODY_ZONE_L_LEG
+
+/datum/quirk/prosthetic_limb/right_leg
+	name = "Prosthetic Limb (Right Leg)"
+	desc = "An accident caused you to lose your right leg. Because of this, it's replaced with a prosthetic!"
+	specific = BODY_ZONE_R_LEG
 
 /datum/quirk/social_anxiety
 	name = "Social Anxiety"

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -10,6 +10,29 @@
 	lose_text = "<span class='notice'>You can taste again!</span>"
 	medical_record_text = "Patient suffers from ageusia and is incapable of tasting food or reagents."
 
+/datum/quirk/vegetarian
+	name = "Vegetarian"
+	desc = "You find the idea of eating meat morally and physically repulsive."
+	value = 0
+	gain_text = "<span class='notice'>You feel repulsion at the idea of eating meat.</span>"
+	lose_text = "<span class='notice'>You feel like eating meat isn't that bad.</span>"
+	medical_record_text = "Patient reports a vegetarian diet."
+
+/datum/quirk/vegetarian/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/datum/species/species = H.dna.species
+	species.liked_food &= ~MEAT
+	species.disliked_food |= MEAT
+
+/datum/quirk/vegetarian/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		var/datum/species/species = H.dna.species
+		if(initial(species.liked_food) & MEAT)
+			species.liked_food |= MEAT
+		if(!initial(species.disliked_food) & MEAT)
+			species.disliked_food &= ~MEAT
+
 /datum/quirk/pineapple_liker
 	name = "Ananas Affinity"
 	desc = "You find yourself greatly enjoying fruits of the ananas genus. You can't seem to ever get enough of their sweet goodness!"
@@ -102,7 +125,7 @@
 	medical_record_text = "Patient never skipped ass day."
 	gain_text = "<span class='notice'>Your ass rivals those of golems.</span>"
 	lose_text = "<span class='notice'>Your butt feels more squishy and slappable.</span>"
-	
+
 /datum/quirk/headpat_slut
 	name = "Headpat Slut"
 	desc = "You like headpats, alot, maybe even a little bit too much. Headpats give you a bigger mood boost and cause arousal"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1515,6 +1515,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				var/quirk = href_list["trait"]
 				if(!SSquirks.quirks[quirk])
 					return
+				for(var/V in SSquirks.quirk_blacklist) //V is a list
+					var/list/L = V
+					for(var/Q in all_quirks)
+						if((quirk in L) && (Q in L) && !(Q == quirk)) //two quirks have lined up in the list of the list of quirks that conflict with each other, so return (see quirks.dm for more details)
+							to_chat(user, "<span class='danger'>[quirk] is incompatible with [Q].</span>")
+							return
 				var/value = SSquirks.quirk_points[quirk]
 				if(value == 0)
 					if(quirk in neutral_quirks)


### PR DESCRIPTION

## About The Pull Request

This PR ports the seletable prostethic limbs from Yogstation (https://github.com/yogstation13/Yogstation/pull/7060), as a consequence, also adds a blacklist, balancing the use of certain combinations of quirks (aka you can't select mute and have social anxiety at the same time anymore, for exemple, since the last only affects the ability to talk, thus currently being a free point for mute characters).
This also ports two new quirks: hypersensistive (things affect your mod more than normal) and vegetarian.

![image](https://user-images.githubusercontent.com/46802162/96825346-416e3400-1407-11eb-8371-1e7d502387aa.png)
![image](https://user-images.githubusercontent.com/46802162/96825355-48954200-1407-11eb-8e33-73d0240343ac.png)
![image](https://user-images.githubusercontent.com/46802162/96825429-7da19480-1407-11eb-91d0-aaa044c1572f.png)
![image](https://user-images.githubusercontent.com/46802162/96825407-69f62e00-1407-11eb-9627-50e96ba71f46.png)
![image](https://user-images.githubusercontent.com/46802162/96825379-5945b800-1407-11eb-8d74-2a7772e30962.png)
![image](https://user-images.githubusercontent.com/46802162/96825470-94e08200-1407-11eb-8930-416b47c3036f.png)
![image](https://user-images.githubusercontent.com/46802162/96825481-9b6ef980-1407-11eb-84c8-3b339b09cf41.png)

## Why It's Good For The Game

It somewhat improves the character creation, opens more space for RP opportunities and balances the use of some quirks.

## Changelog
:cl:
add: seletable prostethic limbs quirks;
add: hypersensistive quirk;
add: vegetarian quirk;
add: blacklist for some quirks
/:cl:

