### PR TITLE
Combustible Lemons - To be or not to be?

### DIFF
--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -112,6 +112,7 @@
 	icon_grow = "lime-grow"
 	icon_dead = "lime-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
+	mutatelist = list(/obj/item/seeds/firelemon)
 	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.05)
 
 /obj/item/reagent_containers/food/snacks/grown/citrus/lemon

--- a/code/modules/research/xenoarch/artifact.dm
+++ b/code/modules/research/xenoarch/artifact.dm
@@ -89,7 +89,6 @@
 								/obj/item/seeds/cherry/bomb,
 								/obj/item/seeds/gatfruit,
 								/obj/item/seeds/kudzu,
-								/obj/item/seeds/firelemon,
 								/obj/item/seeds/random
 								))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Seems those were in xenoarch, however, in the upstream these are normally obtainable through mutations. Should we add these?

## Why It's Good For The Game

I dunno, more stuff for T botany seems neat tbh

## Changelog
:cl:
add: lemons can mutate into combustible lemons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
