### PR TITLE
Adds the REAL black suit and an unobtainable tie to the loadout.

### DIFF
--- a/modular_citadel/code/modules/client/loadout/neck.dm
+++ b/modular_citadel/code/modules/client/loadout/neck.dm
@@ -13,6 +13,11 @@
 	category = SLOT_NECK
 	path = /obj/item/clothing/neck/tie/black
 
+/datum/gear/bloodredtie
+	name = "Blood-red tie"
+	category = SLOT_NECK
+	path = /obj/item/clothing/neck/tie/bloodred
+
 /datum/gear/collar
 	name = "Collar"
 	category = SLOT_NECK

--- a/modular_citadel/code/modules/client/loadout/suit.dm
+++ b/modular_citadel/code/modules/client/loadout/suit.dm
@@ -208,3 +208,8 @@
 	name = "Kromatose Short Jacket"
 	category = SLOT_WEAR_SUIT
 	path = /obj/item/clothing/suit/polychromic/kromacrop
+
+/datum/gear/blacksuitjacket
+	name = "Black Suit Jacket"
+	category = SLOT_WEAR_SUIT
+	path =	/obj/item/clothing/suit/toggle/lawyer/black

--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -38,6 +38,11 @@
 	category = SLOT_W_UNIFORM
 	path = /obj/item/clothing/under/suit_jacket/white
 
+/datum/gear/suitblackreal
+	name = "Black suit shirt"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/lawyer/blacksuit
+
 /datum/gear/galaxy_b
 	name = "De Void of Soul"
 	category = SLOT_W_UNIFORM

--- a/modular_citadel/code/modules/custom_loadout/custom_items.dm
+++ b/modular_citadel/code/modules/custom_loadout/custom_items.dm
@@ -288,7 +288,7 @@
 
 /obj/item/clothing/neck/tie/bloodred
 	name = "blood-red tie"
-	desc = "A neosilk clip-on tie. This one has a black S on the tipping and looks rather suspicious."
+	desc = "A neosilk tie. This one has a black S on the tipping and looks rather suspicious."
 	icon = 'icons/obj/custom.dmi'
 	icon_state = "bloodredtie"
 	alternate_worn_icon = 'icons/mob/custom_w.dmi'

--- a/modular_citadel/code/modules/custom_loadout/custom_items.dm
+++ b/modular_citadel/code/modules/custom_loadout/custom_items.dm
@@ -287,8 +287,8 @@
 	mutantrace_variation = NO_MUTANTRACE_VARIATION
 
 /obj/item/clothing/neck/tie/bloodred
-	name = "Blood Red Tie"
-	desc = "A neosilk clip-on tie. This one has a black S on the tipping and looks rather unique."
+	name = "blood-red tie"
+	desc = "A neosilk clip-on tie. This one has a black S on the tipping and looks rather suspicious."
 	icon = 'icons/obj/custom.dmi'
 	icon_state = "bloodredtie"
 	alternate_worn_icon = 'icons/mob/custom_w.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the black suit and black suit jacket to the loadout. Changes an unobtainable item's name to not be weirdly capitalized, and adds that to the loadout too; the blood-red tie. It's a donor item seemingly left behind from citadel or something, thus being unobtainable. It has no armor or anything, it just looks good.
![image](https://user-images.githubusercontent.com/44104681/99861376-dded3880-2b63-11eb-8eef-9ec2b723ad3e.png)
![image](https://user-images.githubusercontent.com/44104681/99861399-f1989f00-2b63-11eb-8fff-345851bf46e8.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Now the crew can come to work looking professional, and an item that was taking up space is actually getting used.
Tested and approved by Vlad(s Salads)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Black suit, black suit jacket, and blood-red tie are now in the loadout!
spellcheck: Blood-Red Tie is now blood-red tie. Weird ass capitalization begone!
tweak: We no longer live in a society.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
