### PR TITLE
Various (small) Botany Changes

### DIFF
--- a/code/modules/hydroponics/grown/apple.dm
+++ b/code/modules/hydroponics/grown/apple.dm
@@ -38,7 +38,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/apple/gold
 	maturation = 10
 	production = 10
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/gold = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 40 // Alchemy!
 

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -69,7 +69,7 @@
 	plantname = "Mimana Tree"
 	product = /obj/item/reagent_containers/food/snacks/grown/banana/mime
 	growthstages = 4
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/consumable/nothing = 0.1, /datum/reagent/toxin/mutetoxin = 0.1, /datum/reagent/consumable/nutriment = 0.02)
 	rarity = 15
 
@@ -98,7 +98,7 @@
 	icon_grow = "banana-grow"
 	plantname = "Bluespace Banana Tree"
 	product = /obj/item/reagent_containers/food/snacks/grown/banana/bluespace
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/slip, /datum/plant_gene/trait/teleport, /datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list(/datum/reagent/bluespace = 0.2, /datum/reagent/consumable/banana = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.02)
 	rarity = 30

--- a/code/modules/hydroponics/grown/beans.dm
+++ b/code/modules/hydroponics/grown/beans.dm
@@ -39,7 +39,7 @@
 	plantname = "Koibean Plants"
 	product = /obj/item/reagent_containers/food/snacks/grown/koibeans
 	potency = 10
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/toxin/carpotoxin = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.05)
 	rarity = 20
 

--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -64,7 +64,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/berries/death
 	lifespan = 30
 	potency = 50
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/toxin/coniine = 0.08, /datum/reagent/toxin/staminatoxin = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 30
 
@@ -89,7 +89,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/berries/glow
 	lifespan = 30
 	endurance = 25
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/glow/white, /datum/plant_gene/trait/noreact, /datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list(/datum/reagent/uranium = 0.25, /datum/reagent/iodine = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 20
@@ -147,7 +147,7 @@
 	species = "bluecherry"
 	plantname = "Blue Cherry Tree"
 	product = /obj/item/reagent_containers/food/snacks/grown/bluecherries
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.07, /datum/reagent/consumable/sugar = 0.07)
 	rarity = 10
 
@@ -172,7 +172,7 @@
 	plantname = "Cherry Bulb Tree"
 	product = /obj/item/reagent_containers/food/snacks/grown/cherrybulbs
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/glow/pink)
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.07, /datum/reagent/consumable/sugar = 0.07)
 	rarity = 10
 
@@ -232,7 +232,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/grapes/green
 	reagents_add = list(/datum/reagent/medicine/kelotane = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1, /datum/reagent/consumable/sugar = 0.1)
 	// No rarity: technically it's a beneficial mutant, but it's not exactly "new"...
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 
 /obj/item/reagent_containers/food/snacks/grown/grapes/green
 	seed = /obj/item/seeds/grape/green
@@ -255,7 +255,7 @@
 	icon_grow = "strawberry-grow"
 	icon_dead = "berry-dead"
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.07, /datum/reagent/consumable/nutriment = 0.1, /datum/reagent/consumable/sugar = 0.2)
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 
 /obj/item/reagent_containers/food/snacks/grown/strawberry
 	seed = /obj/item/seeds/strawberry

--- a/code/modules/hydroponics/grown/cannabis.dm
+++ b/code/modules/hydroponics/grown/cannabis.dm
@@ -27,7 +27,7 @@
 	species = "megacannabis"
 	plantname = "Rainbow Weed"
 	product = /obj/item/reagent_containers/food/snacks/grown/cannabis/rainbow
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/toxin/mindbreaker = 0.15, /datum/reagent/toxin/lipolicide = 0.35)
 	rarity = 40
 
@@ -38,7 +38,7 @@
 	species = "blackcannabis"
 	plantname = "Deathweed"
 	product = /obj/item/reagent_containers/food/snacks/grown/cannabis/death
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/toxin/cyanide = 0.35, /datum/reagent/drug/space_drugs = 0.15, /datum/reagent/toxin/lipolicide = 0.15)
 	rarity = 40
 
@@ -49,7 +49,7 @@
 	species = "whitecannabis"
 	plantname = "Lifeweed"
 	product = /obj/item/reagent_containers/food/snacks/grown/cannabis/white
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/medicine/omnizine = 0.35, /datum/reagent/drug/space_drugs = 0.15, /datum/reagent/toxin/lipolicide = 0.15)
 	rarity = 40
 
@@ -61,7 +61,7 @@
 	species = "ocannabis"
 	plantname = "Omega Weed"
 	product = /obj/item/reagent_containers/food/snacks/grown/cannabis/ultimate
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/drug/space_drugs = 0.3,
 						/datum/reagent/toxin/mindbreaker = 0.3,
 						/datum/reagent/mercury = 0.15,

--- a/code/modules/hydroponics/grown/cereals.dm
+++ b/code/modules/hydroponics/grown/cereals.dm
@@ -34,7 +34,7 @@
 	species = "oat"
 	plantname = "Oat Stalks"
 	product = /obj/item/reagent_containers/food/snacks/grown/oat
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 
 /obj/item/reagent_containers/food/snacks/grown/oat
 	seed = /obj/item/seeds/wheat/oat
@@ -57,7 +57,7 @@
 	species = "rice"
 	plantname = "Rice Stalks"
 	product = /obj/item/reagent_containers/food/snacks/grown/rice
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	growthstages = 3
 
 /obj/item/reagent_containers/food/snacks/grown/rice
