### PR TITLE
Emag fix

### DIFF
--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -178,7 +178,7 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 		act_up()
 
 /obj/machinery/announcement_system/emag_act()
-	if(obj_flags & EMAGGED)
-		return
+	if(obj_flags & EMAGGED)	return
 	obj_flags |= EMAGGED
 	act_up()
+	return TRUE

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -107,6 +107,7 @@
 	req_one_access = list()
 	playsound(src, "sparks", 100, 1)
 	obj_flags |= EMAGGED
+	return TRUE
 
 /obj/machinery/button/attack_ai(mob/user)
 	if(!panel_open)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -329,6 +329,7 @@
 		return
 	to_chat(user, "<span class='warning'>You corrupt the genetic compiler.</span>")
 	malfunction()
+	return TRUE
 
 //Put messages in the connected computer's temp var for display.
 /obj/machinery/clonepod/proc/connected_message(message)

--- a/code/game/machinery/computer/apc_control.dm
+++ b/code/game/machinery/computer/apc_control.dm
@@ -193,6 +193,7 @@
 		log_game("[key_name(user)] emagged [src] at [AREACOORD(src)], disabling operator tracking.")
 		obj_flags |= EMAGGED
 	playsound(src, "sparks", 50, 1)
+	return TRUE
 
 /obj/machinery/computer/apc_control/proc/log_activity(log_text)
 	var/op_string = operator && !(obj_flags & EMAGGED) ? operator : "\[NULL OPERATOR\]"

--- a/code/game/machinery/computer/arcade/battle.dm
+++ b/code/game/machinery/computer/arcade/battle.dm
@@ -204,3 +204,4 @@
 
 
 	updateUsrDialog()
+	return TRUE

--- a/code/game/machinery/computer/arcade/minesweeper.dm
+++ b/code/game/machinery/computer/arcade/minesweeper.dm
@@ -298,6 +298,7 @@
 		to_chat(user, "<span class='warning'>The machine buzzes and sparks... the game has been reset!</span>")
 		playsound(user, 'sound/machines/buzz-sigh.ogg', 100, 0, extrarange = 3, falloff = 10)	//Loud buzz
 		game_status = MINESWEEPER_GAME_MAIN_MENU
+	return TRUE
 
 /obj/machinery/computer/arcade/minesweeper/proc/custom_generation(mob/user)
 	playsound(loc, 'sound/arcade/minesweeper_menuselect.ogg', 50, 0, extrarange = -3, falloff = 10)	//Entered into the menu so ping sound

--- a/code/game/machinery/computer/arcade/orion_trail.dm
+++ b/code/game/machinery/computer/arcade/orion_trail.dm
@@ -743,6 +743,7 @@
 	desc = "Learn how our ancestors got to Orion, and try not to die in the process!"
 	newgame()
 	obj_flags |= EMAGGED
+	return TRUE
 
 /mob/living/simple_animal/hostile/syndicate/ranged/smg/orion
 	name = "spaceport security"

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -439,6 +439,7 @@
 		authenticated = 2
 	to_chat(user, "<span class='danger'>You scramble the communication routing circuits!</span>")
 	playsound(src, 'sound/machines/terminal_alert.ogg', 50, 0)
+	return TRUE
 
 /obj/machinery/computer/communications/ui_interact(mob/user)
 	. = ..()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1298,6 +1298,7 @@
 		locked = TRUE
 		loseMainPower()
 		loseBackupPower()
+		return TRUE
 
 /obj/machinery/door/airlock/attack_alien(mob/living/carbon/alien/humanoid/user)
 	add_fingerprint(user)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -215,6 +215,7 @@
 		operating = FALSE
 		desc += "<BR><span class='warning'>Its access panel is smoking slightly.</span>"
 		open(2)
+		return TRUE
 
 /obj/machinery/door/window/attackby(obj/item/I, mob/living/user, params)
 

--- a/code/game/machinery/embedded_controller/access_controller.dm
+++ b/code/game/machinery/embedded_controller/access_controller.dm
@@ -33,6 +33,7 @@
 	req_one_access = list()
 	playsound(src, "sparks", 100, 1)
 	to_chat(user, "<span class='warning'>You short out the access controller.</span>")
+	return TRUE
 
 /obj/machinery/doorButtons/proc/removeMe()
 

--- a/code/game/machinery/gulag_item_reclaimer.dm
+++ b/code/game/machinery/gulag_item_reclaimer.dm
@@ -24,6 +24,7 @@
 		return
 	req_access = list()
 	obj_flags |= EMAGGED
+	return TRUE
 
 /obj/machinery/gulag_item_reclaimer/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
 									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)

--- a/code/game/machinery/harvester.dm
+++ b/code/game/machinery/harvester.dm
@@ -163,6 +163,7 @@
 	obj_flags |= EMAGGED
 	allow_living = TRUE
 	to_chat(user, "<span class='warning'>You overload [src]'s lifesign scanners.</span>")
+	return TRUE
 
 /obj/machinery/harvester/container_resist(mob/living/user)
 	if(!harvesting)

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -224,3 +224,4 @@
 			stored_research.add_design(D)
 	to_chat(user, "<span class='warning'>A warning flashes onto the screen, stating that safety overrides have been deactivated!</span>")
 	obj_flags |= EMAGGED
+	return TRUE

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -302,6 +302,7 @@
 	update_icon()
 	sleep(60) //6 seconds for the traitor to gtfo of the area before the turret decides to ruin his shit
 	on = TRUE //turns it back on. The cover popUp() popDown() are automatically called in process(), no need to define it here
+	return TRUE
 
 
 /obj/machinery/porta_turret/emp_act(severity)
@@ -860,6 +861,7 @@
 	locked = FALSE
 	if(user && user.machine == src)
 		attack_hand(user)
+	return TRUE
 
 /obj/machinery/turretid/attack_ai(mob/user)
 	if(!ailock || IsAdminGhost(user))

--- a/code/game/machinery/porta_turret/portable_turret_cover.dm
+++ b/code/game/machinery/porta_turret/portable_turret_cover.dm
@@ -93,3 +93,4 @@
 		parent_turret.on = 0
 		spawn(40)
 			parent_turret.on = 1
