### PR TITLE
Blacklists some animals (such as megafauna and ghosts) from being targeted by sentience events

### DIFF
--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -1,3 +1,11 @@
+/var/list/blacklisted_sentient_animals = typecacheof(list(
+	/mob/living/simple_animal/slime,
+	/mob/living/simple_animal/hostile/megafauna,
+	/mob/living/simple_animal/hostile/blob,
+	/mob/living/simple_animal/jacq,
+	/mob/living/simple_animal/holodeck_monkey,
+	/mob/living/simple_animal/astral))
+
 /datum/round_event_control/sentience
 	name = "Random Human-level Intelligence"
 	typepath = /datum/round_event/ghost_role/sentience
@@ -32,6 +40,8 @@
 	for(var/mob/living/simple_animal/L in GLOB.alive_mob_list)
 		var/turf/T = get_turf(L)
 		if(!T || !is_station_level(T.z))
+			continue
+		if(is_type_in_typecache(L, blacklisted_sentient_animals))
 			continue
 		if(!(L in GLOB.player_list) && !L.mind)
 			potential += L


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simple QoL PR. Certain animals are either not compatible or outright stupid to be targets of the sentience, such as ghosts, megafauna (in the off chance that someone brings bubblegum to the station and that one random sentience event triggers) and those slimes that have been left to die by the local xenobiologist.

## Why It's Good For The Game

light pink baby slime (450) has died at Xenobiology Lab.
red adult slime (588) has died at Xenobiology Lab.
purple baby slime (90) has died at Xenobiology Lab.
purple adult slime (97) has died at Xenobiology Lab.
blue baby slime (325) has died at Xenobiology Lab.

yeah let's not do that

## Changelog
:cl:
balance: no more unkillable or straight unfun sentient animals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