@@ -81,7 +81,7 @@
 	species = "meatwheat"
 	plantname = "Meatwheat"
 	product = /obj/item/reagent_containers/food/snacks/grown/meatwheat
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 
 /obj/item/reagent_containers/food/snacks/grown/meatwheat
 	name = "meatwheat"

--- a/code/modules/hydroponics/grown/chaos_shroom.dm
+++ b/code/modules/hydroponics/grown/chaos_shroom.dm
@@ -1,0 +1,11 @@
+//This file is to show off what "interesting" things the seeds' mutatespecie() proc could do, done by DragonTrance
+
+/obj/item/seeds/sample/chaos_mushroom
+	name = "Chaos Mushroom"
+	item_flags = ABSTRACT | DANGEROUS_POSSESSION	//Don't want people getting their hands on this from the xmas tree
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
+
+/obj/item/seeds/sample/chaos_mushroom/mutatespecie()
+	. = ..()
+	message_admins(":)")
+	ex_act(EXPLODE_HEAVY, src)

--- a/code/modules/hydroponics/grown/chili.dm
+++ b/code/modules/hydroponics/grown/chili.dm
@@ -15,7 +15,7 @@
 	icon_grow = "chili-grow" // Uses one growth icons set for all the subtypes
 	icon_dead = "chili-dead" // Same for the dead icon
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list(/obj/item/seeds/chili/ice, /obj/item/seeds/chili/ghost, /obj/item/seeds/chili/pink)
+	mutatelist = list(/obj/item/seeds/chili/ice, /obj/item/seeds/chili/ghost)
 	reagents_add = list(/datum/reagent/consumable/capsaicin = 0.25, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.04)
 
 /obj/item/reagent_containers/food/snacks/grown/chili

--- a/code/modules/hydroponics/grown/chili.dm
+++ b/code/modules/hydroponics/grown/chili.dm
@@ -15,7 +15,7 @@
 	icon_grow = "chili-grow" // Uses one growth icons set for all the subtypes
 	icon_dead = "chili-dead" // Same for the dead icon
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list(/obj/item/seeds/chili/ice, /obj/item/seeds/chili/ghost)
+	mutatelist = list(/obj/item/seeds/chili/ice, /obj/item/seeds/chili/ghost, /obj/item/seeds/chili/pink)
 	reagents_add = list(/datum/reagent/consumable/capsaicin = 0.25, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.04)
 
 /obj/item/reagent_containers/food/snacks/grown/chili
@@ -40,7 +40,7 @@
 	maturation = 4
 	production = 4
 	rarity = 20
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/consumable/frostoil = 0.25, /datum/reagent/consumable/nutriment/vitamin = 0.02, /datum/reagent/consumable/nutriment = 0.02)
 
 /obj/item/reagent_containers/food/snacks/grown/icepepper
@@ -66,7 +66,7 @@
 	production = 10
 	yield = 3
 	rarity = 20
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/consumable/condensedcapsaicin = 0.3, /datum/reagent/consumable/capsaicin = 0.55, /datum/reagent/consumable/nutriment = 0.04)
 
 /obj/item/reagent_containers/food/snacks/grown/ghost_chili
@@ -79,31 +79,6 @@
 	bitesize_mod = 4
 	foodtype = FRUIT
 	wine_power = 50
-
-//Pink-peppers
-/obj/item/seeds/chili/pink
-	name = "pack of pink pepper seeds"
-	desc = "These seeds grow into pink pepper plants."
-	icon_state = "seed-chilipink"
-	species = "chilipink"
-	plantname = "Pink Pepper Plants"
-	product = /obj/item/reagent_containers/food/snacks/grown/pink_chili
-	maturation = 6
-	production = 4
-	yield = 3
-	rarity = 20
-	mutatelist = list()
-	reagents_add = list("aphro" = 0.2, "penis_enlarger" = 0.08, "vitamin" = 0.04, "nutriment" = 0.04)
-
-/obj/item/reagent_containers/food/snacks/grown/pink_chili
-	seed = /obj/item/seeds/chili/pink
-	name = "pink pepper"
-	desc = "It looks almost like a knotted phallus. Is it... throbbing?"
-	icon_state = "pinkchilipepper"
-	filling_color = "#FF1458"
-	bitesize_mod = 3
-	foodtype = FRUIT
-	wine_power = 40
 
 /obj/item/reagent_containers/food/snacks/grown/ghost_chili/attack_hand(mob/user)
 	. = ..()
@@ -124,3 +99,30 @@
 	else
 		held_mob = null
 		..()
+
+//Pink-peppers
+/obj/item/seeds/chili/pink
+	name = "pack of pink pepper seeds"
+	desc = "These seeds grow into pink pepper plants."
+	icon_state = "seed-chilipink"
+	species = "chilipink"
+	plantname = "Pink Pepper Plants"
+	product = /obj/item/reagent_containers/food/snacks/grown/pink_chili
+	maturation = 6
+	production = 4
+	yield = 3
+	rarity = 20
+	genes = list(/datum/plant_gene/trait/repeated_harvest,
+		/datum/plant_gene/reagent/unextractable/aphro, /datum/plant_gene/reagent/unextractable/incubus)
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.04, /datum/reagent/consumable/nutriment/vitamin = 0.04)
+
+/obj/item/reagent_containers/food/snacks/grown/pink_chili
+	seed = /obj/item/seeds/chili/pink
+	name = "pink pepper"
+	desc = "It looks almost like a knotted phallus. Is it... throbbing?"
+	icon_state = "pinkchilipepper"
+	filling_color = "#FF1458"
+	bitesize_mod = 3
+	foodtype = FRUIT
+	wine_power = 40

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -78,6 +78,7 @@
 	icon_dead = "lime-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.05, /datum/reagent/medicine/haloperidol = 0.15)
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 
 /obj/item/reagent_containers/food/snacks/grown/citrus/orange_3d
 	seed = /obj/item/seeds/orange