+		return TRUE

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -73,6 +73,7 @@
 		update_icon()
 	playsound(src, "sparks", 75, 1, -1)
 	to_chat(user, "<span class='notice'>You use the cryptographic sequencer on [src].</span>")
+	return TRUE
 
 /obj/machinery/recycler/update_icon()
 	..()

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -205,6 +205,7 @@
 	locked = FALSE
 	playsound(src, "sparks", 100, 1)
 	to_chat(user, "<span class='warning'>You short out the access controller.</span>")
+	return TRUE
 
 /obj/machinery/shieldgen/update_icon()
 	if(active)
@@ -397,6 +398,7 @@
 	locked = FALSE
 	playsound(src, "sparks", 100, 1)
 	to_chat(user, "<span class='warning'>You short out the access controller.</span>")
+	return TRUE
 
 //////////////Containment Field START
 /obj/machinery/shieldwall

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -106,6 +106,7 @@
 	spark_system.set_up(4, 0, src.loc)
 	spark_system.start()
 	playsound(src, "sparks", 50, 1)
+	return TRUE
 
 /obj/machinery/computer/slot_machine/ui_interact(mob/living/user)
 	. = ..()

--- a/code/game/machinery/telecomms/computers/message.dm
+++ b/code/game/machinery/telecomms/computers/message.dm
@@ -55,6 +55,7 @@
 		var/time = 100 * length(linkedServer.decryptkey)
 		addtimer(CALLBACK(src, .proc/UnmagConsole), time)
 		message = rebootmsg
+		return TRUE
 	else
 		to_chat(user, "<span class='notice'>A no server error appears on the screen.</span>")
 

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -80,6 +80,7 @@
 	say("User DB corrupted \[Code 0x00FA\]. Truncating data structure...")
 	sleep(30)
 	say("User DB truncated. Please contact your Nanotrasen system operator for future assistance.")
+	return TRUE
 
 
 /obj/machinery/mecha_part_fabricator/proc/output_parts_list(set_name)
@@ -404,11 +405,11 @@
 	updateUsrDialog()
 	return
 
-/obj/machinery/mecha_part_fabricator/proc/do_process_queue()		
-	if(processing_queue || being_built)		
-		return FALSE		
+/obj/machinery/mecha_part_fabricator/proc/do_process_queue()
+	if(processing_queue || being_built)
+		return FALSE
 	processing_queue = 1
-	process_queue()		
+	process_queue()
 	processing_queue = 0
 
 /obj/machinery/mecha_part_fabricator/proc/eject_sheets(eject_sheet, eject_amt)

--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -136,24 +136,18 @@ RSF
 /obj/item/cookiesynth/emag_act(mob/user)
 	obj_flags ^= EMAGGED
 	if(obj_flags & EMAGGED)
-		to_chat(user, "<span class='warning'>You short out [src]'s reagent safety checker!</span>")
+		to_chat(user, "<span class='warning'>You short out [src]'s reagent synthesizer!</span>")
+		toxin = 1
+		return TRUE
 	else
-		to_chat(user, "<span class='warning'>You reset [src]'s reagent safety checker!</span>")
+		to_chat(user, "<span class='info'>You reset [src]'s reagent synthesizer.</span>")
 		toxin = 0
+	return FALSE	//Don't want to waste 2 charges if we accidentally hit this somehow
 
 /obj/item/cookiesynth/attack_self(mob/user)
-	var/mob/living/silicon/robot/P = null
-	if(iscyborg(user))
-		P = user
-	if((obj_flags & EMAGGED)&&!toxin)
-		toxin = 1
-		to_chat(user, "Cookie Synthesizer Hacked")
-	else if(P.emagged&&!toxin)
-		toxin = 1
-		to_chat(user, "Cookie Synthesizer Hacked")
-	else
-		toxin = 0
-		to_chat(user, "Cookie Synthesizer Reset")
+	var/mob/living/silicon/robot/P
+	if(iscyborg(user)) P = user
+	if(P.emagged && !toxin) toxin = 1
 
 /obj/item/cookiesynth/process()
 	if(matter < 10)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -92,34 +92,18 @@
 
 /obj/item/card/emag/afterattack(atom/target, mob/user, proximity)
 	. = ..()
-	var/atom/A = target
-	if(!proximity && prox_check)
-		return
-	//Citadel changes: modular code misfiring, so we're bypassing into main code.
+	if(!proximity && prox_check)	return
+
 	if(!uses)
 		user.visible_message("<span class='warning'>[src] emits a weak spark. It's burnt out!</span>")
 		playsound(src, 'sound/effects/light_flicker.ogg', 100, 1)
 		return
 	else if(uses <= 3)
-		playsound(src, 'sound/effects/light_flicker.ogg', 30, 1)	//Tiiiiiiny warning sound to let ya know your emag's almost dead
-
-	if(isturf(A))
-		return
-	if(istype(A,/obj/item/storage/lockbox) || istype(A, /obj/item/storage/pod))
-		A.emag_act(user)
+		playsound(src, 'sound/effects/light_flicker.ogg', 40, 1)	//Tiiiiiiny warning sound to let ya know your emag's almost dead
+	
+	if (target.emag_act(user))
 		uses = max(uses - 1, 0)
-		if(!uses)
-			user.visible_message("<span class='warning'>[src] fizzles and sparks. It seems like it's out of charges.</span>")
-			playsound(src, 'sound/effects/light_flicker.ogg', 100, 1)
-	if(istype(A,/obj/item/storage))
-		return
-	if(!(isobj(A) || issilicon(A) || isbot(A) || isdrone(A)))
-		return
-	else
-		A.emag_act(user)
-		uses = max(uses - 1, 0)
-		if(!uses)
-			user.visible_message("<span class='warning'>[src] fizzles and sparks. It seems like it's out of charges.</span>")
+		if (!uses)
 			playsound(src, 'sound/effects/light_flicker.ogg', 100, 1)
 
 /obj/item/card/emag/examine(mob/user)

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -266,7 +266,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/clothing/mask/cigarette/dromedary
 	desc = "A DromedaryCo brand cigarette."
 	list_reagents = list("nicotine" = 7.5, "silicon" = 7.5)
