### PR TITLE
Makes revenants no longer able to be contaminated by radiation

### DIFF
--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -26,6 +26,7 @@
 	spacewalk = TRUE
 	sight = SEE_SELF
 	throwforce = 0
+	rad_flags = RAD_NO_CONTAMINATE | RAD_PROTECT_CONTENTS
 
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is a bug.

## Why It's Good For The Game

Let's not cover the station in the warm green glow. At least not that easily, shall we?

## Changelog
:cl:
bugfix: Revenants should no longer get irradiated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
