### PR TITLE
[Proposal] Makes radiation resonance less undesirable.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -123,6 +123,7 @@
 #define	TRAIT_CALCIUM_HEALER	"calcium_healer"
 #define TRAIT_ALCOHOL_LIGHTWEIGHT	"alcohol_lightweight" //Skyrat port
 #define TRAIT_CURSED_BLOOD	"cursed_blood" //Yo dawg I heard you like bloodborne references so I put a
+#define TRAIT_RADRESONANCE "radioactive resonance" //Hyperstation edit
 
 #define TRAIT_SWIMMING			"swimming"			//only applied by /datum/element/swimming, for checking
 #define TRAIT_CAPTAIN_METABOLISM "captain-metabolism"

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -445,6 +445,7 @@
 		power = 2
 	if(A.properties["transmittable"] >= 6)
 		cellular_damage = TRUE
+	ADD_TRAIT(A.affected_mob, TRAIT_RADRESONANCE, DISEASE_TRAIT)
 
 /datum/symptom/heal/radiation/CanHeal(datum/disease/advance/A)
 	var/mob/living/M = A.affected_mob
@@ -482,3 +483,8 @@
 		if(L.heal_damage(heal_amt/parts.len, heal_amt/parts.len))
 			M.update_damage_overlays()
 	return 1
+
+/datum/symptom/heal/radiation/End(datum/disease/advance/A)
+	if(!..())
+		return
+	REMOVE_TRAIT(A.affected_mob, TRAIT_RADRESONANCE, DISEASE_TRAIT)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1305,6 +1305,10 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		radiation = 0
 		return TRUE
 
+	if(HAS_TRAIT(H, TRAIT_RADRESONANCE))
+		//Don't do anything.
+		return TRUE
+
 	if(radiation > RAD_MOB_KNOCKDOWN && prob(RAD_MOB_KNOCKDOWN_PROB))
 		if(!H.IsKnockdown())
 			H.emote("collapse")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes a virus with the radioactive resonance turn its carrier "immune" to radiation. (They still carry radiation, but will not receive the negative effects of such)
Note: Races that are immune to radiation will still not have any benefits from this.
Intentionally does not protect one from radioactive storms, but that can be changed.

## Why It's Good For The Game

Currently, radioactive resonance is one of the most undesirable positive virus traits. Why? Well, it never really stops you from mutating all to hell and/or giving you negative effects. No virologist that I have ever seen has -ever- used radioactive resonance because it's just... Bad. This should balance it, but requires proper testing.

## Changelog
:cl:
balance: Makes the radiation resonance trait less undesirable in virology.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