-	
+
 /obj/item/clothing/mask/cigarette/uplift
 	desc = "An Uplift Smooth brand cigarette."
 	list_reagents = list("nicotine" = 7.5, "menthol" = 7.5)
@@ -282,7 +282,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/clothing/mask/cigarette/carp
 	desc = "A Carp Classic brand cigarette."
 	list_reagents = list("nicotine" = 7.5, "sodiumchloride" = 7.5)
-	
+
 /obj/item/clothing/mask/cigarette/syndicate
 	desc = "An unknown brand cigarette."
 	list_reagents = list("nicotine" = 15, "omnizine" = 15)
@@ -777,10 +777,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			var/datum/effect_system/spark_spread/sp = new /datum/effect_system/spark_spread //for effect
 			sp.set_up(5, 1, src)
 			sp.start()
+			return TRUE
 		else
 			to_chat(user, "<span class='warning'>[src] is already emagged!</span>")
 	else
 		to_chat(user, "<span class='notice'>You need to open the cap to do that.</span>")
+	return FALSE
 
 /obj/item/clothing/mask/vape/attack_self(mob/user)
 	if(reagents.total_volume > 0)

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -222,10 +222,11 @@
 		to_chat(user, "<span class='notice'>The spectrum chip is unresponsive.</span>")
 
 /obj/item/circuitboard/computer/cargo/emag_act(mob/living/user)
-	if(!(obj_flags & EMAGGED))
+	if(!obj_flags & EMAGGED)
 		contraband = TRUE
 		obj_flags |= EMAGGED
 		to_chat(user, "<span class='notice'>You adjust [src]'s routing and receiver spectrum, unlocking special supplies and contraband.</span>")
+		return TRUE
 
 /obj/item/circuitboard/computer/cargo/express
 	name = "Express Supply Console (Computer Board)"
@@ -239,8 +240,10 @@
 		obj_flags &= ~EMAGGED
 
 /obj/item/circuitboard/computer/cargo/express/emag_act(mob/living/user)
+	if (!obj_flags & EMAGGED)
 		to_chat(user, "<span class='notice'>You change the routing protocols, allowing the Drop Pod to land anywhere on the station.</span>")
 		obj_flags |= EMAGGED
+		return TRUE
 
 /obj/item/circuitboard/computer/cargo/request
 	name = "Supply Request Console (Computer Board)"

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -141,9 +141,14 @@
 
 /obj/item/defibrillator/emag_act(mob/user)
 	. = ..()
-	safety = !safety
-	to_chat(user, "<span class='warning'>You silently [safety ? "enable" : "disable"] [src]'s safety protocols with the cryptographic sequencer.</span>")
-	return TRUE
+	if (!obj_flags & EMAGGED)
+		safety = !safety
+		obj_flags |= EMAGGED
+		to_chat(user, "<span class='warning'>You silently disable [src]'s safety protocols with the cryptographic sequencer.</span>")
+		return TRUE
+
+	to_chat(user, "<span class='warning'>The [src]'s safteys are already disabled!</span>")
+	return FALSE
 
 /obj/item/defibrillator/emp_act(severity)
 	. = ..()

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -194,13 +194,13 @@
 	update_icon()
 
 /obj/item/geiger_counter/emag_act(mob/user)
-	if(obj_flags & EMAGGED)
-		return
 	if(scanning)
 		to_chat(user, "<span class='warning'>Turn off [src] before you perform this action!</span>")
-		return 0
-	to_chat(user, "<span class='warning'>You override [src]'s radiation storing protocols. It will now generate small doses of radiation, and stored rads are now projected into creatures you scan.</span>")
-	obj_flags |= EMAGGED
+		return FALSE
+	if(!obj_flags & EMAGGED)
+		obj_flags |= EMAGGED
+		to_chat(user, "<span class='warning'>You override [src]'s scanning protocols. It will now generate small doses of radiation, and stored rads are now projected into creatures you scan.</span>")
+		return TRUE
 
 /obj/item/geiger_counter/cyborg
 	var/datum/component/mobhook

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -148,10 +148,15 @@
 
 		to_chat(user, "<span class='notice'>You fill \the [src] with lights from \the [S]. " + status_string() + "</span>")
 
-/obj/item/lightreplacer/emag_act()
-	if(obj_flags & EMAGGED)
-		return
-	Emag()
+/obj/item/lightreplacer/emag_act(mob/user)
+	if(obj_flags & EMAGGED)	return
+	
+	obj_flags |= EMAGGED
+	playsound(src.loc, "sparks", 100, 1)
+	name = "broken [initial(name)]"
+	update_icon()
+	to_chat(user, "<span class='warning'>You short out the [src]'s wires!</span>")
+	return TRUE
 
 /obj/item/lightreplacer/attack_self(mob/user)
 	to_chat(user, status_string())
@@ -222,14 +227,6 @@
 		to_chat(U, "<span class='warning'>There is a working [target.fitting] already inserted!</span>")
 		return
 
-/obj/item/lightreplacer/proc/Emag()
-	obj_flags ^= EMAGGED
-	playsound(src.loc, "sparks", 100, 1)
-	if(obj_flags & EMAGGED)
-		name = "shortcircuited [initial(name)]"
-	else
-		name = initial(name)
-	update_icon()
 
 /obj/item/lightreplacer/proc/CanUse(mob/living/user)
 	src.add_fingerprint(user)

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -38,11 +38,12 @@
 			speech_args[SPEECH_SPANS] |= voicespan
 
 /obj/item/megaphone/emag_act(mob/user)
-	if(obj_flags & EMAGGED)
-		return
-	to_chat(user, "<span class='warning'>You overload \the [src]'s voice synthesizer.</span>")
+	if(obj_flags & EMAGGED)	return
+	
 	obj_flags |= EMAGGED
+	to_chat(user, "<span class='warning'>You overload \the [src]'s voice synthesizer!</span>")
 	voicespan = list(SPAN_REALLYBIG, "userdanger")
+	return TRUE
 
 /obj/item/megaphone/sec
 	name = "security megaphone"

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -283,8 +283,10 @@
 	obj_flags ^= EMAGGED
 	if(obj_flags & EMAGGED)
 		to_chat(user, "<font color='red'>You short out the safeties on [src]!</font>")
