### PR TITLE
Re-lowers bloodsucker chaos level

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -765,7 +765,7 @@
   required_enemies = list(3,2,2,2,2,2,2,2,2,2)
   weight = 3
   cost = 10
-  requirements = list(90,80,70,60,55,50,45,40,35,30)
+  requirements = list(101,90,80,70,60,55,50,45,40,35)
   high_population_requirement = 30
   repeatable = FALSE
   chaos_min = 3.0

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -765,10 +765,10 @@
   required_enemies = list(3,2,2,2,2,2,2,2,2,2)
   weight = 3
   cost = 10
-  requirements = list(101,101,101,60,55,50,45,40,35,30)
+  requirements = list(90,80,70,60,55,50,45,40,35,30)
   high_population_requirement = 30
   repeatable = FALSE
-  chaos_min = 4.0
+  chaos_min = 3.0
 
 datum/dynamic_ruleset/midround/bloodsucker/trim_candidates()
 	..()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -844,9 +844,9 @@
 	required_candidates = 1
 	weight = 3
 	cost = 0
-	requirements = list(101,101,101,70,60,60,50,50,50,40)
+	requirements = list(101,101,50,40,40,30,30,30,20,20)
 	high_population_requirement = 10
-	chaos_min = 4.0
+	chaos_min = 3.0
 
 
 /datum/dynamic_ruleset/roundstart/bloodsucker/pre_execute()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lowers the chaos level and requirements required for bloodsuckers

## Why It's Good For The Game

Let's not place the most interesting antag that we've had in a very long time on a high chaos level on par with nukies, wizards and others when they don't even have kill objectives nor are nowhere near as disruptive as the other antags on chaos level 4.

What is this, did someone get salty because they got bitten by a vampire and had to drink iron for a while? Jesus...

## Changelog
:cl:
balance: Bloodsuckers moved to chaos level 3.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
