### PR TITLE
Adds a radioactive type of greenglow cleanable decal

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -265,7 +265,7 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 /obj/effect/meteor/irradiated/meteor_effect()
 	..()
 	explosion(src.loc, 0, 0, 4, 3, 0)
-	new /obj/effect/decal/cleanable/greenglow(get_turf(src))
+	new /obj/effect/decal/cleanable/greenglow/radioactive(get_turf(src))
 	radiation_pulse(src, 500)
 
 //Meaty Ore

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -84,6 +84,29 @@
 	. = ..()
 	set_light(2, 0.8, "#22FFAA")
 
+/obj/effect/decal/cleanable/greenglow/radioactive
+	name = "radioactive hazard"
+	desc = "You should really clean this up..."
+	var/rad_pulse_strength = 5
+	var/last_event = 0
+	var/active = null
+
+/obj/effect/decal/cleanable/greenglow/radioactive/Crossed(atom/movable/O)
+	. = ..()
+	if(ismob(O))
+		radiate()
+		
+/obj/effect/decal/cleanable/greenglow/radioactive/proc/radiate()
+	if(!active)
+		if(world.time > last_event+15)
+			active = 1
+			radiation_pulse(src, rad_pulse_strength)
+			for(var/obj/effect/decal/cleanable/greenglow/radioactive/T in orange(1,src))
+				T.radiate()
+			last_event = world.time
+			active = 0
+			return
+
 /obj/effect/decal/cleanable/greenglow/ex_act()
 	return
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1096,9 +1096,9 @@
 /datum/reagent/radium/reaction_turf(turf/T, reac_volume)
 	if(reac_volume >= 3)
 		if(!isspaceturf(T))
-			var/obj/effect/decal/cleanable/greenglow/GG = locate() in T.contents
+			var/obj/effect/decal/cleanable/greenglow/radioactive/GG = locate() in T.contents
 			if(!GG)
-				GG = new/obj/effect/decal/cleanable/greenglow(T)
+				GG = new/obj/effect/decal/cleanable/greenglow/radioactive(T)
 			GG.reagents.add_reagent("radium", reac_volume)
 
 /datum/reagent/space_cleaner/sterilizine
@@ -1186,9 +1186,9 @@
 /datum/reagent/uranium/reaction_turf(turf/T, reac_volume)
 	if(reac_volume >= 3)
 		if(!isspaceturf(T))
-			var/obj/effect/decal/cleanable/greenglow/GG = locate() in T.contents
+			var/obj/effect/decal/cleanable/greenglow/radioactive/GG = locate() in T.contents
 			if(!GG)
-				GG = new/obj/effect/decal/cleanable/greenglow(T)
+				GG = new/obj/effect/decal/cleanable/greenglow/radioactive(T)
 			GG.reagents.add_reagent("uranium", reac_volume)
 
 /datum/reagent/bluespace


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a subtype of the greenglow decal which is moderately radioactive (pulses of 5) when stepped on/crossed
(Note, this is not even close to the amount of radiation uranium tiles give when stepped on)

## Why It's Good For The Game

It's just a fluff thing that I thought of when looking at decals and realizing there was never any type of radiation for the ones created by irradiated meteors or spilling uranium/radium.

## Changelog
:cl:
add: radioactive hazard decal type
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