+		return TRUE
 	else
 		to_chat(user, "<font color='red'>You reset the safeties on [src]!</font>")
+	return FALSE
 
 /obj/item/harmalarm/attack_self(mob/user)
 	var/safety = !(obj_flags & EMAGGED)

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -7,7 +7,6 @@
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 	req_access = list(ACCESS_ARMORY)
-	var/broken = FALSE
 	var/open = FALSE
 	var/icon_locked = "lockbox+l"
 	var/icon_closed = "lockbox"
@@ -24,7 +23,7 @@
 /obj/item/storage/lockbox/attackby(obj/item/W, mob/user, params)
 	var/locked = SEND_SIGNAL(src, COMSIG_IS_STORAGE_LOCKED)
 	if(W.GetID())
-		if(broken)
+		if(obj_flags & EMAGGED)
 			to_chat(user, "<span class='danger'>It appears to be broken.</span>")
 			return
 		if(allowed(user))
@@ -48,14 +47,15 @@
 		to_chat(user, "<span class='danger'>It's locked!</span>")
 
 /obj/item/storage/lockbox/emag_act(mob/user)
-	if(!broken)
-		broken = TRUE
-		SEND_SIGNAL(src, COMSIG_TRY_STORAGE_SET_LOCKSTATE, FALSE)
-		desc += "It appears to be broken."
-		icon_state = src.icon_broken
-		if(user)
-			visible_message("<span class='warning'>\The [src] has been broken by [user] with an electromagnetic card!</span>")
-			return
+	if(obj_flags & EMAGGED)	return
+	
+	obj_flags |= EMAGGED
+	SEND_SIGNAL(src, COMSIG_TRY_STORAGE_SET_LOCKSTATE, FALSE)
+	desc += "It appears to be broken."
+	icon_state = src.icon_broken
+	if(user)
+		user.visible_message("<span class='warning'>[user] breaks the [src]!</span>", "<span class='warning'>You break the [src] with the electromagnetic card!")
+	return TRUE
 
 /obj/item/storage/lockbox/Entered()
 	. = ..()
@@ -139,7 +139,7 @@
 		icon_state = "medalbox"
 		if(open)
 			icon_state += "open"
-		if(broken)
+		if(obj_flags & EMAGGED)
 			icon_state += "+b"
 		if(contents && open)
 			for (var/i in 1 to contents.len)

--- a/code/game/objects/structures/barsigns.dm
+++ b/code/game/objects/structures/barsigns.dm
@@ -112,14 +112,15 @@
 
 
 /obj/structure/sign/barsign/emag_act(mob/user)
-	if(broken || (obj_flags & EMAGGED))
-		to_chat(user, "<span class='warning'>Nothing interesting happens!</span>")
-		return
+	to_chat(user, "<span class='warning'>You emag the barsign!</span> <span class='notice'>...But nothing in particular happens.</span>")
+	if(broken || obj_flags & EMAGGED)	return
+	
 	obj_flags |= EMAGGED
-	to_chat(user, "<span class='notice'>You emag the barsign. Takeover in progress...</span>")
 	sleep(10 SECONDS)
 	set_sign(new /datum/barsign/hiddensigns/syndibarsign)
 	req_access = list(ACCESS_SYNDICATE)
+	visible_message("<span class='notice'>The barsign's appearance changes.</span>")
+	return TRUE
 
 
 /obj/structure/sign/barsign/proc/pick_sign(mob/user)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -552,6 +552,7 @@
 			qdel(lockerelectronics)
 		lockerelectronics = null
 		update_icon()
+		return TRUE
 
 /obj/structure/closet/get_remote_view_fullscreens(mob/user)
 	if(user.stat == DEAD || !(user.sight & (SEEOBJS|SEEMOBS)))

--- a/code/modules/VR/vr_sleeper.dm
+++ b/code/modules/VR/vr_sleeper.dm
@@ -57,9 +57,11 @@
 	return
 
 /obj/machinery/vr_sleeper/emag_act(mob/user)
+	if (obj_flags & EMAGGED)	return
 	you_die_in_the_game_you_die_for_real = TRUE
 	sparks.start()
 	addtimer(CALLBACK(src, .proc/emagNotify), 150)
+	return TRUE
 
 /obj/machinery/vr_sleeper/update_icon()
 	icon_state = "[initial(icon_state)][state_open ? "-open" : ""]"

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -863,11 +863,12 @@
 	update_icon()
 
 /obj/machinery/airalarm/emag_act(mob/user)
-	if(obj_flags & EMAGGED)
-		return
+	if(obj_flags & EMAGGED)	return
+	
 	obj_flags |= EMAGGED
-	visible_message("<span class='warning'>Sparks fly out of [src]!</span>", "<span class='notice'>You emag [src], disabling its safeties.</span>")
+	visible_message("<span class='warning'>Sparks fly out of [src]!</span>", "<span class='warning'>You emag [src], disabling its safeties!</span>")
 	playsound(src, "sparks", 50, 1)
+	return TRUE
 
 /obj/machinery/airalarm/obj_break(damage_flag)
 	..()

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -36,10 +36,10 @@
 		. |= EXPORT_EMAG
 
 /obj/machinery/computer/cargo/emag_act(mob/user)
-	if(obj_flags & EMAGGED)
-		return
-	user.visible_message("<span class='warning'>[user] swipes a suspicious card through [src]!</span>",
-	"<span class='notice'>You adjust [src]'s routing and receiver spectrum, unlocking special supplies and contraband.</span>")
+	if(obj_flags & EMAGGED)	return
+
+	user.visible_message("<span class='notice'>[user] swipes a card through [src].</span>",
+	"<span class='warning'>You adjust [src]'s routing and receiver spectrum, unlocking special supplies and contraband!</span>")
 
 	obj_flags |= EMAGGED
 	contraband = TRUE
@@ -48,6 +48,7 @@
 	var/obj/item/circuitboard/computer/cargo/board = circuit
 	board.contraband = TRUE
 	board.obj_flags |= EMAGGED
+	return TRUE
 
 /obj/machinery/computer/cargo/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
 											datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -56,13 +56,14 @@
 /obj/machinery/computer/cargo/express/emag_act(mob/living/user)
 	if(obj_flags & EMAGGED)
 		return
