### PR TITLE
Fixes Infinite Slime Exploit + Fixes invincible runtime

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -294,7 +294,12 @@
 	if(!SSticker.HasRoundStarted())
 		to_chat(M, "You cannot attack people before the game has started.")
 		return
-
+//Hyperstation Edit
+	if(istype(src, /mob/living/simple_animal/slime))
+		M.visible_message("<span class='notice'>[M] boops \the [src].</span>","<span class='notice'>You boop \the [src].</span>")
+		//This was made to prevent sentient slime players from exploting removing infinite nutrient from other slimes.
+		return
+//End of hyperstation edit
 	if(M.buckled)
 		if(M in buckled_mobs)
 			M.Feedstop()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -294,12 +294,7 @@
 	if(!SSticker.HasRoundStarted())
 		to_chat(M, "You cannot attack people before the game has started.")
 		return
-//Hyperstation Edit
-	if(istype(src, /mob/living/simple_animal/slime))
-		M.visible_message("<span class='notice'>[M] boops \the [src].</span>","<span class='notice'>You boop \the [src].</span>")
-		//This was made to prevent sentient slime players from exploting removing infinite nutrient from other slimes.
-		return
-//End of hyperstation edit
+
 	if(M.buckled)
 		if(M in buckled_mobs)
 			M.Feedstop()

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -113,30 +113,26 @@
 		icon_dead = "original_dead"
 	//Read_Memory()
 	. = ..()
-
+/*
 /mob/living/simple_animal/pet/cat/Runtime/Life()
-	/*
 	if(!cats_deployed && SSticker.current_state >= GAME_STATE_SETTING_UP)
 		Deploy_The_Cats()
 	if(!stat && SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)
 		Write_Memory()
 		memory_saved = TRUE
-	*/
 	..()
-
+*/
 /mob/living/simple_animal/pet/cat/Runtime/make_babies()
 	var/mob/baby = ..()
 	if(baby)
 		children += baby
 		return baby
-
-/mob/living/simple_animal/pet/cat/Runtime/death()
 /*
+/mob/living/simple_animal/pet/cat/Runtime/death()
 	if(!memory_saved)
 		Write_Memory(TRUE)
 	..()
 */
-
 /mob/living/simple_animal/pet/cat/Runtime/proc/Read_Memory()
 	if(fexists("data/npc_saves/Runtime.sav")) //legacy compatability to convert old format to new
 		var/savefile/S = new /savefile("data/npc_saves/Runtime.sav")

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -260,7 +260,7 @@
 		visible_message("<span class='danger'>[M] pulls [src] off!</span>")
 		return
 	attacked += 5
-	if(nutrition >= 100) //steal some nutrition. negval handled in life()
+	if(nutrition >= 100 && !istype(src, /mob/living/simple_animal/slime)) //steal some nutrition. negval handled in life()
 		nutrition -= (50 + (40 * M.is_adult))
 		M.add_nutrition(50 + (40 * M.is_adult))
 	if(health > 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. Due to an exploit regarding how you can attack other slimes to infinitely generate more slimes, I made it so slimes cannot gain nutrient by attacking other slimes.

This also fixes the issue with runtime being invincible.

## Why It's Good For The Game

Exploits are bad, yo. Invincible runtime is also bad.

## Changelog
:cl:
fix: invincible runtime is no longer invincible
balance: slimes are now completely prevented from obtaining nutrient from other slimes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