@@ -113,6 +114,7 @@
 	icon_dead = "lime-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.05)
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 
 /obj/item/reagent_containers/food/snacks/grown/citrus/lemon
 	seed = /obj/item/seeds/lemon
@@ -138,6 +140,7 @@
 	endurance = 45
 	yield = 4
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.05)
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 
 /obj/item/reagent_containers/food/snacks/grown/firelemon
 	seed = /obj/item/seeds/firelemon

--- a/code/modules/hydroponics/grown/cocoa_vanilla.dm
+++ b/code/modules/hydroponics/grown/cocoa_vanilla.dm
@@ -38,7 +38,7 @@
 	plantname = "Vanilla Tree"
 	product = /obj/item/reagent_containers/food/snacks/grown/vanillapod
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/consumable/vanilla = 0.25, /datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/vanillapod
@@ -63,7 +63,7 @@
 	yield = 3
 	production = 7
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/consumable/enzyme = 0.1, /datum/reagent/consumable/nutriment = 0.1)
 	growthstages = 4
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'

--- a/code/modules/hydroponics/grown/corn.dm
+++ b/code/modules/hydroponics/grown/corn.dm
@@ -55,7 +55,7 @@
 	species = "snapcorn"
 	plantname = "Snapcorn Stalks"
 	product = /obj/item/grown/snapcorn
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	rarity = 10
 
 /obj/item/grown/snapcorn

--- a/code/modules/hydroponics/grown/cotton.dm
+++ b/code/modules/hydroponics/grown/cotton.dm
@@ -63,6 +63,7 @@
 	growthstages = 3
 	growing_icon = 'icons/obj/hydroponics/growing.dmi'
 	icon_dead = "cotton-dead"
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 
 /obj/item/grown/cotton/durathread
 	seed = /obj/item/seeds/cotton/durathread

--- a/code/modules/hydroponics/grown/eggplant.dm
+++ b/code/modules/hydroponics/grown/eggplant.dm
@@ -35,7 +35,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/shell/eggy
 	lifespan = 75
 	production = 12
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/shell/eggy

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -67,15 +67,10 @@
 	growing_icon = 'icons/obj/hydroponics/growing_flowers.dmi'
 	icon_grow = "spacemanstrumpet-grow"
 	icon_dead = "spacemanstrumpet-dead"
-	mutatelist = list()
-	genes = list(/datum/plant_gene/reagent/polypyr)
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
+	genes = list(/datum/plant_gene/reagent/unextractable/polypyr)
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.05)
 	rarity = 30
-
-/obj/item/seeds/poppy/lily/trumpet/Initialize(mapload, nogenes = FALSE)
-	. = ..()
-	if(!nogenes)
-		unset_mutability(/datum/plant_gene/reagent/polypyr, PLANT_GENE_EXTRACTABLE)
 
 /obj/item/reagent_containers/food/snacks/grown/trumpet
 	seed = /obj/item/seeds/poppy/lily/trumpet
@@ -94,7 +89,7 @@
 	species = "geranium"
 	plantname = "Geranium Plants"
 	product = /obj/item/reagent_containers/food/snacks/grown/poppy/geranium
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 
 /obj/item/reagent_containers/food/snacks/grown/poppy/geranium
 	seed = /obj/item/seeds/poppy/geranium
@@ -122,6 +117,7 @@
 	genes = list(/datum/plant_gene/trait/plant_type/weed_hardy)
 	growing_icon = 'icons/obj/hydroponics/growing_flowers.dmi'
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.04)
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 
 /obj/item/reagent_containers/food/snacks/grown/harebell
 	seed = /obj/item/seeds/harebell
@@ -185,7 +181,7 @@
 	icon_dead = "sunflower-dead"
 	product = /obj/item/reagent_containers/food/snacks/grown/moonflower
 	genes = list(/datum/plant_gene/trait/glow/purple)
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/consumable/ethanol/moonshine = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.02, /datum/reagent/consumable/nutriment = 0.02)
 	rarity = 15
 
@@ -210,7 +206,7 @@
 	icon_grow = "novaflower-grow"
 	icon_dead = "sunflower-dead"
 	product = /obj/item/grown/novaflower
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/consumable/condensedcapsaicin = 0.25, /datum/reagent/consumable/capsaicin = 0.3, /datum/reagent/consumable/nutriment = 0)
 	rarity = 20
 

--- a/code/modules/hydroponics/grown/garlic.dm
+++ b/code/modules/hydroponics/grown/garlic.dm
@@ -10,6 +10,7 @@
 	growthstages = 3
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
 	reagents_add = list("garlic" = 0.15, "nutriment" = 0.1)
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 
 /obj/item/reagent_containers/food/snacks/grown/garlic
 	seed = /obj/item/seeds/garlic

--- a/code/modules/hydroponics/grown/grass_carpet.dm
+++ b/code/modules/hydroponics/grown/grass_carpet.dm
@@ -50,6 +50,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/grass/fairy
 	icon_grow = "fairygrass-grow"
 	icon_dead = "fairygrass-dead"
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/glow/blue)
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.02, /datum/reagent/hydrogen = 0.05, /datum/reagent/drug/space_drugs = 0.15)
 
@@ -69,7 +70,7 @@
 	species = "carpet"
 	plantname = "Carpet"
 	product = /obj/item/reagent_containers/food/snacks/grown/grass/carpet
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	rarity = 10
 
 /obj/item/reagent_containers/food/snacks/grown/grass/carpet