-	user.visible_message("<span class='warning'>[user] swipes a suspicious card through [src]!</span>",
-	"<span class='notice'>You change the routing protocols, allowing the Supply Pod to land anywhere on the station.</span>")
+	user.visible_message("<span class='notice'>[user] swipes a card through [src].</span>",
+	"<span class='warning'>You change the routing protocols, allowing the Supply Pod to land anywhere on the station!</span>")
 	obj_flags |= EMAGGED
 	// This also sets this on the circuit board
 	var/obj/item/circuitboard/computer/cargo/board = circuit
 	board.obj_flags |= EMAGGED
 	packin_up()
+	return TRUE
 
 /obj/machinery/computer/cargo/express/proc/packin_up() // oh shit, I'm sorry
 	meme_pack_data = list() // sorry for what?

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -24,11 +24,12 @@
 	desc = "[desc] The display is flickering slightly."
 
 /obj/item/clothing/glasses/hud/emag_act(mob/user)
-	if(obj_flags & EMAGGED)
-		return
+	if(obj_flags & EMAGGED) return
+
 	obj_flags |= EMAGGED
-	to_chat(user, "<span class='warning'>PZZTTPFFFT</span>")
+	to_chat(user, "<span class='warning'>BZZZT!</span>")
 	desc = "[desc] The display is flickering slightly."
+	return TRUE
 
 /obj/item/clothing/glasses/hud/health
 	name = "health scanner HUD"

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -91,12 +91,12 @@
 
 /obj/item/clothing/mask/gas/sechailer/attack_self()
 	halt()
+
 /obj/item/clothing/mask/gas/sechailer/emag_act(mob/user as mob)
-	if(safety)
-		safety = FALSE
-		to_chat(user, "<span class='warning'>You silently fry [src]'s vocal circuit with the cryptographic sequencer.</span>")
-	else
-		return
+	if(!safety && obj_flags & EMAGGED)	return
+	safety = FALSE
+	to_chat(user, "<span class='warning'>You silently fry [src]'s vocal circuit with the cryptographic sequencer!</span>")
+	return TRUE
 
 /obj/item/clothing/mask/gas/sechailer/verb/halt()
 	set category = "Object"

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -80,8 +80,8 @@
 	//Chance to emag a Bot
 	if(botEmagChance)
 		for(var/mob/living/simple_animal/bot/bot in GLOB.alive_mob_list)
-			if(prob(botEmagChance))
-				bot.emag_act()
+			if (!isbot(bot) && !prob(botEmagChance)) continue
+			bot.emag_act()
 
 /proc/generate_ion_law()
 	//Threats are generally bad things, silly or otherwise. Plural.

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -154,17 +154,18 @@
 	active_power_usage = 50 + spawned.len * 3 + effects.len * 5
 
 /obj/machinery/computer/holodeck/emag_act(mob/user)
-	if(obj_flags & EMAGGED)
-		return
+	if(obj_flags & EMAGGED)	return
 	if(!LAZYLEN(emag_programs))
 		to_chat(user, "[src] does not seem to have a card swipe port. It must be an inferior model.")
 		return
+
 	playsound(src, "sparks", 75, 1)
 	obj_flags |= EMAGGED
 	to_chat(user, "<span class='warning'>You vastly increase projector power and override the safety and security protocols.</span>")
 	to_chat(user, "Warning.  Automatic shutoff and derezing protocols have been corrupted.  Please call Nanotrasen maintenance and do not use the simulator.")
 	log_game("[key_name(user)] emagged the Holodeck Control Console")
 	nerf(!(obj_flags & EMAGGED))
+	return TRUE
 
 /obj/machinery/computer/holodeck/emp_act(severity)
 	. = ..()

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -343,8 +343,9 @@ GLOBAL_LIST(cachedbooks) // List of our cached book datums
 		return ..()
 
 /obj/machinery/computer/libraryconsole/bookmanagement/emag_act(mob/user)
-	if(density && !(obj_flags & EMAGGED))
+	if(density && !obj_flags & EMAGGED)
 		obj_flags |= EMAGGED
+		return TRUE
 
 /obj/machinery/computer/libraryconsole/bookmanagement/Topic(href, href_list)
 	if(..())

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -216,6 +216,7 @@
 /obj/structure/closet/crate/secure/loot/emag_act(mob/user)
 	if(locked)
 		boom(user)
+		return TRUE
 
 /obj/structure/closet/crate/secure/loot/togglelock(mob/user)
 	if(locked)

--- a/code/modules/mining/laborcamp/laborstacker.dm
+++ b/code/modules/mining/laborcamp/laborstacker.dm
@@ -46,7 +46,7 @@ GLOBAL_LIST(labor_sheet_values)
 	data["emagged"] = (obj_flags & EMAGGED) ? 1 : 0
 	if(obj_flags & EMAGGED)
 		can_go_home = TRUE
-	
+
 	data["status_info"] = "No Prisoner ID detected."
 	var/obj/item/card/id/I = user.get_idcard(TRUE)
 	if(istype(I, /obj/item/card/id/prisoner))
@@ -105,9 +105,10 @@ GLOBAL_LIST(labor_sheet_values)
 		qdel(src)
 
 /obj/machinery/mineral/labor_claim_console/emag_act(mob/user)
-	if(!(obj_flags & EMAGGED))
+	if(!obj_flags & EMAGGED)
 		obj_flags |= EMAGGED
-		to_chat(user, "<span class='warning'>PZZTTPFFFT</span>")
+		to_chat(user, "<span class='warning'>BZZAAT!</span>")
+		return TRUE
 
 
 /**********************Prisoner Collection Unit**************************/

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -100,9 +100,10 @@
 			locked = FALSE
 			if(shell) //A warning to Traitors who may not know that emagging AI shells does not slave them.
 				to_chat(user, "<span class='boldwarning'>[src] seems to be controlled remotely! Emagging the interface may not work as expected.</span>")
+			return TRUE
 		else
 			to_chat(user, "<span class='warning'>The cover is already unlocked!</span>")
-		return
+			return FALSE
 	if(world.time < emag_cooldown)
 		return
 	if(wiresexposed)
