### PR TITLE
Adds the Ability to deconstruct various objects

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -112,7 +112,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	flags_1 = CONDUCT_1
 	resistance_flags = FIRE_PROOF
 	merge_type = /obj/item/stack/sheet/metal
-	grind_results = list("iron" = 20)
+	grind_results = list(/datum/reagent/iron = 20)
 	point_value = 2
 	tableVariant = /obj/structure/table
 
@@ -175,7 +175,7 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 80)
 	resistance_flags = FIRE_PROOF
 	merge_type = /obj/item/stack/sheet/plasteel
-	grind_results = list("iron" = 20, "plasma" = 20)
+	grind_results = list(/datum/reagent/iron = 20, /datum/reagent/toxin/plasma = 20)
 	point_value = 23
 	tableVariant = /obj/structure/table/reinforced
 
@@ -240,7 +240,7 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	resistance_flags = FLAMMABLE
 	merge_type = /obj/item/stack/sheet/mineral/wood
 	novariants = TRUE
-	grind_results = list("carbon" = 20)
+	grind_results = list(/datum/reagent/carbon = 20)
 
 /obj/item/stack/sheet/mineral/wood/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.wood_recipes
@@ -426,6 +426,15 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 	new/datum/stack_recipe("large box", /obj/structure/closet/cardboard, 4), \
 	new/datum/stack_recipe("cardboard cutout", /obj/item/cardboard_cutout, 5), \
 	null, \
+	new /datum/stack_recipe("donut box", /obj/item/storage/fancy/donut_box),				\
+	new /datum/stack_recipe("donk-pockets box", /obj/item/storage/box/donkpockets),			\
+	new /datum/stack_recipe("donk-pockets spicy box", /obj/item/storage/box/donkpockets/donkpocketspicy),			\
+	new /datum/stack_recipe("donk-pockets teriyaki box", /obj/item/storage/box/donkpockets/donkpocketteriyaki),		\
+	new /datum/stack_recipe("donk-pockets pizza box", /obj/item/storage/box/donkpockets/donkpocketpizza),			\
+	new /datum/stack_recipe("donk-pockets berry box", /obj/item/storage/box/donkpockets/donkpocketberry),			\
+	new /datum/stack_recipe("donk-pockets honk box", /obj/item/storage/box/donkpockets/donkpockethonk),				\
+	new /datum/stack_recipe("monkey cube box", /obj/item/storage/box/monkeycubes),
+	null, \
 	new/datum/stack_recipe("colored brown", /obj/item/storage/box/brown), \
 	new/datum/stack_recipe("colored green", /obj/item/storage/box/green), \
 	new/datum/stack_recipe("colored red", /obj/item/storage/box/blue), \