--- a/code/modules/hydroponics/grown/kudzu.dm
+++ b/code/modules/hydroponics/grown/kudzu.dm
@@ -7,6 +7,7 @@
 	species = "kudzu"
 	plantname = "Kudzu"
 	product = /obj/item/reagent_containers/food/snacks/grown/kudzupod
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/plant_type/weed_hardy)
 	lifespan = 20
 	endurance = 10

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -11,7 +11,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	icon_dead = "watermelon-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list(/obj/item/seeds/watermelon/holy)
+	mutate_factor = PLANT_MUTATE_CUSTOM	//Custom to make lewd melon more rare in case of more "serious" scenarios, see mutatespecie()
 	reagents_add = list(/datum/reagent/water = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.2)
 
 /obj/item/seeds/watermelon/suicide_act(mob/user)
@@ -20,6 +20,16 @@
 	new product(drop_location())
 	qdel(src)
 	return MANUAL_SUICIDE
+
+/obj/item/seeds/watermelon/mutatespecie()
+	. = ..()
+	if (src != /obj/item/seeds/watermelon && . != PLANT_MUTATE_CUSTOM)
+		return
+
+	if (prob(70))
+		mutatelist = /obj/item/seeds/watermelon/holy
+	else
+		mutatelist = /obj/item/seeds/watermelon/milk
 
 /obj/item/reagent_containers/food/snacks/grown/watermelon
 	seed = /obj/item/seeds/watermelon
@@ -45,7 +55,7 @@
 	plantname = "Holy Melon Vines"
 	product = /obj/item/reagent_containers/food/snacks/grown/holymelon
 	genes = list(/datum/plant_gene/trait/glow/yellow)
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/water/holywater = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 20
 
@@ -71,8 +81,9 @@
 	species = "milkmelon"
 	plantname = "Milk Melon Vines"
 	product = /obj/item/reagent_containers/food/snacks/grown/milkmelon
-	mutatelist = list()
-	reagents_add = list("milk" = 0.2, "breast_enlarger" = 0.08, "vitamin" = 0.04, "nutriment" = 0.1)
+	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/reagent/unextractable/succubus)
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
+	reagents_add = list(/datum/reagent/consumable/milk = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 20
 
 /obj/item/reagent_containers/food/snacks/grown/milkmelon

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -11,7 +11,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	icon_dead = "watermelon-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutate_factor = PLANT_MUTATE_CUSTOM	//Custom to make lewd melon more rare in case of more "serious" scenarios, see mutatespecie()
+	mutatelist = list(/obj/item/seeds/watermelon/holy)
 	reagents_add = list(/datum/reagent/water = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.2)
 
 /obj/item/seeds/watermelon/suicide_act(mob/user)
@@ -21,6 +21,7 @@
 	qdel(src)
 	return MANUAL_SUICIDE
 
+/*	//Add this when someone decides lewd plants are fit enough to add again
 /obj/item/seeds/watermelon/mutatespecie()
 	. = ..()
 	if (src != /obj/item/seeds/watermelon && . != PLANT_MUTATE_CUSTOM)
@@ -30,6 +31,7 @@
 		mutatelist = /obj/item/seeds/watermelon/holy
 	else
 		mutatelist = /obj/item/seeds/watermelon/milk
+*/
 
 /obj/item/reagent_containers/food/snacks/grown/watermelon
 	seed = /obj/item/seeds/watermelon

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -19,6 +19,7 @@
 	yield = 4
 	potency = 15
 	growthstages = 4
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/medicine/morphine = 0.35, /datum/reagent/medicine/charcoal = 0.35, /datum/reagent/consumable/nutriment = 0)
@@ -71,6 +72,7 @@
 	yield = 2
 	potency = 35
 	growthstages = 3
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/drug/mushroomhallucinogen = 0.04, /datum/reagent/toxin/amatoxin = 0.1, /datum/reagent/consumable/nutriment = 0, /datum/reagent/toxin/amanitin = 0.2)
@@ -97,6 +99,7 @@
 	yield = 5
 	potency = 15
 	growthstages = 3
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/drug/mushroomhallucinogen = 0.25, /datum/reagent/consumable/nutriment = 0.02)
@@ -148,7 +151,7 @@
 	maturation = 5
 	yield = 1
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.05, /datum/reagent/consumable/nutriment = 0.15)
 	rarity = 30
 
@@ -212,14 +215,14 @@
 	endurance = 8
 	yield = 4
 	growthstages = 2
-	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/reagent/teslium, /datum/plant_gene/trait/plant_type/carnivory)
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
+	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/reagent/unextractable/teslium, /datum/plant_gene/trait/plant_type/carnivory)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/seeds/chanterelle/jupitercup/Initialize(mapload, nogenes = FALSE)
 	. = ..()
 	if(!nogenes)
-		unset_mutability(/datum/plant_gene/reagent/teslium, PLANT_GENE_EXTRACTABLE)
 		unset_mutability(/datum/plant_gene/trait/plant_type/carnivory, PLANT_GENE_REMOVABLE)
 
 /obj/item/reagent_containers/food/snacks/grown/mushroom/jupitercup
@@ -292,7 +295,7 @@
 	plantname = "Glowcaps"
 	product = /obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom/glowcap
 	genes = list(/datum/plant_gene/trait/glow/red, /datum/plant_gene/trait/cell_charge, /datum/plant_gene/trait/plant_type/fungal_metabolism)
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/teslium = 0.1, /datum/reagent/consumable/nutriment = 0.04)
 	rarity = 30
 