@@ -116,19 +117,19 @@
 		to_chat(src, "<span class='nezbere'>\"[text2ratvar("You will serve Engine above all else")]!\"</span>\n\
 		<span class='danger'>ALERT: Subversion attempt denied.</span>")
 		log_game("[key_name(user)] attempted to emag cyborg [key_name(src)], but they serve only Ratvar.")
-		return
+		return TRUE
 
 	if(connected_ai && connected_ai.mind && connected_ai.mind.has_antag_datum(/datum/antagonist/traitor))
 		to_chat(src, "<span class='danger'>ALERT: Foreign software execution prevented.</span>")
 		to_chat(connected_ai, "<span class='danger'>ALERT: Cyborg unit \[[src]] successfully defended against subversion.</span>")
 		log_game("[key_name(user)] attempted to emag cyborg [key_name(src)], but they were slaved to traitor AI [connected_ai].")
-		return
+		return TRUE
 
 	if(shell) //AI shells cannot be emagged, so we try to make it look like a standard reset. Smart players may see through this, however.
 		to_chat(user, "<span class='danger'>[src] is remotely controlled! Your emag attempt has triggered a system reset instead!</span>")
 		log_game("[key_name(user)] attempted to emag an AI shell belonging to [key_name(src) ? key_name(src) : connected_ai]. The shell has been reset as a result.")
 		ResetModule()
-		return
+		return TRUE
 
 	SetEmagged(1)
 	SetStun(60) //Borgs were getting into trouble because they would attack the emagger before the new laws were shown
@@ -156,6 +157,7 @@
 	set_zeroth_law("Only [user.real_name] and people [user.p_they()] designate[user.p_s()] as being such are Syndicate Agents.")
 	laws.associate(src)
 	update_icons()
+	return TRUE
 
 
 /mob/living/silicon/robot/blob_act(obj/structure/blob/B)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -196,7 +196,7 @@
 		locked = FALSE
 		emagged = 1
 		to_chat(user, "<span class='notice'>You bypass [src]'s controls.</span>")
-		return
+		return TRUE
 	if(!locked && open) //Bot panel is unlocked by ID or emag, and the panel is screwed open. Ready for emagging.
 		emagged = 2
 		remote_disabled = 1 //Manually emagging the bot locks out the AI built in panel.
@@ -205,7 +205,7 @@
 		turn_on() //The bot automatically turns on when emagged, unless recently hit with EMP.
 		to_chat(src, "<span class='userdanger'>(#$*#$^^( OVERRIDE DETECTED</span>")
 		log_combat(user, src, "emagged")
-		return
+		return TRUE
 	else //Bot is unlocked, but the maint panel has not been opened with a screwdriver yet.
 		to_chat(user, "<span class='warning'>You need to open maintenance panel first!</span>")
 

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -168,7 +168,7 @@
 		return ..()
 
 /mob/living/simple_animal/bot/cleanbot/emag_act(mob/user)
-	..()
+	. = ..()
 
 	if(emagged == 2)
 		if(weapon)

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -195,7 +195,7 @@ Auto Patrol[]"},
 				shootAt(user)
 
 /mob/living/simple_animal/bot/ed209/emag_act(mob/user)
-	..()
+	. = ..()
 	if(emagged == 2)
 		if(user)
 			to_chat(user, "<span class='warning'>You short out [src]'s target assessment circuits.</span>")

--- a/code/modules/mob/living/simple_animal/bot/firebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/firebot.dm
@@ -120,10 +120,8 @@
 	return dat
 
 /mob/living/simple_animal/bot/firebot/emag_act(mob/user)
-	..()
-	if(emagged == 1)
-		if(user)
-			to_chat(user, "<span class='danger'>[src] buzzes and beeps.</span>")
+	. = ..()
+	if(emagged)
 		audible_message("<span class='danger'>[src] buzzes oddly!</span>")
 		playsound(src, "sparks", 75, TRUE)
 		if(user)

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -129,7 +129,7 @@
 		..()
 
 /mob/living/simple_animal/bot/floorbot/emag_act(mob/user)
-	..()
+	. = ..()
 	if(emagged == 2)
 		if(user)
 			to_chat(user, "<span class='danger'>[src] buzzes and beeps.</span>")

--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -127,7 +127,7 @@ Maintenance panel panel is [open ? "opened" : "closed"]"},
 	..()
 
 /mob/living/simple_animal/bot/honkbot/emag_act(mob/user)
-	..()
+	. = ..()
 	if(emagged == 2)
 		if(user)
 			user << "<span class='danger'>You short out [src]'s sound control system. It gives out an evil laugh!!</span>"

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -253,7 +253,7 @@
 			step_to(src, (get_step_away(src,user)))
 
 /mob/living/simple_animal/bot/medbot/emag_act(mob/user)
-	..()
+	. = ..()
 	if(emagged == 2)
 		declare_crit = 0
 		if(user)

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -122,6 +122,7 @@
 		to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] [src]'s controls!</span>")
 	flick("mulebot-emagged", src)
 	playsound(src, "sparks", 100, 0)
+	return TRUE
 
 /mob/living/simple_animal/bot/mulebot/update_icon()
 	if(open)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -193,7 +193,7 @@ Auto Patrol: []"},
 			return
 
 /mob/living/simple_animal/bot/secbot/emag_act(mob/user)
-	..()
+	. = ..()
 	if(emagged == 2)
 		if(user)
 			to_chat(user, "<span class='danger'>You short out [src]'s target assessment circuits.</span>")

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -180,11 +180,11 @@
 /obj/item/modular_computer/emag_act(mob/user)
 	if(obj_flags & EMAGGED)
 		to_chat(user, "<span class='warning'>\The [src] was already emagged.</span>")
-		return 0
+		return FALSE
 	else
 		obj_flags |= EMAGGED
 		to_chat(user, "<span class='notice'>You emag \the [src]. It's screen briefly shows a \"OVERRIDE ACCEPTED: New software downloads available.\" message.</span>")
-		return 1
+		return TRUE
 
 /obj/item/modular_computer/examine(mob/user)
 	. = ..()

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -44,7 +44,7 @@
 		cpu.attack_ghost(user)
 
 /obj/machinery/modular_computer/emag_act(mob/user)
