### PR TITLE
(Hopefully) Prevents supermatter oxygen cheese 

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -3,7 +3,7 @@
 //Modifications include removing the world-ending full supermatter variation, and leaving only the shard.
 
 #define PLASMA_HEAT_PENALTY 15     // Higher == Bigger heat and waste penalty from having the crystal surrounded by this gas. Negative numbers reduce penalty.
-#define OXYGEN_HEAT_PENALTY 1
+#define OXYGEN_HEAT_PENALTY 2
 #define CO2_HEAT_PENALTY 0.1
 #define PLUOXIUM_HEAT_PENALTY -1
 #define TRITIUM_HEAT_PENALTY 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Turns out that infinitely pumping oxygen into the SM and letting it beyond pressure threshold actually does nothing. Let's change that by making oxygen increase the heat (slightly)

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/53913550/99916783-eae86400-2cea-11eb-9558-4cdbb09c600f.png)
![image](https://user-images.githubusercontent.com/53913550/99916824-30a52c80-2ceb-11eb-9ce7-c0ddd2059a4d.png)

This shouldn't be a thing. 

## Changelog
:cl:
balance: increased oxygen heat penalty a little bit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
