### PR TITLE
Ashwalkers to station for no raisen

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -47,7 +47,8 @@
 	move_resist = MOVE_FORCE_NORMAL
 	density = FALSE
 	flavour_text = "<span class='big bold'>You are an ash walker.</span><b> Your tribe worships <span class='danger'>the Necropolis</span>. The wastes are sacred ground, its monsters a blessed bounty. \
-	You have seen lights in the distance... they foreshadow the arrival of outsiders that seek to tear apart the Necropolis and its domain. Fresh sacrifices for your nest.</b>"
+	You have seen lights in the distance... they foreshadow the arrival of outsiders that seek to tear apart the Necropolis and its domain. Fresh sacrifices for your nest. \
+	For what lies beyond the lights, you get the impression that going towards it is forbidden, rumors say <span class='danger'>the Necropolis</span> does not favor those who leave the sacred ground. </b>"
 	assignedrole = "Ash Walker"
 
 /obj/effect/mob_spawn/human/ash_walker/special(mob/living/new_spawn)


### PR DESCRIPTION

## About The Pull Request

Simply makes it that the ghost role flavor text spawn tells them that it's simply not okay to just run up onto station as an ashwalker. Fight on home turf!

## Why It's Good For The Game

Quality of life for staff to bwoink players that try to rule lawyer their way out a situation due to flavour text saying that 'it doesn't say you can't go on station.' Lets fix that.

## Changelog
:cl:
add: Added words
admin: Can now bwoink the ash walker on station with a chainsaw.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