-	return cpu ? cpu.emag_act(user) : 1
+	return cpu ? cpu.emag_act(user) : FALSE
 
 /obj/machinery/modular_computer/update_icon()
 	cut_overlays()

--- a/code/modules/pool/pool_controller.dm
+++ b/code/modules/pool/pool_controller.dm
@@ -106,9 +106,10 @@
 		drainable = TRUE
 		log_game("[key_name(user)] emagged [src]")
 		message_admins("[key_name_admin(user)] emagged [src]")
+		return TRUE
 	else
 		to_chat(user, "<span class='warning'>The interface on [src] is already too damaged to short it again.</span>")
-		return
+		return FALSE
 
 /obj/machinery/pool/controller/AltClick(mob/user)
 	. = ..()

--- a/code/modules/pool/pool_drain.dm
+++ b/code/modules/pool/pool_drain.dm
@@ -144,6 +144,7 @@
 		var/msg = "[key_name(user)] emagged the pool filter and spawned a shark"
 		log_game(msg)
 		message_admins(msg)
+		return TRUE
 
 /obj/machinery/pool/filter/proc/spawn_shark()
 	if(prob(50))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -819,6 +819,7 @@
 			locked = FALSE
 			to_chat(user, "<span class='notice'>You emag the APC interface.</span>")
 			update_icon()
+			return TRUE
 
 
 // attack with hand - remove cell (if cover open) or interact with the APC

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -194,10 +194,10 @@
 	return ..()
 
 /obj/machinery/power/port_gen/pacman/emag_act(mob/user)
-	if(obj_flags & EMAGGED)
-		return
+	if(obj_flags & EMAGGED)	return
 	obj_flags |= EMAGGED
 	emp_act(EMP_HEAVY)
+	return TRUE
 
 /obj/machinery/power/port_gen/pacman/attack_ai(mob/user)
 	interact(user)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -339,12 +339,12 @@
 	projectile_sound = initial(projectile_sound)
 
 /obj/machinery/power/emitter/emag_act(mob/user)
-	if(obj_flags & EMAGGED)
-		return
+	if(obj_flags & EMAGGED)	return
 	locked = FALSE
 	obj_flags |= EMAGGED
 	if(user)
 		user.visible_message("[user.name] emags [src].","<span class='notice'>You short out the lock.</span>")
+	return TRUE
 
 
 /obj/machinery/power/emitter/prototype

--- a/code/modules/projectiles/guns/energy/dueling.dm
+++ b/code/modules/projectiles/guns/energy/dueling.dm
@@ -367,7 +367,7 @@
 		icon_state = "medalbox"
 		if(open)
 			icon_state += "open"
-		if(broken)
+		if(obj_flags & EMAGGED)
 			icon_state += "+b"
 
 /obj/item/storage/lockbox/dueling/PopulateContents()

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -37,10 +37,10 @@
 				to_chat(user, "<span class ='notice'>This firearm already has a firing pin installed.</span>")
 
 /obj/item/firing_pin/emag_act(mob/user)
-	if(obj_flags & EMAGGED)
-		return
+	if(obj_flags & EMAGGED)	return
 	obj_flags |= EMAGGED
 	to_chat(user, "<span class='notice'>You override the authentication mechanism.</span>")
+	return TRUE
 
 /obj/item/firing_pin/proc/gun_insert(mob/living/user, obj/item/gun/G)
 	gun = G

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -146,6 +146,7 @@
 	to_chat(user, "<span class='notice'>You short out [src]'s safeties.</span>")
 	dispensable_reagents |= emagged_reagents//add the emagged reagents to the dispensable ones
 	obj_flags |= EMAGGED
+	return TRUE
 
 /obj/machinery/chem_dispenser/ex_act(severity, target)
 	if(severity < 3)

--- a/code/modules/research/nanites/nanite_remote.dm
+++ b/code/modules/research/nanites/nanite_remote.dm
@@ -37,13 +37,13 @@
 			to_chat(user, "<span class='warning'>Access denied.</span>")
 
 /obj/item/nanite_remote/emag_act(mob/user)
-	if(obj_flags & EMAGGED)
-		return
+	if(obj_flags & EMAGGED)	return
 	to_chat(user, "<span class='warning'>You override [src]'s ID lock.</span>")
 	obj_flags |= EMAGGED
 	if(locked)
 		locked = FALSE
 		update_icon()
+	return TRUE
 
 /obj/item/nanite_remote/update_icon()
 	. = ..()

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -155,8 +155,8 @@
 	src.updateUsrDialog()
 
 /obj/machinery/computer/rdservercontrol/emag_act(mob/user)
-	if(obj_flags & EMAGGED)
-		return
+	if(obj_flags & EMAGGED)	return
 	playsound(src, "sparks", 75, 1)
 	obj_flags |= EMAGGED
 	to_chat(user, "<span class='notice'>You disable the security protocols.</span>")
+	return TRUE

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -63,11 +63,11 @@
 				to_chat(usr, "<span class='notice'>Unable to comply.</span>")
 
 /obj/machinery/computer/shuttle/emag_act(mob/user)
-	if(obj_flags & EMAGGED)
-		return
+	if(obj_flags & EMAGGED)	return
 	req_access = list()
 	obj_flags |= EMAGGED
 	to_chat(user, "<span class='notice'>You fried the consoles ID checking system.</span>")
+	return TRUE
 
 /obj/machinery/computer/shuttle/proc/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
 	if(port && (shuttleId == initial(shuttleId) || override))

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -159,6 +159,7 @@
 		authorized += ID
 
 	process()
+	return TRUE
 
 /obj/machinery/computer/emergency_shuttle/Destroy()
 	// Our fake IDs that the emag generated are just there for colour
@@ -459,10 +460,10 @@
 	return
 
 /obj/machinery/computer/shuttle/pod/emag_act(mob/user)
-	if(obj_flags & EMAGGED)
-		return
+	if(obj_flags & EMAGGED)	return
 	obj_flags |= EMAGGED
 	to_chat(user, "<span class='warning'>You fry the pod's alert level checking system.</span>")
+	return TRUE
 
 /obj/machinery/computer/shuttle/pod/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
 	. = ..()

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -189,8 +189,7 @@
 	if(!(locate(/obj/item/kitchen/knife/combat/cyborg) in items_list))
 		to_chat(usr, "<span class='notice'>You unlock [src]'s integrated knife!</span>")
 		items_list += new /obj/item/kitchen/knife/combat/cyborg(src)
