### PR TITLE
Fixes Meatwheat Poisoning, Wrong Simplemob Gibs and a runtime.

### DIFF
--- a/code/modules/food_and_drinks/food/snacks/meat.dm
+++ b/code/modules/food_and_drinks/food/snacks/meat.dm
@@ -224,7 +224,7 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/meatwheat
 	name = "meatwheat clump"
 	desc = "This doesn't look like meat, but your standards aren't <i>that</i> high to begin with."
-	list_reagents = list("nutriment" = 3, "vitamin" = 2, "blood" = 5, "cooking_oil" = 1)
+	list_reagents = list("nutriment" = 3, "vitamin" = 2, "cooking_oil" = 1)
 	filling_color = rgb(150, 0, 0)
 	icon_state = "meatwheat_clump"
 	bitesize = 4

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -21,7 +21,7 @@
 
 /mob/living/proc/spawn_gibs(with_bodyparts, atom/loc_override)
 	var/location = loc_override ? loc_override.drop_location() : drop_location()
-	if(mob_biotypes & MOB_ROBOTIC)
+	if(MOB_ROBOTIC in mob_biotypes)
 		new /obj/effect/gibspawner/robot(location, src, get_static_viruses())
 	else
 		new /obj/effect/gibspawner/generic(location, src, get_static_viruses())

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -164,7 +164,7 @@
 			if(starting)
 				splatter_dir = get_dir(starting, target_loca)
 			var/obj/item/bodypart/B = L.get_bodypart(def_zone)
-			if(B.status == BODYPART_ROBOTIC) // So if you hit a robotic, it sparks instead of bloodspatters
+			if(B && B.status == BODYPART_ROBOTIC) // So if you hit a robotic, it sparks instead of bloodspatters
 				do_sparks(2, FALSE, target.loc)
 				if(prob(25))
 					new /obj/effect/decal/cleanable/oil(target_loca)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports the following fixes from cit:
Removes blood from meatwheat, preventing poisoning due to incompatible blood types, fixes the wrong gibs being thrown when simplemobs get butchered and one runtime that happens when shooting certain robotics.

## Why It's Good For The Game

I don't feel like I want the chef to get lynched for accidentally poisoning the crew because of incompatible blood. Also, runtime man bad.

## Changelog
:cl:
fix: simplemob correct gibs
tweak: meatwheat no longer has blood
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
