### PR TITLE
Allows the wizard to load their current character's appearance

### DIFF
--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -21,6 +21,9 @@
 		create_objectives()
 	if(move_to_lair)
 		send_to_lair()
+	var/mob/living/carbon/human/H = owner.current
+	H.mirrorcanloadappearance = TRUE
+	H.checkloadappearance()
 	. = ..()
 	if(allow_rename)
 		rename_wizard()
@@ -58,6 +61,7 @@
 		SSjob.SendToLateJoin(owner.current)
 		to_chat(owner, "HOT INSERTION, GO GO GO")
 	owner.current.forceMove(pick(GLOB.wizardstart))
+
 
 /datum/antagonist/wizard/proc/create_objectives()
 	var/datum/objective/new_objective = new("Cause as much creative mayhem as you can aboard the station! The more outlandish your methods of achieving this, the better! Make sure there's a decent amount of crew alive to tell of your tale.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Just like the nukies.

## Why It's Good For The Game

ye

## Changelog
:cl:
add: Wizards can now load a character, like ghost roles and nukies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
