### PR TITLE
Pooj Blood Code Cleanup

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -109,12 +109,7 @@ GLOBAL_LIST_INIT(all_types_bloods,list(
 		"BUG"
 		))
 
-GLOBAL_LIST_INIT(blood_types, list(
-		"blood",
-		"jellyblood"
-		))
-
-GLOBAL_LIST_INIT(blood_id_types, list(
-		"blood" = /datum/reagent/blood,
-		"jellyblood" = /datum/reagent/blood/jellyblood
+GLOBAL_LIST_INIT(blood_reagent_types, list(
+		/datum/reagent/blood,
+		/datum/reagent/blood/jellyblood
 		))

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -262,7 +262,7 @@
 			if(blood_id)
 				data["occupant"]["blood"] = list() // We can start populating this list.
 				var/blood_type = C.dna.blood_type
-				if(blood_id != "blood") // special blood substance
+				if(!(blood_id in GLOB.blood_reagent_types)) // special blood substance
 					var/datum/reagent/R = GLOB.chemical_reagents_list[blood_id]
 					if(R)
 						blood_type = R.name

--- a/code/game/objects/effects/decals/cleanable/aliens.dm
+++ b/code/game/objects/effects/decals/cleanable/aliens.dm
@@ -30,13 +30,19 @@
 	var/list/diseases = list()
 	SEND_SIGNAL(src, COMSIG_GIBS_STREAK, directions, diseases)
 	var/direction = pick(directions)
-	for(var/i in 0 to pick(0, 200; 1, 150; 2, 50))
-		sleep(2)
-		if(i > 0)
+	var/dist = 0
+	if(prob(50))		//yes this and the one below are different for a reason.
+		if(prob(25))
+			dist = 2
+		else
+			dist = 1
+	if(dist)
+		for(var/i in 1 to dist)
+			sleep(2)
 			var/obj/effect/decal/cleanable/blood/splatter/xeno/splat = new /obj/effect/decal/cleanable/blood/splatter/xeno(loc, diseases)
 			splat.transfer_blood_dna(blood_DNA, diseases)
-		if(!step_to(src, get_step(src, direction), 0))
-			break
+			if(!step_to(src, get_step(src, direction), 0))
+				break
 
 /obj/effect/decal/cleanable/blood/gibs/xeno/up
 	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6","gibup1","gibup1","gibup1")

--- a/code/game/objects/effects/decals/cleanable/gibs.dm
+++ b/code/game/objects/effects/decals/cleanable/gibs.dm
@@ -5,7 +5,7 @@
 	layer = LOW_OBJ_LAYER
 	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6")
 	mergeable_decal = FALSE
-	bloodiness = 0
+	bloodiness = 0				//This isn't supposed to be bloody.
 	var/body_colors = "#e3ba84"	//a default color just in case.
 	var/gibs_reagent_id = /datum/reagent/liquidgibs
 	var/gibs_bloodtype = "A+"
@@ -19,7 +19,6 @@
 	if(gibs_bloodtype)
 		add_blood_DNA(list("Non-human DNA" = gibs_bloodtype), diseases)
 	update_icon()
-
 
 /obj/effect/decal/cleanable/blood/gibs/update_icon()
 	add_atom_colour(blood_DNA_to_color(), FIXED_COLOUR_PRIORITY)
@@ -45,13 +44,18 @@
 	var/list/diseases = list()
 	SEND_SIGNAL(src, COMSIG_GIBS_STREAK, directions, diseases)
 	var/direction = pick(directions)
-	for(var/i in 0 to pick(0, 200; 1, 150; 2, 50))
-		sleep(2)
-		if(i > 0)
+	var/dist = 0
+	if(prob(50))		//yes this and the one below are different for a reason.
+		if(prob(25))
+			dist = 2
+		else
+			dist = 1
+	if(dist)
+		for(var/i in 1 to dist)
 			var/obj/effect/decal/cleanable/blood/splatter/splat = new /obj/effect/decal/cleanable/blood/splatter(loc, diseases)
 			splat.transfer_blood_dna(blood_DNA, diseases)
-		if(!step_to(src, get_step(src, direction), 0))
-			break
+			if(!step_to(src, get_step(src, direction), 0))
+				break
 
 /obj/effect/decal/cleanable/blood/gibs/up
 	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6","gibup1","gibup1","gibup1")

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -414,20 +414,18 @@ GENE SCANNER
 	// Blood Level
 	if(M.has_dna())
 		var/mob/living/carbon/C = M
-		var/blood_id = C.get_blood_id()
-		if(blood_id)
+		var/blood_typepath = C.get_blood_id()
+		if(blood_typepath)
 			if(ishuman(C))
 				var/mob/living/carbon/human/H = C
 				if(H.bleed_rate)
 					msg += "<span class='danger'>Subject is bleeding!</span>\n"
 			var/blood_percent =  round((C.scan_blood_volume() / (BLOOD_VOLUME_NORMAL * C.blood_ratio))*100)
 			var/blood_type = C.dna.blood_type
-			if(blood_id != ("blood" || "jellyblood"))//special blood substance
-				var/datum/reagent/R = GLOB.chemical_reagents_list[blood_id]
+			if(!(blood_typepath in GLOB.blood_reagent_types))
+				var/datum/reagent/R = GLOB.chemical_reagents_list[blood_typepath]
 				if(R)
 					blood_type = R.name
-				else
-					blood_type = blood_id
 			if(C.scan_blood_volume() <= (BLOOD_VOLUME_SAFE*C.blood_ratio) && C.scan_blood_volume() > (BLOOD_VOLUME_OKAY*C.blood_ratio))
 				msg += "<span class='danger'>LOW blood level [blood_percent] %, [C.scan_blood_volume()] cl,</span> <span class='info'>type: [blood_type]</span>\n"
 			else if(C.scan_blood_volume() <= (BLOOD_VOLUME_OKAY*C.blood_ratio))

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -398,7 +398,6 @@
 		fingerprintshidden = from.fingerprintshidden.Copy()
 	if(from.fingerprintslast)
 		fingerprintslast = from.fingerprintslast
-	//TODO bloody overlay
 
 /obj/item/stack/microwave_act(obj/machinery/microwave/M)
 	if(istype(M) && M.dirty < 100)

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -346,7 +346,6 @@
 		icon_state = "dualsaber[item_color][wielded]"
 	else
 		icon_state = "dualsaber0"
-
 	clean_blood()
 
 /obj/item/twohanded/dualsaber/attack(mob/target, mob/living/carbon/human/user)

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -65,7 +65,6 @@
 
 	fingerprintslast = M.ckey
 
-
 //Set ignoregloves to add prints irrespective of the mob having gloves on.
 /atom/proc/add_fingerprint(mob/living/M, ignoregloves = FALSE)
 	if(!M || !M.key)

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -836,7 +836,7 @@
 	px_x = 2
 	px_y = 12
 	max_stamina_damage = 50
-	stam_heal_tick = 2
+	stam_heal_tick = 4
 
 /obj/item/bodypart/r_leg/is_disabled()
 	if(HAS_TRAIT(owner, TRAIT_PARALYSIS_R_LEG))

--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -17,7 +17,6 @@
 			return L
 	return FALSE
 
-
 /mob/proc/has_left_hand(check_disabled = TRUE)
 	return TRUE
 
@@ -45,8 +44,6 @@
 /mob/living/carbon/alien/larva/has_right_hand()
 	return TRUE
 
-
-
 /mob/proc/has_left_leg()
 	return TRUE
 
@@ -66,7 +63,6 @@
 		return TRUE
 	else
 		return FALSE
-
 
 //Limb numbers
 /mob/proc/get_num_arms(check_disabled = TRUE)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -223,11 +223,6 @@ obj/item/organ/heart/cybernetic/upgraded/on_life()
 
 /obj/item/organ/heart/ipc
 	name = "IPC heart"
-	desc = "An electronic pump that regulates hydraulic functions, the electronics have EMP shielding."
-	icon_state = "heart-c"
-
-/obj/item/organ/heart/ipc
-	name = "IPC heart"
 	desc = "An electronic pump that regulates hydraulic functions, they have an auto-restart after EMPs."
 	icon_state = "heart-c"
 	organ_flags = ORGAN_SYNTHETIC

--- a/modular_citadel/code/modules/reagents/reagents/cit_reagents.dm
+++ b/modular_citadel/code/modules/reagents/reagents/cit_reagents.dm
@@ -1,7 +1,7 @@
 //body bluids
 /datum/reagent/consumable/semen
 	name = "Semen"
-	description = "Sperm from some animal. I bet you'll drink this out of a bucket someday."
+	description = "Sperm from some animal. Useless for anything but insemination, really."
 	taste_description = "something salty"
 	taste_mult = 2 //Not very overpowering flavor
 	data = list("donor"=null,"viruses"=null,"donor_DNA"=null,"blood_type"=null,"resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null)


### PR DESCRIPTION
Cleanup/Partial revert of RGB blood ""rework""

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10705 and https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10910

## Why It's Good For The Game

Now that we have the reagent ID refactor, it's about time to fix pooj's blood code with silicons' fixes.


## Changelog
🆑
refactor: A good amount of the blood RGB rework was cleaned up/reverted, with some notable gameplay changes including: Gibs and blood not having max blood by default (no more easy rampages, cultists), infinite gib streaking, etc etc.
fix: Fixed a little issue with sleeper UI and blood types.
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
