### PR TITLE
Revert Reebe on mapload

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -91,7 +91,7 @@ SUBSYSTEM_DEF(mapping)
 		seedRuins(space_ruins, CONFIG_GET(number/space_budget), /area/space, space_ruins_templates)
 	SSmapping.seedStation()
 	loading_ruins = FALSE
-
+	/*
 	//Hyper change - preload Reebe for midround purposes. I'll change this when I find a decent way to load maps midround.
 	var/list/errorList = list()
 	var/list/reebes = SSmapping.LoadGroup(errorList, "Reebe", "map_files/generic", "City_of_Cogs.dmm", default_traits = ZTRAITS_REEBE, silent = TRUE)
@@ -101,7 +101,7 @@ SUBSYSTEM_DEF(mapping)
 		return FALSE
 	for(var/datum/parsed_map/PM in reebes)
 		PM.initTemplateBounds()
-	
+	*/
 #endif
 	repopulate_sorted_areas()
 	// Set up Z-level transitions.

--- a/code/modules/cargo/bounties/engineering.dm
+++ b/code/modules/cargo/bounties/engineering.dm
@@ -23,13 +23,7 @@
 	name = "Full Tank of Tritium"
 	description = "Station 42 is looking to kickstart their research program. Ship them a tank full of Tritium."
 	gas_type = /datum/gas/tritium
-//Hyperstation edit
-/datum/bounty/item/engineering/gas/hypernoblium_tank
-	name = "Full Tank of Hyper-Noblium"
-	description = "The 7th Echelon is looking to research the effects of this rare gas in organics. They ask for a full tank of it. Are you up to the task?"
-	gas_type = /datum/gas/hypernoblium
-	reward = 75000 //Very, very difficult to make, requires a fuckton of structural re-design around engineering and can actually royally fuck up the entirety of the station if not done correctly.
-//Hypersation edit end
+
 /datum/bounty/item/engineering/pacman
 	name = "P.A.C.M.A.N.-type portable generator"
 	description = "A neighboring station had a problem with their SMES, and now need something to power their communications console. Can you send them a P.AC.M.A.N.?"

--- a/code/modules/cargo/bounties/engineering.dm
+++ b/code/modules/cargo/bounties/engineering.dm
@@ -23,7 +23,13 @@
 	name = "Full Tank of Tritium"
 	description = "Station 42 is looking to kickstart their research program. Ship them a tank full of Tritium."
 	gas_type = /datum/gas/tritium
-
+//Hyperstation edit
+/datum/bounty/item/engineering/gas/hypernoblium_tank
+	name = "Full Tank of Hyper-Noblium"
+	description = "The 7th Echelon is looking to research the effects of this rare gas in organics. They ask for a full tank of it. Are you up to the task?"
+	gas_type = /datum/gas/hypernoblium
+	reward = 75000 //Very, very difficult to make, requires a fuckton of structural re-design around engineering and can actually royally fuck up the entirety of the station if not done correctly.
+//Hypersation edit end
 /datum/bounty/item/engineering/pacman
 	name = "P.A.C.M.A.N.-type portable generator"
 	description = "A neighboring station had a problem with their SMES, and now need something to power their communications console. Can you send them a P.AC.M.A.N.?"

--- a/config/config.txt
+++ b/config/config.txt
@@ -475,3 +475,6 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 ##	For reference, Goonstation uses a resolution of 21x15 for it's widescreen mode.
 ##	Do note that changing this value will affect the title screen. The title screen will have to be updated manually if this is changed.
 DEFAULT_VIEW 21x15
+
+## Enable Dynamic mode
+DYNAMIC_MODE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disables the reebe from loading on mapload, as the smaller reebe seems to load perfectly fine with the multi z updates and box station doesn't spawn amidst ruins.

Also permanently adds dynamic to the config.txt, since we have it active anyway.

## Why It's Good For The Game

no eldritch affair shenanigans

## Changelog
:cl:
revert: reebe spawning on roundload
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
