### PR TITLE
Superior medicines are actually superior now

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -291,7 +291,7 @@
 	if(M.getFireLoss() > 30)
 		M.adjustFireLoss(-4*REM, 0) //Twice as effective as silver sulfadiazine for severe burns
 	else
-		M.adjustFireLoss(-2*REM, 0) //But only a quarter as effective for more minor ones
+		M.adjustFireLoss(-2*REM, 0) //Just as good as base for minor ones
 	..()
 	. = 1
 
@@ -595,7 +595,7 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 	if(M.getBruteLoss() > 30)
 		M.adjustBruteLoss(-4*REM, 0) //Twice as effective as styptic powder for severe bruising
 	else
-		M.adjustBruteLoss(-2*REM, 0) //But only a quarter as effective for more minor ones
+		M.adjustBruteLoss(-2*REM, 0) //Just as good as base for minor ones
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -288,10 +288,10 @@
 	value = 4
 
 /datum/reagent/medicine/oxandrolone/on_mob_life(mob/living/carbon/M)
-	if(M.getFireLoss() > 25)
+	if(M.getFireLoss() > 30)
 		M.adjustFireLoss(-4*REM, 0) //Twice as effective as silver sulfadiazine for severe burns
 	else
-		M.adjustFireLoss(-0.5*REM, 0) //But only a quarter as effective for more minor ones
+		M.adjustFireLoss(-2*REM, 0) //But only a quarter as effective for more minor ones
 	..()
 	. = 1
 
@@ -592,10 +592,10 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 
 
 /datum/reagent/medicine/sal_acid/on_mob_life(mob/living/carbon/M)
-	if(M.getBruteLoss() > 25)
+	if(M.getBruteLoss() > 30)
 		M.adjustBruteLoss(-4*REM, 0) //Twice as effective as styptic powder for severe bruising
 	else
-		M.adjustBruteLoss(-0.5*REM, 0) //But only a quarter as effective for more minor ones
+		M.adjustBruteLoss(-2*REM, 0) //But only a quarter as effective for more minor ones
 	..()
 	. = 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases the "ultra-effective" threshold from 25 to 30 on Salicylic Acid and Oxandrolone (nerf for balance)
Increases the "basic" healing to match basic medicines on Salicylic Acid and Oxandrolone (buff)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Salicylic Acid is made using eight of the base reagents.
Bicaridine takes only three.
Oxandrolone is made using six of the base reagents.
Kelotane takes only two.
Known as "Superior Medicines" and clearly taking at least a little more effort than their "Basic Medicine" cousins, Bicaridine and Kelotane, there should be no competition between them. And yet, there is. As soon as your damage is less than 25, these higher effort medicines are suddenly dogshit compared to their two-click and three-click twins. To this issue, there are two solutions as I see it. Nerf the base medicines or buff the superior ones. Nerfing the easy peasy medicines is just going to scare off more new medical players, which we really don't need. Thus, this is the best option. If these numbers don't quite seem right, they are of course negotiable, but I simply refuse to allow my superior medicines to get bullied by the commoner-drugs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Healing on lower amounts of damage for Salicyclic Acid and Oxandrolone now matches Bicaridine and Kelotane.
balance: The superheal damage threshold for said medicines has been increased to 30
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
