### PR TITLE
ATMOS Firelocks and more

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -26,7 +26,7 @@
 //Research point amounts
 #define NOBLIUM_RESEARCH_AMOUNT				100
 #define BZ_RESEARCH_AMOUNT					15
-#define MIASMA_RESEARCH_AMOUNT				16
+#define MIASMA_RESEARCH_AMOUNT				6		//lolno, fart gas 2 ez
 #define STIMULUM_RESEARCH_AMOUNT			50
 //Plasma fusion properties
 #define FUSION_ENERGY_THRESHOLD				3e9 	//Amount of energy it takes to start a fusion reaction

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -123,7 +123,7 @@
 #define	TRAIT_CALCIUM_HEALER	"calcium_healer"
 #define TRAIT_ALCOHOL_LIGHTWEIGHT	"alcohol_lightweight" //Skyrat port
 #define TRAIT_CURSED_BLOOD	"cursed_blood" //Yo dawg I heard you like bloodborne references so I put a
-#define TRAIT_RADRESONANCE "radioactive resonance" //Hyperstation edit
+#define TRAIT_RADRESONANCE "radioactive_resonance" //Hyperstation edit
 
 #define TRAIT_SWIMMING			"swimming"			//only applied by /datum/element/swimming, for checking
 #define TRAIT_CAPTAIN_METABOLISM "captain-metabolism"

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -78,9 +78,17 @@
 
 /obj/item/holosign_creator/atmos
 	name = "ATMOS holofan projector"
-	desc = "A holographic projector that creates holographic fans that prevent changes in atmosphere conditions."
+	desc = "A holographic projector that creates holographic fans that prevent changes in atmosphere conditions. Somehow."
 	icon_state = "signmaker_atmos"
 	holosign_type = /obj/structure/holosign/barrier/atmos
+	creation_time = 0
+	max_signs = 3
+
+/obj/item/holosign_creator/firelock
+	name = "ATMOS holofirelock projector"
+	desc = "A holographic projector that creates holographic barriers that prevent changes in temperature conditions."
+	icon_state = "signmaker_engi"
+	holosign_type = /obj/structure/holosign/barrier/firelock
 	creation_time = 0
 	max_signs = 3
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -98,6 +98,7 @@
 	new /obj/item/tank/internals/emergency_oxygen/engi(src)
 	new /obj/item/analyzer(src)
 	new /obj/item/holosign_creator/atmos(src)
+	new /obj/item/holosign_creator/firelock(src)
 	new /obj/item/watertank/atmos(src)
 	new /obj/item/clothing/suit/fire/atmos(src)
 	new /obj/item/clothing/head/hardhat/atmos(src)

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -67,8 +67,8 @@
 	rad_insulation = RAD_LIGHT_INSULATION
 
 /obj/structure/holosign/barrier/atmos
-	name = "holo firelock"
-	desc = "A holographic barrier resembling a firelock. Though it does not prevent solid objects from passing through, gas is kept out."
+	name = "holo fan"
+	desc = "A holographic barrier resembling a tiny fan. Though it does not prevent solid objects from passing through, gas is kept out. Somehow."
 	icon_state = "holo_fan"
 	density = FALSE
 	layer = ABOVE_MOB_LAYER
@@ -81,7 +81,16 @@
 	. = ..()
 	air_update_turf(TRUE)
 
-/obj/structure/holosign/barrier/atmos/blocksTemperature()
+/obj/structure/holosign/barrier/firelock
+	name = "holo firelock"
+	desc = "A holographic barrier resembling a firelock. Though it does not prevent solid objects or gas from passing through, temperature changes are kept out."
+	icon_state = "holo_firelock"
+	density = FALSE
+	anchored = TRUE
+	alpha = 150
+	resistance_flags = FIRE_PROOF
+
+/obj/structure/holosign/barrier/firelock/blocksTemperature()
 	return TRUE
 
 /obj/structure/holosign/barrier/cyborg

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -387,8 +387,6 @@
 	if(blocks_air)
 		..()
 		return
-
-	
 	for (var/atom/movable/G in src)
 		if (G.blocksTemperature())
 			return
@@ -410,10 +408,8 @@
 
 				if(!neighbor.thermal_conductivity)
 					continue
-
 				if(neighbor.archived_cycle < SSair.times_fired)
 					neighbor.archive()
-
 				neighbor.neighbor_conduct_with_src(src)
 
 				neighbor.consider_superconductivity()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -59,7 +59,7 @@
 		B = new(T)
 	if(data["blood_DNA"])
 		B.blood_DNA[data["blood_DNA"]] = data["blood_type"]
-	if(!B.reagents)
+	if(B.reagents)
 		B.reagents.add_reagent(id, reac_volume)
 	B.update_icon()
 

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -408,6 +408,16 @@
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
+/datum/design/holosignfirelock
+	name = "ATMOS Holofirelock Projector"
+	desc = "A holographic projector that creates holographic barriers that prevent changes in temperature conditions."
+	id = "holosignfirelock"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 5000, MAT_GLASS = 1000, MAT_GOLD = 1000, MAT_SILVER = 1000)
+	build_path = /obj/item/holosign_creator/firelock
+	category = list("Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+
 /datum/design/forcefield_projector
 	name = "Forcefield Projector"
 	desc = "A device which can project temporary forcefields to seal off an area."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -413,7 +413,7 @@
 	display_name = "Electromagnetic Theory"
 	description = "Study into usage of frequencies in the electromagnetic spectrum."
 	prereq_ids = list("base")
-	design_ids = list("holosign", "holosignsec", "holosignengi", "holosignatmos", "inducer", "tray_goggles", "holopad")
+	design_ids = list("holosign", "holosignsec", "holosignengi", "holosignatmos", "holosignfirelock", "inducer", "tray_goggles", "holopad")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Improvements all around. Couple of dumb runtime fixes, nerf to science miasma research point generation (haha almost the same research points as making bz? lolno) and finally, the long requested atmos holo firelocks are here.

![image](https://user-images.githubusercontent.com/53913550/99676228-fcb1d900-2a56-11eb-9dbd-8f95039261de.png)


## Why It's Good For The Game

Because having NOTHING be able to fully block temperatures is real bad.

## Changelog
:cl:
add: atmos holo firelocks
balance: miasma research points lowered
fix: typos from my rad resonance update
fix: one runtime involving blood puddles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
