### PR TITLE
Fixes an inconsistency with the light eater and marker beacons

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -202,6 +202,10 @@
 		var/obj/item/I = AM
 		if(I.light_range && I.light_power)
 			disintegrate(I)
+	else if(istype(AM, /obj/structure/marker_beacon))
+		var/obj/structure/marker_beacon/I = AM
+		disintegrate(I)
+		//why the fuck is the marker beacon a structure? who. what. why.
 
 /obj/item/light_eater/proc/disintegrate(obj/item/O)
 	if(istype(O, /obj/item/pda))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Marker beacons are not detected by the light eater because they are not items and yes structures (why though?)
So I went ahead and changed that.

## Why It's Good For The Game

inconsistency bad, marker stacks can be used to ez powergame nightmares.

## Changelog
:cl:
fix: marker beacons should now be able to be properly destroyed by nightmares.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