@@ -489,7 +498,7 @@ GLOBAL_LIST_INIT(runed_metal_recipes, list ( \
 	sheettype = "runed"
 	merge_type = /obj/item/stack/sheet/runed_metal
 	novariants = TRUE
-	grind_results = list("iron" = 5, "blood" = 15)
+	grind_results = list(/datum/reagent/iron = 5, /datum/reagent/blood = 15)
 
 /obj/item/stack/sheet/runed_metal/ratvar_act()
 	new /obj/item/stack/tile/brass(loc, amount)
@@ -565,7 +574,7 @@ GLOBAL_LIST_INIT(brass_recipes, list ( \
 	throw_range = 3
 	turf_type = /turf/open/floor/clockwork
 	novariants = FALSE
-	grind_results = list("iron" = 5, "teslium" = 15, "holyoil" = 1)
+	grind_results = list(/datum/reagent/iron = 5, /datum/reagent/teslium = 15, /datum/reagent/fuel/holyoil = 1)
 	merge_type = /obj/item/stack/tile/brass
 	tableVariant = /obj/structure/table/reinforced/brass
 
@@ -618,7 +627,7 @@ GLOBAL_LIST_INIT(bronze_recipes, list ( \
 	throw_range = 3
 	turf_type = /turf/open/floor/bronze
 	novariants = FALSE
-	grind_results = list("iron" = 5, "copper" = 3) //we have no "tin" reagent so this is the closest thing
+	grind_results = list(/datum/reagent/iron = 5, /datum/reagent/copper = 3) //we have no "tin" reagent so this is the closest thing
 	merge_type = /obj/item/stack/tile/bronze
 	tableVariant = /obj/structure/table/bronze
 
@@ -672,7 +681,7 @@ GLOBAL_LIST_INIT(bronze_recipes, list ( \
 	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 1
 	throw_range = 3
-	grind_results = list("carbon" = 10)
+	grind_results = list(/datum/reagent/carbon = 10)
 	merge_type = /obj/item/stack/sheet/bone
 
 GLOBAL_LIST_INIT(plastic_recipes, list(

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -17,30 +17,34 @@
  * Metal
  */
 GLOBAL_LIST_INIT(metal_recipes, list ( \
-	new/datum/stack_recipe("stool", /obj/structure/chair/stool, one_per_turf = TRUE, on_floor = TRUE), \
-	new/datum/stack_recipe("bar stool", /obj/structure/chair/stool/bar, one_per_turf = TRUE, on_floor = TRUE), \
-	new/datum/stack_recipe("chair", /obj/structure/chair, one_per_turf = TRUE, on_floor = TRUE), \
-	new/datum/stack_recipe("bed", /obj/structure/bed, 2, one_per_turf = TRUE, on_floor = TRUE), \
-	//CIT CHANGE - adds sofas to metal recipe list
-	new/datum/stack_recipe_list("sofas", list( \
-		new /datum/stack_recipe("sofa (middle)", /obj/structure/chair/sofa, one_per_turf = TRUE, on_floor = TRUE), \
-		new /datum/stack_recipe("sofa (left)", /obj/structure/chair/sofa/left, one_per_turf = TRUE, on_floor = TRUE), \
-		new /datum/stack_recipe("sofa (right)", /obj/structure/chair/sofa/right, one_per_turf = TRUE, on_floor = TRUE), \
-		new /datum/stack_recipe("sofa (corner)", /obj/structure/chair/sofa/corner, one_per_turf = TRUE, on_floor = TRUE), \
-		)), \
-	//END OF CIT CHANGES
-	null, \
-	new/datum/stack_recipe_list("office chairs", list( \
+	new/datum/stack_recipe_list("seats", \
+		list( \
+		new/datum/stack_recipe("stool", /obj/structure/chair/stool, one_per_turf = TRUE, on_floor = TRUE), \
+		new/datum/stack_recipe("bar stool", /obj/structure/chair/stool/bar, one_per_turf = TRUE, on_floor = TRUE), \
+		new/datum/stack_recipe("chair", /obj/structure/chair, one_per_turf = TRUE, on_floor = TRUE), \
+		null, \
 		new/datum/stack_recipe("dark office chair", /obj/structure/chair/office/dark, 5, one_per_turf = TRUE, on_floor = TRUE), \
 		new/datum/stack_recipe("light office chair", /obj/structure/chair/office/light, 5, one_per_turf = TRUE, on_floor = TRUE), \
-		)), \
-	new/datum/stack_recipe_list("comfy chairs", list( \
+		null, \
 		new/datum/stack_recipe("beige comfy chair", /obj/structure/chair/comfy/beige, 2, one_per_turf = TRUE, on_floor = TRUE), \
 		new/datum/stack_recipe("black comfy chair", /obj/structure/chair/comfy/black, 2, one_per_turf = TRUE, on_floor = TRUE), \
 		new/datum/stack_recipe("brown comfy chair", /obj/structure/chair/comfy/brown, 2, one_per_turf = TRUE, on_floor = TRUE), \
 		new/datum/stack_recipe("lime comfy chair", /obj/structure/chair/comfy/lime, 2, one_per_turf = TRUE, on_floor = TRUE), \
-		new/datum/stack_recipe("teal comfy chair", /obj/structure/chair/comfy/teal, 2, one_per_turf = TRUE, on_floor = TRUE), \
+		new/datum/stack_recipe("teal comfy chair", /obj/structure/chair/comfy/teal, 2, one_per_turf = TRUE, on_floor = TRUE) \
 		)), \
+	//CIT CHANGE - adds sofas to metal recipe list
+	new/datum/stack_recipe_list("sofas", \
+		list( \
+		new/datum/stack_recipe("sofa (middle)", /obj/structure/chair/sofa, one_per_turf = TRUE, on_floor = TRUE), \
+		new/datum/stack_recipe("sofa (left)", /obj/structure/chair/sofa/left, one_per_turf = TRUE, on_floor = TRUE), \
+		new/datum/stack_recipe("sofa (right)", /obj/structure/chair/sofa/right, one_per_turf = TRUE, on_floor = TRUE), \
+		new/datum/stack_recipe("sofa (corner)", /obj/structure/chair/sofa/corner, one_per_turf = TRUE, on_floor = TRUE) \
+		)), \
+	//END OF CIT CHANGES
+	new/datum/stack_recipe("bed", /obj/structure/bed, 2, one_per_turf = TRUE, on_floor = TRUE), \
+	null, \
+	//add this when I can find a way to make them easily constructible > new/datum/stack_recipe("sink", /obj/structure/sink, 2, one_per_turf = TRUE, on_floor = TRUE),
+	new/datum/stack_recipe("shower", /obj/machinery/shower/crafted, 2, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \
 	new/datum/stack_recipe("rack parts", /obj/item/rack_parts), \
 	new/datum/stack_recipe("closet", /obj/structure/closet, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
@@ -56,7 +60,8 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("modular console", /obj/machinery/modular_computer/console/buildable/, 10, time = 25, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("machine frame", /obj/structure/frame/machine, 5, time = 25, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \
-	new /datum/stack_recipe_list("airlock assemblies", list( \
+	new /datum/stack_recipe_list("airlock assemblies", \
+		list( \
 		new /datum/stack_recipe("standard airlock assembly", /obj/structure/door_assembly, 4, time = 50, one_per_turf = 1, on_floor = 1), \
 		new /datum/stack_recipe("public airlock assembly", /obj/structure/door_assembly/door_assembly_public, 4, time = 50, one_per_turf = 1, on_floor = 1), \
 		new /datum/stack_recipe("command airlock assembly", /obj/structure/door_assembly/door_assembly_com, 4, time = 50, one_per_turf = 1, on_floor = 1), \
@@ -74,7 +79,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 		new /datum/stack_recipe("external maintenance airlock assembly", /obj/structure/door_assembly/door_assembly_extmai, 4, time = 50, one_per_turf = 1, on_floor = 1), \
 		new /datum/stack_recipe("airtight hatch assembly", /obj/structure/door_assembly/door_assembly_hatch, 4, time = 50, one_per_turf = 1, on_floor = 1), \
 		new /datum/stack_recipe("maintenance hatch assembly", /obj/structure/door_assembly/door_assembly_mhatch, 4, time = 50, one_per_turf = 1, on_floor = 1), \
-	)), \
+		)), \
 	null, \
 	new/datum/stack_recipe("firelock frame", /obj/structure/firelock_frame, 3, time = 50, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("turret frame", /obj/machinery/porta_turret_construct, 5, time = 25, one_per_turf = TRUE, on_floor = TRUE), \
@@ -107,7 +112,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	flags_1 = CONDUCT_1
 	resistance_flags = FIRE_PROOF
 	merge_type = /obj/item/stack/sheet/metal
-	grind_results = list(/datum/reagent/iron = 20)
+	grind_results = list("iron" = 20)
 	point_value = 2
 	tableVariant = /obj/structure/table
 
@@ -170,7 +175,7 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 80)
 	resistance_flags = FIRE_PROOF
 	merge_type = /obj/item/stack/sheet/plasteel
-	grind_results = list(/datum/reagent/iron = 20, /datum/reagent/toxin/plasma = 20)
+	grind_results = list("iron" = 20, "plasma" = 20)
 	point_value = 23
 	tableVariant = /obj/structure/table/reinforced
 
@@ -235,7 +240,7 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	resistance_flags = FLAMMABLE
 	merge_type = /obj/item/stack/sheet/mineral/wood
 	novariants = TRUE
-	grind_results = list(/datum/reagent/carbon = 20)
+	grind_results = list("carbon" = 20)
 
 /obj/item/stack/sheet/mineral/wood/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.wood_recipes
@@ -421,15 +426,6 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 	new/datum/stack_recipe("large box", /obj/structure/closet/cardboard, 4), \
 	new/datum/stack_recipe("cardboard cutout", /obj/item/cardboard_cutout, 5), \
 	null, \
-	new /datum/stack_recipe("donut box", /obj/item/storage/fancy/donut_box),				\
-	new /datum/stack_recipe("donk-pockets box", /obj/item/storage/box/donkpockets),			\
-	new /datum/stack_recipe("donk-pockets spicy box", /obj/item/storage/box/donkpockets/donkpocketspicy),			\
-	new /datum/stack_recipe("donk-pockets teriyaki box", /obj/item/storage/box/donkpockets/donkpocketteriyaki),		\
-	new /datum/stack_recipe("donk-pockets pizza box", /obj/item/storage/box/donkpockets/donkpocketpizza),			\
-	new /datum/stack_recipe("donk-pockets berry box", /obj/item/storage/box/donkpockets/donkpocketberry),			\
-	new /datum/stack_recipe("donk-pockets honk box", /obj/item/storage/box/donkpockets/donkpockethonk),				\
-	new /datum/stack_recipe("monkey cube box", /obj/item/storage/box/monkeycubes),
-	null, \
 	new/datum/stack_recipe("colored brown", /obj/item/storage/box/brown), \
 	new/datum/stack_recipe("colored green", /obj/item/storage/box/green), \
 	new/datum/stack_recipe("colored red", /obj/item/storage/box/blue), \
@@ -493,7 +489,7 @@ GLOBAL_LIST_INIT(runed_metal_recipes, list ( \
 	sheettype = "runed"
 	merge_type = /obj/item/stack/sheet/runed_metal
 	novariants = TRUE
-	grind_results = list(/datum/reagent/iron = 5, /datum/reagent/blood = 15)
+	grind_results = list("iron" = 5, "blood" = 15)
 
 /obj/item/stack/sheet/runed_metal/ratvar_act()
 	new /obj/item/stack/tile/brass(loc, amount)
@@ -569,7 +565,7 @@ GLOBAL_LIST_INIT(brass_recipes, list ( \
 	throw_range = 3
 	turf_type = /turf/open/floor/clockwork
 	novariants = FALSE
-	grind_results = list(/datum/reagent/iron = 5, /datum/reagent/teslium = 15, /datum/reagent/fuel/holyoil = 1)
+	grind_results = list("iron" = 5, "teslium" = 15, "holyoil" = 1)
 	merge_type = /obj/item/stack/tile/brass
 	tableVariant = /obj/structure/table/reinforced/brass
 
@@ -622,7 +618,7 @@ GLOBAL_LIST_INIT(bronze_recipes, list ( \
 	throw_range = 3
 	turf_type = /turf/open/floor/bronze
 	novariants = FALSE
-	grind_results = list(/datum/reagent/iron = 5, /datum/reagent/copper = 3) //we have no "tin" reagent so this is the closest thing
+	grind_results = list("iron" = 5, "copper" = 3) //we have no "tin" reagent so this is the closest thing
 	merge_type = /obj/item/stack/tile/bronze
 	tableVariant = /obj/structure/table/bronze
 
@@ -676,7 +672,7 @@ GLOBAL_LIST_INIT(bronze_recipes, list ( \
 	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 1
 	throw_range = 3
-	grind_results = list(/datum/reagent/carbon = 10)
+	grind_results = list("carbon" = 10)
 	merge_type = /obj/item/stack/sheet/bone
 
 GLOBAL_LIST_INIT(plastic_recipes, list(

--- a/code/game/objects/structures/loom.dm
+++ b/code/game/objects/structures/loom.dm
@@ -8,14 +8,45 @@
 	density = TRUE
 	anchored = TRUE
 
-/obj/structure/loom/attackby(obj/item/stack/sheet/W, mob/user)
-	if(W.is_fabric && W.amount > 1)
-		user.show_message("<span class='notice'>You start weaving the [W.name] through the loom..</span>", 1)
-		if(W.use_tool(src, user, W.pull_effort))
-			new W.loom_result(drop_location())
-			user.show_message("<span class='notice'>You weave the [W.name] into a workable fabric.</span>", 1)
-			W.amount = (W.amount - 2)
-			if(W.amount < 1)
-				qdel(W)
+/obj/structure/loom/attackby(obj/item/I, mob/user)
+	if (user.a_intent != INTENT_HELP)
+		return ..()
+	if (istype(I, /obj/item/stack/sheet))
+		if (!anchored)
+			return to_chat(user, "<span class='notice'>You have to anchor [src] first!</span>")
+
+		var/obj/item/stack/sheet/W = I
+		if(W.is_fabric && W.amount > 1)
+			user.visible_message("<span class='notice'[user] starts weaving [W.name] through the loom.</span>",
+								"<span class='notice'>You start weaving the [W.name] through the loom.</span>")
+
+			if(W.use_tool(src, user, W.pull_effort))
+				new W.loom_result(drop_location())
+				to_chat(user, "<span class='notice'>You weave the [W.name] into a workable fabric.</span>")
+				W.amount = (W.amount - 2)
+				if(W.amount < 1)
+					qdel(W)
+		else
+			to_chat("<span class='notice'>You need at least 2 [W.name] to loom into fabric!</span>")
 	else
-		user.show_message("<span class='notice'>You need a valid fabric and at least 2 of said fabric before using this.</span>", 1)
+		switch (I.tool_behaviour)
+			if (TOOL_SCREWDRIVER)
+				user.visible_message("<span class='info'>[user] starts disassembling [src]...</span>",
+									"<span class='info'>You start disassembling [src]...</span>")
+				I.play_tool_sound(src)
+				if(I.use_tool(src, user, 60))
+					playsound(src.loc, 'sound/items/deconstruct.ogg', 50, TRUE)
+					deconstruct(TRUE)
+			if (TOOL_WRENCH)
+				if (anchored)
+					to_chat(user, "<span class='notice'>You unsecure the [src].</span>")
+					I.play_tool_sound(src)
+					anchored = FALSE
+				else
+					to_chat(user, "<span class='notice'>You secure the [src].</span>")
+					I.play_tool_sound(src)
+					anchored = TRUE
+
+/obj/structure/loom/deconstruct(disassembled = TRUE)
+	new /obj/item/stack/sheet/mineral/wood (get_turf(src), 10)
+	qdel(src)

--- a/code/game/objects/structures/loom.dm
+++ b/code/game/objects/structures/loom.dm
@@ -37,6 +37,7 @@
 				if(I.use_tool(src, user, 60))
 					playsound(src.loc, 'sound/items/deconstruct.ogg', 50, TRUE)
 					deconstruct(TRUE)
+				return
 			if (TOOL_WRENCH)
 				if (anchored)
 					to_chat(user, "<span class='notice'>You unsecure the [src].</span>")
@@ -46,6 +47,8 @@
 					to_chat(user, "<span class='notice'>You secure the [src].</span>")
 					I.play_tool_sound(src)
 					anchored = TRUE
+				return
+	return ..()
 
 /obj/structure/loom/deconstruct(disassembled = TRUE)
 	new /obj/item/stack/sheet/mineral/wood (get_turf(src), 10)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -219,6 +219,9 @@
 	var/watertemp = "normal"	//freezing, normal, or boiling
 	var/datum/looping_sound/showering/soundloop
 
+/obj/machinery/shower/crafted	//When created from sheets of metal
+	anchored = FALSE
+
 /obj/machinery/shower/Initialize()
 	. = ..()
 	soundloop = new(list(src), FALSE)
@@ -226,6 +229,29 @@
 /obj/machinery/shower/Destroy()
 	QDEL_NULL(soundloop)
 	return ..()
+
+/obj/machinery/shower/deconstruct(disassembled = TRUE)
+	new /obj/item/stack/sheet/metal (get_turf(src), 2)
+	Destroy()
+
+//Copy from /obj/structure/chair
+/obj/machinery/shower/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE, CALLBACK(src, .proc/can_user_rotate),CALLBACK(src, .proc/can_be_rotated),null)
+
+/obj/machinery/shower/proc/can_be_rotated(mob/user)
+	return !anchored
+
+/obj/machinery/shower/proc/can_user_rotate(mob/user)
+	if(istype(user, /mob/living))
+		if(!user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
+			return FALSE
+		else
+			return TRUE
+	else if(isobserver(user) && CONFIG_GET(flag/ghost_interaction))
+		return TRUE
+	return FALSE
+////
 
 /obj/effect/mist
 	name = "mist"
@@ -236,6 +262,8 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /obj/machinery/shower/interact(mob/M)
+	if (!anchored)
+		return to_chat(M, "<span class='warning'>You have to connect [src] to the floor first!</span>")
 	on = !on
 	update_icon()
 	add_fingerprint(M)
@@ -258,25 +286,56 @@
 
 /obj/machinery/shower/attackby(obj/item/I, mob/user, params)
 	if(I.type == /obj/item/analyzer)
-		to_chat(user, "<span class='notice'>The water temperature seems to be [watertemp].</span>")
-	else
+		to_chat(user, "<span class='notice'>The water temperature seems to be <span class='bold'>[watertemp]</span>.</span>")
+		return
+
+	if (user.a_intent != INTENT_HELP)
 		return ..()
 
-/obj/machinery/shower/wrench_act(mob/living/user, obj/item/I)
-	to_chat(user, "<span class='notice'>You begin to adjust the temperature valve with \the [I]...</span>")
-	if(I.use_tool(src, user, 50))
-		switch(watertemp)
-			if("normal")
-				watertemp = "freezing"
-			if("freezing")
-				watertemp = "boiling"
-			if("boiling")
-				watertemp = "normal"
-		user.visible_message("<span class='notice'>[user] adjusts the shower with \the [I].</span>", "<span class='notice'>You adjust the shower with \the [I] to [watertemp] temperature.</span>")
-		log_game("[key_name(user)] has wrenched a shower to [watertemp] at ([x],[y],[z])")
-		add_hiddenprint(user)
-	return TRUE
+	switch (I.tool_behaviour)
+		if (TOOL_WRENCH)
+			if (!anchored)
+				user.visible_message("<span class='notice'>[user] starts to take apart [src]...</span>", "<span class='notice'>You start dismantling [src]...</span>")
+				I.play_tool_sound(src)
+				if(I.use_tool(src, user, 20))
+					deconstruct(TRUE)
+			else
+				to_chat(user, "<span class='notice'>You begin to adjust the temperature valve with \the [I]...</span>")
+				if(I.use_tool(src, user, 50))
+					switch(watertemp)
+						if("normal")
+							watertemp = "freezing"
+						if("freezing")
+							watertemp = "boiling"
+						if("boiling")
+							watertemp = "normal"
+					user.visible_message("<span class='notice'>[user] adjusts the shower with \the [I].</span>", "<span class='notice'>You adjust the shower with \the [I] to [watertemp] temperature.</span>")
+					log_game("[key_name(user)] has wrenched a shower to [watertemp] at ([x],[y],[z])")
+					add_hiddenprint(user)
 
+		if (TOOL_SCREWDRIVER)
+			if (!anchored)
+				to_chat(user, "<span class='notice'>You begin screwing in [src] to the floor...</span>")
+				I.play_tool_sound(src)
+				if(I.use_tool(src, user, 30))
+					user.visible_message("<span class='notice'>[user] connects [src] to the floor.</span>", "<span class='notice'>You connect [src] to the floor.</span>")
+					anchored = TRUE
+			else
+				to_chat(user, "<span class='notice'>You start to take out [src]'s screws...</span>")
+				on = FALSE
+				soundloop.stop()
+				update_icon()
+				I.play_tool_sound(src)
+				if(I.use_tool(src, user, 20))
+					user.visible_message("<span class='notice'>[user] disconnects [src] from the floor.</span>", "<span class='notice'>You disconnect [src] from the floor.</span>")
+					anchored = FALSE
+
+/obj/machinery/shower/examine()
+	. += ..()
+	if (anchored)
+		. += "<span class='info'>It looks like it can be taken apart with a <span class='bold'>screwdriver</span>...</span>"
+	else
+		. += "<span class='info'>Its <span class='bold'>screws</span> are out of place, allowing it to be <span class='bold'>dismantled with a wrench</span>.</span>"
 
 /obj/machinery/shower/update_icon()	//this is terribly unreadable, but basically it makes the shower mist up
 	cut_overlays()					//once it's been on for a while, in addition to handling the water overlay.
@@ -463,6 +522,27 @@
 	anchored = TRUE
 	var/busy = FALSE 	//Something's being washed at the moment
 	var/dispensedreagent = /datum/reagent/water // for whenever plumbing happens
+	layer = WALL_OBJ_LAYER
+
+/*/obj/structure/sink/Initialize()	//This doesn't work in the slightest. It used to at some point through development, but that made it so you cant interact with the object whatsoever. I hate this.
+	. = ..()
+	switch (dir)	//Thinking about moving this into its own construction sequence so it can actually work, like using a screwdriver will set its pixel offset, but I feel like that's too much
+		if (NORTH)	//Or maybe putting it in lateinit... but that's sloppy and I feel like it wont work when spawning it in after the round starts
+			pixel_x = pixel_y = 0
+			layer = WALL_OBJ_LAYER
+		if (EAST)
+			pixel_x = 12
+			pixel_y = 3
+			layer = WALL_OBJ_LAYER
+		if (SOUTH)
+			pixel_y = 24
+			pixel_x = 0
+			layer = ABOVE_OBJ_LAYER
+		if (WEST)
+			pixel_x = -12
+			pixel_y = 3
+			layer = WALL_OBJ_LAYER
+*/
 
 
 /obj/structure/sink/attack_hand(mob/living/user)
@@ -509,7 +589,16 @@
 
 /obj/structure/sink/attackby(obj/item/O, mob/living/user, params)
 	if(busy)
-		to_chat(user, "<span class='warning'>Someone's already washing here!</span>")
+		to_chat(user, "<span class='warning'>Someone's already washing here.</span>")
+		return
+
+	if (istype(O, /obj/item/wrench) && user.a_intent == INTENT_HELP)
+		to_chat(user, "<span class='notice'>You start deconstructing [src]...</span>")
+		O.play_tool_sound(src)
+
+		if(O.use_tool(src, user, 20))
+			playsound(src.loc, 'sound/items/deconstruct.ogg', 50, TRUE)
+			deconstruct(TRUE)
 		return
 
 	if(istype(O, /obj/item/reagent_containers))
@@ -574,15 +663,12 @@
 		return ..()
 
 /obj/structure/sink/deconstruct(disassembled = TRUE)
-	new /obj/item/stack/sheet/metal (loc, 3)
+	new /obj/item/stack/sheet/metal (loc, 2)
 	qdel(src)
-
-
 
 /obj/structure/sink/kitchen
 	name = "kitchen sink"
 	icon_state = "sink_alt"
-
 
 /obj/structure/sink/puddle	//splishy splashy ^_^
 	name = "puddle"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can now deconstruct looms, wooden/ferment barrels, sinks and showers. You can also now construct showers, and the metal sheet crafting menu has been sorted a tiny bit

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
1. Looms always created runtimes if you used anything on it other than a material sheet
2. You don't have to bash wooden barrels, sinks or showers to get rid of them anymore
3. The ability to move showers around gives creative and utility flexibility

## How to deconstruct said structures
- Looms can be deconstructed with screwdrivers, and bolted to the floor with wrenches
- Wooden barrels' actions are the same as looms, with the addition of it creating a reaction on adjacent tiles (depending on how many reagents are in the barrel) when you successfully deconstruct it.
- Showers can be disconnected from the floor with a screwdriver, then dismantled with a wrench. When created from a sheet of metal, you just have to screw them to the floor

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: various things can be deconstructed
add: showers can be moved around
fix: removed loom runtimes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