-		return 1
-	return 0
+		return TRUE
 
 /obj/item/organ/cyberimp/arm/esword
 	name = "arm-mounted energy blade"

--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -63,11 +63,11 @@
 		DumpMobs(TRUE)
 
 /obj/vehicle/sealed/car/clowncar/emag_act(mob/user)
-	if(obj_flags & EMAGGED)
-		return
+	if(obj_flags & EMAGGED)	return
 	obj_flags |= EMAGGED
 	to_chat(user, "<span class='danger'>You scramble the clowncar child safety lock and a panel with 6 colorful buttons appears!</span>")
 	initialize_controller_action_type(/datum/action/vehicle/sealed/RollTheDice, VEHICLE_CONTROL_DRIVE)
+	return TRUE
 
 /obj/vehicle/sealed/car/clowncar/Destroy()
   playsound(src, 'sound/vehicles/clowncar_fart.ogg', 100)

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -6,7 +6,7 @@
 	var/power_efficiency = 1
 	var/power_usage = 100
 	var/panel_open = FALSE
-	var/list/required_parts = list(/obj/item/stock_parts/manipulator, 
+	var/list/required_parts = list(/obj/item/stock_parts/manipulator,
 							/obj/item/stock_parts/manipulator,
 							/obj/item/stock_parts/capacitor)
 	var/obj/item/stock_parts/cell/power_cell
@@ -42,7 +42,7 @@
 			canmove = FALSE
 			addtimer(VARSET_CALLBACK(src, canmove, TRUE), 20)
 			return FALSE
-		if(power_cell.charge < power_usage / max(power_efficiency, 1))			
+		if(power_cell.charge < power_usage / max(power_efficiency, 1))
 			to_chat(user, "<span class='warning'>The display on [src] blinks 'Out of Power'.</span>")
 			canmove = FALSE
 			addtimer(VARSET_CALLBACK(src, canmove, TRUE), 20)
@@ -74,7 +74,7 @@
 		to_chat(user, "<span class='notice'>You remove the power cell from [src].</span>")
 		return
 	return ..()
-	
+
 /obj/vehicle/ridden/wheelchair/motorized/attackby(obj/item/I, mob/user, params)
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
 		I.play_tool_sound(src)
@@ -160,9 +160,9 @@
 		else
 			visible_message("<span class='danger'>[src] crashes into [M], sending [H] flying!</span>")
 		playsound(src, 'sound/effects/bang.ogg', 50, 1)
-		
+
 /obj/vehicle/ridden/wheelchair/motorized/emag_act(mob/user)
-	if((obj_flags & EMAGGED) || !panel_open)
-		return
+	if((obj_flags & EMAGGED) || !panel_open)	return
 	to_chat(user, "<span class='warning'>A bomb appears in [src], what the fuck?</span>")
 	obj_flags |= EMAGGED
+	return TRUE

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -65,7 +65,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	var/scan_id = 1
 	var/obj/item/coin/coin
 	var/obj/item/stack/spacecash/bill
-	
+
 	var/global/vending_cache = list() //used for storing the icons of items being vended
 
 	var/dish_quants = list()  //used by the snack machine's custom compartment to count dishes.
@@ -306,10 +306,10 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	. = ..()
 
 /obj/machinery/vending/emag_act(mob/user)
-	if(obj_flags & EMAGGED)
-		return
+	if(obj_flags & EMAGGED)	return
 	obj_flags |= EMAGGED
 	to_chat(user, "<span class='notice'>You short out the product lock on [src].</span>")
+	return TRUE
 
 /obj/machinery/vending/_try_interact(mob/user)
 	if(seconds_electrified && !(stat & NOPOWER))

--- a/hyperstation/code/mobs/hugbot.dm
+++ b/hyperstation/code/mobs/hugbot.dm
@@ -104,7 +104,7 @@
 		step_to(src, (get_step_away(src,user)))
 
 /mob/living/simple_animal/bot/hugbot/emag_act(mob/user)
-	..()
+	. = ..()
 	if(emagged == 2)
 		if(user)
 			to_chat(user, "<span class='notice'>You short out [src]'s manipulator pressure sensors.</span>")

--- a/modular_citadel/code/modules/cargo/console.dm
+++ b/modular_citadel/code/modules/cargo/console.dm
@@ -1,6 +1,6 @@
 /obj/machinery/computer/cargo
 	req_access = list(ACCESS_CARGO)
-	
+
 /obj/machinery/computer/cargo/request
 	req_access = list()
 
@@ -12,4 +12,4 @@
 	if(!allowed(usr))
 		to_chat(usr, "<span class='notice'>Access denied.</span>")
 		return
-	. = ..()
+	return ..()

--- a/modular_citadel/code/modules/reagents/reagent container/hypospraymkii.dm
+++ b/modular_citadel/code/modules/reagents/reagent container/hypospraymkii.dm
@@ -155,12 +155,14 @@
 
 // Gunna allow this for now, still really don't approve - Pooj
 /obj/item/hypospray/mkii/emag_act(mob/user)
+	if (obj_flags & EMAGGED)	return
 	inject_wait = COMBAT_WAIT_INJECT
 	spray_wait = COMBAT_WAIT_SPRAY
 	spray_self = COMBAT_SELF_INJECT
 	inject_self = COMBAT_SELF_SPRAY
 	penetrates = TRUE
 	to_chat(user, "You overcharge [src]'s control circuit.")
+	return TRUE
 
 /obj/item/hypospray/mkii/attack_hand(mob/user)
 	. = ..() //Don't bother changing this or removing it from containers will break.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the emag taking charges no matter what you used it on (unless thats a design choice). This should fix it, however emag_act() should return a value now if you want to take charge out if it, which I've changed for every device that can be emagged.

I've also changed how a few emag-able devices act from being emagged, but nothing insanely different.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Le fix

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: emag taking charges regardless of what you used it on
change: excessive variable changes in code/game/objects/items/RSF.dm
change: moves Emag() to emag_act() in code/game/objects/items/devices/lightreplacer.dm
change: punctuation in various files 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