@@ -317,7 +320,7 @@
 	plantname = "Shadowshrooms"
 	product = /obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom/shadowshroom
 	genes = list(/datum/plant_gene/trait/glow/shadow, /datum/plant_gene/trait/plant_type/fungal_metabolism)
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/radium = 0.2, /datum/reagent/consumable/nutriment = 0.04)
 	rarity = 30
 
@@ -352,6 +355,7 @@
 	rarity = 20
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1)
 	resistance_flags = FIRE_PROOF
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 
 /obj/item/seeds/lavaland/polypore
 	name = "pack of polypore mycelium"

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -24,7 +24,7 @@
 	maturation = 8
 	yield = 2
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/plant_type/weed_hardy, /datum/plant_gene/trait/stinging)
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/toxin/acid/fluacid = 0.5, /datum/reagent/toxin/acid = 0.5)
 	rarity = 20
 

--- a/code/modules/hydroponics/grown/onion.dm
+++ b/code/modules/hydroponics/grown/onion.dm
@@ -35,6 +35,7 @@
 	species = "onion_red"
 	plantname = "Red Onion Sprouts"
 	weed_chance = 1
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	product = /obj/item/reagent_containers/food/snacks/grown/onion/red
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1, /datum/reagent/consumable/tearjuice = 0.05)
 

--- a/code/modules/hydroponics/grown/peach.dm
+++ b/code/modules/hydroponics/grown/peach.dm
@@ -14,6 +14,7 @@
 	icon_dead = "peach-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 
 /obj/item/reagent_containers/food/snacks/grown/peach
 	seed = /obj/item/seeds/peach

--- a/code/modules/hydroponics/grown/peanuts.dm
+++ b/code/modules/hydroponics/grown/peanuts.dm
@@ -9,6 +9,7 @@
 	growthstages = 4
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.02, /datum/reagent/consumable/nutriment = 0.15, /datum/reagent/consumable/cooking_oil = 0.03)
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 
 /obj/item/reagent_containers/food/snacks/grown/peanut
 	seed = /obj/item/seeds/peanutseed

--- a/code/modules/hydroponics/grown/potato.dm
+++ b/code/modules/hydroponics/grown/potato.dm
@@ -56,7 +56,7 @@
 	species = "sweetpotato"
 	plantname = "Sweet Potato Plants"
 	product = /obj/item/reagent_containers/food/snacks/grown/potato/sweet
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.1, /datum/reagent/consumable/sugar = 0.1, /datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/potato/sweet

--- a/code/modules/hydroponics/grown/pumpkin.dm
+++ b/code/modules/hydroponics/grown/pumpkin.dm
@@ -44,7 +44,7 @@
 	species = "blumpkin"
 	plantname = "Blumpkin Vines"
 	product = /obj/item/reagent_containers/food/snacks/grown/blumpkin
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/ammonia = 0.2, /datum/reagent/chlorine = 0.1, /datum/reagent/consumable/nutriment = 0.2)
 	rarity = 20
 

--- a/code/modules/hydroponics/grown/random.dm
+++ b/code/modules/hydroponics/grown/random.dm
@@ -11,6 +11,7 @@
 	icon_dead = "xpod-dead"
 	icon_harvest = "xpod-harvest"
 	growthstages = 4
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 
 /obj/item/seeds/random/Initialize()
 	. = ..()

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -13,6 +13,7 @@
 	production = 1
 	yield = 1 //seeds if there isn't a dna inside
 	potency = 30
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	var/volume = 5
 	var/ckey = null
 	var/realName = null

--- a/code/modules/hydroponics/grown/root.dm
+++ b/code/modules/hydroponics/grown/root.dm
@@ -44,7 +44,7 @@
 	plantname = "Parsnip"
 	product = /obj/item/reagent_containers/food/snacks/grown/parsnip
 	icon_dead = "carrot-dead"
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.05, /datum/reagent/consumable/nutriment = 0.05)
 
 /obj/item/reagent_containers/food/snacks/grown/parsnip
@@ -97,6 +97,7 @@
 	yield = 6
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
 	icon_dead = "whitebeet-dead"
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/maxchem)
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.05, /datum/reagent/consumable/nutriment = 0.05)
 

--- a/code/modules/hydroponics/grown/tea_coffee.dm
+++ b/code/modules/hydroponics/grown/tea_coffee.dm
@@ -13,7 +13,7 @@
 	growthstages = 5
 	icon_dead = "tea-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list(/obj/item/seeds/tea/astra)
+	mutatelist = list(/obj/item/seeds/tea/astra, /obj/item/seeds/tea/catnip)
 	reagents_add = list(/datum/reagent/toxin/teapowder = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/tea
@@ -33,7 +33,7 @@
 	species = "teaastra"
 	plantname = "Tea Astra Plant"
 	product = /obj/item/reagent_containers/food/snacks/grown/tea/astra
-	mutatelist = list(/obj/item/seeds/tea/catnip)
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/medicine/synaptizine = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/toxin/teapowder = 0.1)
 	rarity = 20
 
@@ -52,6 +52,7 @@
 	desc = "Long stocks with flowering tips that has a chemical to make feline attracted to it."
 	species = "catnip"
 	plantname = "Catnip Plant"
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	product = /obj/item/reagent_containers/food/snacks/grown/tea/catnip
 	reagents_add = list(/datum/reagent/pax/catnip = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.06, /datum/reagent/toxin/teapowder = 0.3)
 	rarity = 50
@@ -101,7 +102,7 @@
 	species = "coffeer"
 	plantname = "Coffee Robusta Bush"
 	product = /obj/item/reagent_containers/food/snacks/grown/coffee/robusta
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/medicine/ephedrine = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/toxin/coffeepowder = 0.1)
 	rarity = 20
 

