### PR TITLE
Allow putting numbers in names

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -103,7 +103,7 @@
 
 
 //Filters out undesirable characters from names
-/proc/reject_bad_name(t_in, allow_numbers=0, max_length=MAX_NAME_LEN)
+/proc/reject_bad_name(t_in, allow_numbers=1, max_length=MAX_NAME_LEN)
 	if(!t_in || length(t_in) > max_length)
 		return //Rejects the input if it is null or if it is longer then the max length allowed
 


### PR DESCRIPTION
## About The Pull Request

Exactly what it says on the tin - allows players to put numbers in their character names for normal characters. For instance, you can now name your IPC something like "Reginald-G62." Special names like clown, mime, chaplain god & religion, and Default Human are unaffected by this change, as they already provide a value to the allow_numbers parameter. Additionally, this also allows numbers to be used when renaming circuits, so you can, for example, now call your circuit flashlight the Pocket Light Mk3.

## Why It's Good For The Game

For people who want to play IPCs, synths, characters who are some kind of mass-produced clone, or anything similar, this adds more RP potential - same goes for the change to circuit naming.

## Changelog
:cl:
tweak: changed the default value of allow_numbers to 1.
/:cl:
