### PR TITLE
 Nerfs RLDs because they hard counter nightmares and night ops.

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -701,18 +701,18 @@ RLD
 	icon_state = "rld"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	matter = 500
-	max_matter = 500
-	sheetmultiplier = 16
+	matter = 200
+	max_matter = 200
+	sheetmultiplier = 5
 	var/mode = LIGHT_MODE
 	actions_types = list(/datum/action/item_action/pick_color)
 	ammo_sections = 5
 	has_ammobar = TRUE
 
-	var/wallcost = 10
-	var/floorcost = 15
-	var/launchcost = 5
-	var/deconcost = 10
+	var/wallcost = 20
+	var/floorcost = 25
+	var/launchcost = 10
+	var/deconcost = 20
 
 	var/walldelay = 10
 	var/floordelay = 10

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -709,10 +709,10 @@ RLD
 	ammo_sections = 5
 	has_ammobar = TRUE
 
-	var/wallcost = 25
-	var/floorcost = 30
-	var/launchcost = 20
-	var/deconcost = 25
+	var/wallcost = 20
+	var/floorcost = 20
+	var/launchcost = 30
+	var/deconcost = 10
 
 	var/walldelay = 10
 	var/floordelay = 10

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -701,18 +701,18 @@ RLD
 	icon_state = "rld"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	matter = 200
-	max_matter = 200
-	sheetmultiplier = 5
+	matter = 240
+	max_matter = 240
+	sheetmultiplier = 8
 	var/mode = LIGHT_MODE
 	actions_types = list(/datum/action/item_action/pick_color)
 	ammo_sections = 5
 	has_ammobar = TRUE
 
-	var/wallcost = 20
-	var/floorcost = 25
-	var/launchcost = 10
-	var/deconcost = 20
+	var/wallcost = 25
+	var/floorcost = 30
+	var/launchcost = 20
+	var/deconcost = 25
 
 	var/walldelay = 10
 	var/floordelay = 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10586
Reduces RLD matter capacity from 500 to 240
Reduces RLD matter increase per sheet from 16 to 8
Increases RLD wall Light construction costs from 10 to 20 (50 uses -> 10 uses)
Increases RLD floor light construction costs from 15 to 20 (~35 uses -> 10 uses)
Increases Light launch cost from 5 to 30 (100 uses -> 8 uses)

Costs will probably need adjustment, but are leaning towards the harsher end for now. Ideally they should be on par with RCDs in terms of costs and benefits.

## Why It's Good For The Game

Rapid Light Dispensers are currently very overpowered because of their ability to effectively spam maintenance with a flood of lights that antagonists/nightmares really cannot compete with. Darkness can be a very important tool for antags and removing that so easily with a single RLD capable of lighting up entire halves of maint is just not fun. It doesn't help that it's cheap as hell to do so in both mats and credits.
Not only that, having 500+ glowsticks thrown around fucks up the lighting system.

## Changelog
🆑
balance: RLDs now cost more to use, have reduced matter capacity, and sheets are worth less when refilling them.
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