--- a/code/modules/hydroponics/grown/tea_coffee.dm
+++ b/code/modules/hydroponics/grown/tea_coffee.dm
@@ -48,7 +48,7 @@
 // Kitty drugs
 /obj/item/seeds/tea/catnip
 	name = "pack of catnip seeds"
-	icon_state = "seed-catnip"
+	//icon_state = "seed-catnip"	//Currently has no icon, so for now just use the default tea icons until it gets sprited, or until I can find a sprite
 	desc = "Long stocks with flowering tips that has a chemical to make feline attracted to it."
 	species = "catnip"
 	plantname = "Catnip Plant"

--- a/code/modules/hydroponics/grown/tobacco.dm
+++ b/code/modules/hydroponics/grown/tobacco.dm
@@ -31,7 +31,7 @@
 	species = "stobacco"
 	plantname = "Space Tobacco Plant"
 	product = /obj/item/reagent_containers/food/snacks/grown/tobacco/space
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/medicine/salbutamol = 0.05, /datum/reagent/drug/nicotine = 0.08, /datum/reagent/consumable/nutriment = 0.03)
 	rarity = 20
 

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -35,7 +35,7 @@
 	species = "bloodtomato"
 	plantname = "Blood-Tomato Plants"
 	product = /obj/item/reagent_containers/food/snacks/grown/tomato/blood
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	reagents_add = list(/datum/reagent/blood = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 20
 
@@ -83,7 +83,7 @@
 	plantname = "Bluespace Tomato Plants"
 	product = /obj/item/reagent_containers/food/snacks/grown/tomato/blue/bluespace
 	yield = 2
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/squash, /datum/plant_gene/trait/slip, /datum/plant_gene/trait/teleport, /datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list(/datum/reagent/lube = 0.2, /datum/reagent/bluespace = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 50
@@ -110,7 +110,7 @@
 	icon_grow = "killertomato-grow"
 	icon_harvest = "killertomato-harvest"
 	icon_dead = "killertomato-dead"
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	rarity = 30
 
 /obj/item/reagent_containers/food/snacks/grown/tomato/killer

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -24,7 +24,7 @@
 	species = "steelcap"
 	plantname = "Steel Caps"
 	product = /obj/item/grown/log/steel
-	mutatelist = list()
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	rarity = 20
 
 
@@ -115,6 +115,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing.dmi'
 	icon_dead = "bamboo-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 
 /obj/item/grown/log/bamboo
 	seed = /obj/item/seeds/bamboo
@@ -163,7 +164,7 @@
 /obj/structure/bonfire/prelit/Initialize()
 	. = ..()
 	StartBurning()
-	
+
 /obj/structure/bonfire/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && (mover.pass_flags & PASSTABLE))
 		return TRUE

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -1,3 +1,14 @@
+//These defines are for seed's mutatespecie() proc for custom stuff that happens when the seed mutates
+//Originally made for making milky melons a bit more rare to get, since holy melons could be more desired in high chaos rounds
+
+#define PLANT_MUTATE_CANNOTMUTATE	-1	//We cannot mutate into anything else, don't do anything
+#define PLANT_MUTATE_GENERIC		1	//We *can* mutate, take the default mutation list and set tray variables
+
+#define PLANT_MUTATE_NOCONTINUE		2	//We mutated, but don't do anything to the plant tray
+#define PLANT_MUTATE_CUSTOM			3	//We've mutated, but custom stuff has happened, and we continue with the default things
+//I also wanted to put these in a different file but byond just hated me doing that so I put these here
+
+
 // Plant analyzer
 /obj/item/plant_analyzer
 	name = "plant analyzer"

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -390,18 +390,43 @@
 	mutate(4, 10, 2, 4, 50, 4, 10, 3)
 
 
-/obj/machinery/hydroponics/proc/mutatespecie() // Mutagent produced a new plant!
+/obj/machinery/hydroponics/proc/mutatespecie() // Mutagen produced a new plant!
 	if(!myseed || dead)
 		return
 
+
 	var/oldPlantName = myseed.plantname
-	if(myseed.mutatelist.len > 0)
-		var/mutantseed = pick(myseed.mutatelist)
-		qdel(myseed)
-		myseed = null
-		myseed = new mutantseed
-	else
-		return
+
+	switch(myseed.mutatespecie())
+		if (PLANT_MUTATE_CANNOTMUTATE)
+			return
+
+		if (PLANT_MUTATE_GENERIC)
+			if(myseed.mutatelist.len > 0)
+				var/mutantseed = pick(myseed.mutatelist)
+				qdel(myseed)
+				myseed = null
+				myseed = new mutantseed
+				myseed.plantname = oldPlantName
+			else
+				return
+
+		if (PLANT_MUTATE_NOCONTINUE)
+			if(myseed.mutatelist.len > 0)
+				var/mutantseed = pick(myseed.mutatelist)
+				qdel(myseed)
+				myseed = null
+				myseed = new mutantseed
+				myseed.plantname = oldPlantName
+			return
+
+		if (PLANT_MUTATE_CUSTOM)
+			var/mutantseed = pick(myseed.mutatelist)
+			qdel(myseed)
+			myseed = null
+			myseed = new mutantseed
+			myseed.plantname = oldPlantName
+
 
 	hardmutate()
 	age = 0
@@ -410,8 +435,9 @@
 	harvest = 0
 	weedlevel = 0 // Reset
 
-	sleep(5) // Wait a while
+	sleep(5) // Wait a bit
 	update_icon()
+	myseed.plantname = initial(myseed.plantname)
 	visible_message("<span class='warning'>[oldPlantName] suddenly mutates into [myseed.plantname]!</span>")
 
 

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -109,7 +109,7 @@
 // Reagent genes store reagent ID and reagent ratio. Amount of reagent in the plant = 1 + (potency * rate)
 /datum/plant_gene/reagent
 	name = "Nutriment"
-	var/reagent_id = "nutriment"
+	var/reagent_id = /datum/reagent/consumable/nutriment
 	var/rate = 0.04
 
 /datum/plant_gene/reagent/get_name()
@@ -125,12 +125,13 @@
 	return formatted_name
 
 /datum/plant_gene/reagent/proc/set_reagent(reag_id)
-	reagent_id = reag_id
 	name = "UNKNOWN"
-
 	var/datum/reagent/R = GLOB.chemical_reagents_list[reag_id]
-	if(R && R.type == reagent_id)
+
+	if (R && istype(R, /datum/reagent))	//sanity check
 		name = R.name
+		reagent_id = reag_id
+
 
 /datum/plant_gene/reagent/New(reag_id = null, reag_rate = 0)
 	..()
@@ -153,15 +154,38 @@
 			return FALSE
 	return TRUE
 
-/datum/plant_gene/reagent/polypyr
+/datum/plant_gene/reagent/unextractable
+	name = "Unextractable Gene"
+	reagent_id = /datum/reagent/consumable/nutriment/vitamin
+	rate = 0.01
+	mutability_flags = PLANT_GENE_REMOVABLE		//This gene can be removed, but it cannot be extracted into a disk
+
+/datum/plant_gene/reagent/unextractable/polypyr
 	name = "Polypyrylium Oligomers"
-	reagent_id = "polypyr"
+	reagent_id = /datum/reagent/medicine/polypyr
 	rate = 0.15
 
-/datum/plant_gene/reagent/teslium
+/datum/plant_gene/reagent/unextractable/teslium
 	name = "Teslium"
-	reagent_id = "teslium"
+	reagent_id = /datum/reagent/teslium
 	rate = 0.1
+
+
+//Lewd chems
+/datum/plant_gene/reagent/unextractable/incubus
+	name = "Incubus Draft"
+	reagent_id = /datum/reagent/fermi/penis_enlarger
+	rate = 0.04		//Changed from 8% to 4%, because the most growns you can get per harvest is 20, even 4% seems like a lot
+
+/datum/plant_gene/reagent/unextractable/succubus
+	name = "Succubus Milk"
+	reagent_id = /datum/reagent/fermi/breast_enlarger
+	rate = 0.04		//Same with this. Not making it 5% because 100 potency will equate this to 5 units of succubus, instead of 4
+
+/datum/plant_gene/reagent/unextractable/aphro
+	name = "Crocin"
+	reagent_id = /datum/reagent/drug/aphrodisiac
+	rate = 0.2
 
 // Various traits affecting the product.
 /datum/plant_gene/trait

--- a/code/modules/hydroponics/sample.dm
+++ b/code/modules/hydroponics/sample.dm
@@ -4,6 +4,7 @@
 	potency = -1
 	yield = -1
 	var/sample_color = "#FFFFFF"
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 
 /obj/item/seeds/sample/Initialize()
 	. = ..()

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -24,6 +24,7 @@
 	var/potency = 10				// The 'power' of a plant. Generally effects the amount of reagent in a plant, also used in other ways.
 	var/growthstages = 6			// Amount of growth sprites the plant has.
 	var/rarity = 0					// How rare the plant is. Used for giving points to cargo when shipping off to CentCom.
+	var/mutate_factor = PLANT_MUTATE_GENERIC	//How we handle getting mutated, in case we want to do extra stuff when mutating into a species
 	var/list/mutatelist = list()	// The type of plants that this plant can mutate into.
 	var/list/genes = list()			// Plant genes are stored here, see plant_genes.dm for more info.
 	var/list/forbiddengenes = list()			// Plant genes that the seed may be forbidden from having.
@@ -122,6 +123,9 @@ obj/item/seeds/proc/is_gene_forbidden(typepath)
 	adjust_weed_chance(rand(-wcmut, wcmut))
 	if(prob(traitmut))
 		add_random_traits(1, 1)
+
+/obj/item/seeds/proc/mutatespecie()		//This is to handle what the seed does just before mutating
+	return mutate_factor
 
 
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1433,7 +1433,7 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 	overdose_threshold = 50
 	taste_description = "numbing bitterness"
 
-/datum/reagent/medicine/polypyr/on_mob_life(mob/living/carbon/M) //I w?nted a collection of small positive effects, this is as hard to obtain as coniine after all.
+/datum/reagent/medicine/polypyr/on_mob_life(mob/living/carbon/M) //I wanted a collection of small positive effects, this is as hard to obtain as coniine after all.
 	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, -0.25)
 	M.adjustBruteLoss(-0.35, 0)
 	if(prob(50))

