### PR TITLE
Revenant Fixes & Balancing

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -1,4 +1,4 @@
-#define REVENANT_SPAWN_THRESHOLD 20
+#define REVENANT_SPAWN_THRESHOLD 15
 #define ABDUCTOR_MAX_TEAMS 4 // blame TG for not using the defines files
 
 //////////////////////////////////////////////

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -8,7 +8,7 @@
 		AltClickNoInteract(src, A)
 		return
 
-	if(ishuman(A))
+	if(iscarbon(A))
 		if(A in drained_mobs)
 			to_chat(src, "<span class='revenwarning'>[A]'s soul is dead and empty.</span>" )
 		else if(in_range(src, A))
@@ -16,7 +16,7 @@
 
 
 //Harvest; activated ly clicking the target, will try to drain their essence.
-/mob/living/simple_animal/revenant/proc/Harvest(mob/living/carbon/human/target)
+/mob/living/simple_animal/revenant/proc/Harvest(mob/living/carbon/target)
 	if(!castcheck(0))
 		return
 	if(draining)
@@ -206,7 +206,7 @@
 	if(!L.on) //wait, wait, don't shock me
 		return
 	flick("[L.base_state]2", L)
-	for(var/mob/living/carbon/human/M in view(shock_range, L))
+	for(var/mob/living/carbon/M in view(shock_range, L))
 		if(M == user)
 			continue
 		L.Beam(M,icon_state="purple_lightning",time=5)

--- a/code/modules/antagonists/revenant/revenant_spawn_event.dm
+++ b/code/modules/antagonists/revenant/revenant_spawn_event.dm
@@ -1,4 +1,4 @@
-#define REVENANT_SPAWN_THRESHOLD 20
+#define REVENANT_SPAWN_THRESHOLD 15
 
 /datum/round_event_control/revenant
 	name = "Spawn Revenant" // Did you mean 'griefghost'?
@@ -19,7 +19,7 @@
 /datum/round_event/ghost_role/revenant/spawn_role()
 	if(!ignore_mobcheck)
 		var/deadMobs = 0
-		for(var/mob/M in GLOB.dead_mob_list)
+		for(var/mob/living/carbon/M in GLOB.dead_mob_list)
 			deadMobs++
 		if(deadMobs < REVENANT_SPAWN_THRESHOLD)
 			message_admins("Event attempted to spawn a revenant, but there were only [deadMobs]/[REVENANT_SPAWN_THRESHOLD] dead mobs.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Previously, the code which checked how many dead mobs there are only checked for var/mob, meaning it would check for everything even if the revenant cannot draw essence from simplemobs.

Now, it properly searches for /living/carbon, draw essence works on subtypes of living/carbon instead of carbon/human so they can also draw essence from any other races that don't inherit carbon/human directly.

Overload lights also works for living/carbon instead of living/carbon/human, which lets it also zap those races.

REVENANT_SPAWN_THRESHOLD is also modified to account for this new change, requiring 15 bodies instead of 20 now that it actually looks for the proper type.

## Why It's Good For The Game

Because spawning revenants around when there are 20 dead bees is not something that should happen.

## Changelog
:cl:
balance: revenant tweaks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
