### PR TITLE
Spooky meteors now only replace catstrophic instead of -every type- and also fixes two broken autobottler designs

### DIFF
--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -32,8 +32,6 @@
 		determine_wave_type()
 
 /datum/round_event/meteor_wave/proc/determine_wave_type()
-	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
-		wave_name = "halloween"
 	if(!wave_name)
 		wave_name = pickweight(list(
 			"normal" = 50,
@@ -45,7 +43,10 @@
 		if("threatening")
 			wave_type = GLOB.meteors_threatening
 		if("catastrophic")
-			wave_type = GLOB.meteors_catastrophic
+			if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+				wave_type = GLOB.meteorsSPOOKY
+			else
+				wave_type = GLOB.meteors_catastrophic
 		if("meaty")
 			wave_type = GLOB.meteorsB
 		if("space dust")

--- a/code/modules/research/designs/autobotter_designs.dm
+++ b/code/modules/research/designs/autobotter_designs.dm
@@ -307,7 +307,7 @@
 	desc = "Allows for the blowing, and bottling of Blooddrop bottles."
 	id = "blooddrop"
 	category = list("Wines")
-	reagents_list = list("champagne" = 30, "co2" = 30, "wine" = 10, "grape_juice" = 30)
+	reagents_list = list("champagne" = 30, "co2" = 30, "wine" = 10, "grapejuice" = 30)
 	build_path = /obj/item/export/bottle/blooddrop
 
 /datum/design/bottle/export/slim_gold
@@ -323,7 +323,7 @@
 	desc = "Allows for the blowing, and bottling of White Bloodmoon bottles."
 	id = "white_bloodmoon"
 	category = list("Wines")
-	reagents_list = list("synthflesh" = 50, "blood" = 50, "gib" = 10)
+	reagents_list = list("synthflesh" = 50, "blood" = 50, "liquidgibs" = 10)
 	build_path = /obj/item/export/bottle/white_bloodmoon
 
 /datum/design/bottle/export/greenroad


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Eh, reagents are dumb. ID reagents soonTM.
Also, turns out meteors are shitcode, yo

## Why It's Good For The Game

**Who would win, a state of the art space station outfitted with the best technology and the brightest minds sent by mankind or one spooky rock?**
oh yea let's not have the game replace dust storms with spooky meteors every year (no I hadn't even touched this)

## Changelog
:cl:
fix: broken autobottler designs
balance: Spooky meteors now only replace catstrophic instead of -every type-
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