--- a/code/modules/research/xenoarch/xenobotany/grown/amauri.dm
+++ b/code/modules/research/xenoarch/xenobotany/grown/amauri.dm
@@ -12,6 +12,7 @@
 	growing_icon = 'code/modules/research/xenoarch/xenobotany/icons/growing.dmi'
 	icon_grow = "amauri-stage"
 	growthstages = 3
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list("shadowmutationtoxin" = 0.1)
 

--- a/code/modules/research/xenoarch/xenobotany/grown/gelthi.dm
+++ b/code/modules/research/xenoarch/xenobotany/grown/gelthi.dm
@@ -12,6 +12,7 @@
 	growing_icon = 'code/modules/research/xenoarch/xenobotany/icons/growing.dmi'
 	icon_grow = "gelthi-stage"
 	growthstages = 3
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list("gold" = 0.1)
 

--- a/code/modules/research/xenoarch/xenobotany/grown/jurlmah.dm
+++ b/code/modules/research/xenoarch/xenobotany/grown/jurlmah.dm
@@ -12,6 +12,7 @@
 	growing_icon = 'code/modules/research/xenoarch/xenobotany/icons/growing.dmi'
 	icon_grow = "jurlmah-stage"
 	growthstages = 5
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list("cryoxadone" = 0.1)
 

--- a/code/modules/research/xenoarch/xenobotany/grown/nofruit.dm
+++ b/code/modules/research/xenoarch/xenobotany/grown/nofruit.dm
@@ -12,6 +12,7 @@
 	growing_icon = 'code/modules/research/xenoarch/xenobotany/icons/growing.dmi'
 	icon_grow = "nofruit-stage"
 	growthstages = 4
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list("nothing" = 0.1, "laughter" = 0.1)
 

--- a/code/modules/research/xenoarch/xenobotany/grown/shand.dm
+++ b/code/modules/research/xenoarch/xenobotany/grown/shand.dm
@@ -12,6 +12,7 @@
 	growing_icon = 'code/modules/research/xenoarch/xenobotany/icons/growing.dmi'
 	icon_grow = "shand-stage"
 	growthstages = 3
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list("pax" = 0.1)
 

--- a/code/modules/research/xenoarch/xenobotany/grown/surik.dm
+++ b/code/modules/research/xenoarch/xenobotany/grown/surik.dm
@@ -12,6 +12,7 @@
 	growing_icon = 'code/modules/research/xenoarch/xenobotany/icons/growing.dmi'
 	icon_grow = "surik-stage"
 	growthstages = 4
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list("frostoil" = 0.1)
 

--- a/code/modules/research/xenoarch/xenobotany/grown/telriis.dm
+++ b/code/modules/research/xenoarch/xenobotany/grown/telriis.dm
@@ -12,6 +12,7 @@
 	growing_icon = 'code/modules/research/xenoarch/xenobotany/icons/growing.dmi'
 	icon_grow = "telriis-stage"
 	growthstages = 4
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list("podmutationtoxin" = 0.1)
 

--- a/code/modules/research/xenoarch/xenobotany/grown/thaadra.dm
+++ b/code/modules/research/xenoarch/xenobotany/grown/thaadra.dm
@@ -12,6 +12,7 @@
 	growing_icon = 'code/modules/research/xenoarch/xenobotany/icons/growing.dmi'
 	icon_grow = "thaadra-stage"
 	growthstages = 4
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list("silver" = 0.1)
 

--- a/code/modules/research/xenoarch/xenobotany/grown/vale.dm
+++ b/code/modules/research/xenoarch/xenobotany/grown/vale.dm
@@ -12,6 +12,7 @@
 	growing_icon = 'code/modules/research/xenoarch/xenobotany/icons/growing.dmi'
 	icon_grow = "vale-stage"
 	growthstages = 4
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list("slime_toxin" = 0.1)
 

--- a/code/modules/research/xenoarch/xenobotany/grown/vaporsac.dm
+++ b/code/modules/research/xenoarch/xenobotany/grown/vaporsac.dm
@@ -12,6 +12,7 @@
 	growing_icon = 'code/modules/research/xenoarch/xenobotany/icons/growing.dmi'
 	icon_grow = "vaporsac-stage"
 	growthstages = 3
+	mutate_factor = PLANT_MUTATE_CANNOTMUTATE
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list("nitrous_oxide" = 0.1)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1833,6 +1833,7 @@
 #include "code\modules\hydroponics\grown\berries.dm"
 #include "code\modules\hydroponics\grown\cannabis.dm"
 #include "code\modules\hydroponics\grown\cereals.dm"
+#include "code\modules\hydroponics\grown\chaos_shroom.dm"
 #include "code\modules\hydroponics\grown\chili.dm"
 #include "code\modules\hydroponics\grown\citrus.dm"
 #include "code\modules\hydroponics\grown\cocoa_vanilla.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Tea now mutates into astra or catnip, instead of Tea > Astra > Catnip, since one is undoubtedly better than the other in some way. As such, Tea Astra no longer mutates into catnip.
- Spam-clicking with mutagen on a plant makes it no longer detectable that it's already mutated ("uses the bucket on gaia" > "deus mutates into gaia")
- Fixes some plants not adding reagents, i.e. spaceman trumpet


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Provides fixes for plants, flexibility for customization in the future if we wanna do anything fancy when a plant mutates, encourages people to grow catnip more, and makes mutagen a teeny bit harder to manage by hiding that the plant had already mutated before it tells you in the chat "Deus suddenly mutates into Gaia!"

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: catnip uses the icons from regular tea now, instead of no icon. this is temporary until I can find a proper icon for catnip, or until someone from the discord is willing to make sprites
add: seeds now have mutatespecie() for special actions to execute when the seeds mutate into a different species. In case we wanna do any fancy stuff
add: some defines in hydroitemdefines.dm. I know this isn't what the file is for, but I got compile errors otherwise
add: Admin-only spawn of a plant that shows off what interesting things the mutatespecie() proc could do (chaos_shroom.dm), dont spawn it cause if it does work as intended (which i TOTALLY didn't check), it makes a big explosion when mutated
balance: Pink Peppers produces 4% incubus instead of 8% and cannot be extracted
balance: Milk Melons produces 4% succubus instead of 8% and cannot be extracted
fix: some plants not adding the correct reagents from genes
code: organized a few things
code: /obj/item/seeds/ now uses mutate_factor, see hydroitemdefines.dm for more info
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
