### PR TITLE
Ports "Nerfs Cloning" by Silicons

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -4,7 +4,7 @@
 //Potential replacement for genetics revives or something I dunno (?)
 
 #define CLONE_INITIAL_DAMAGE     150    //Clones in clonepods start with 150 cloneloss damage and 150 brainloss damage, thats just logical
-#define MINIMUM_HEAL_LEVEL 40
+#define MINIMUM_HEAL_LEVEL 20
 
 #define SPEAK(message) radio.talk_into(src, message, radio_channel)
 
@@ -61,18 +61,15 @@
 	QDEL_LIST(unattached_flesh)
 	. = ..()
 
-/obj/machinery/clonepod/RefreshParts()
+/obj/machinery/clonepod/RefreshParts()	
 	speed_coeff = 0
 	efficiency = 0
 	for(var/obj/item/stock_parts/scanning_module/S in component_parts)
 		efficiency += S.rating
 	for(var/obj/item/stock_parts/manipulator/P in component_parts)
-		speed_coeff += P.rating
-	heal_level = (efficiency * 15) + 10
-	if(heal_level < MINIMUM_HEAL_LEVEL)
-		heal_level = MINIMUM_HEAL_LEVEL
-	if(heal_level > 100)
-		heal_level = 100
+		speed_coeff += (P.rating / 2)
+	speed_coeff = max(1, speed_coeff)
+	heal_level = CLAMP((efficiency * 10) + 10, MINIMUM_HEAL_LEVEL, 100)
 
 //The return of data disks?? Just for transferring between genetics machine/cloning machine.
 //TO-DO: Make the genetics machine accept them.
@@ -164,8 +161,7 @@
 	var/mob/living/carbon/human/H = new /mob/living/carbon/human(src)
 
 	H.hardset_dna(ui, mutation_index, H.real_name, null, mrace, features)
-	if(prob(50 - efficiency*10)) //Chance to give a bad mutation.
-		H.easy_randmut(NEGATIVE+MINOR_NEGATIVE) //100% bad mutation. Can be cured with mutadone.
+	H.easy_randmut(NEGATIVE+MINOR_NEGATIVE) //100% bad mutation. Can be cured with mutadone.
 
 	H.silent = 20 //Prevents an extreme edge case where clones could speak if they said something at exactly the right moment.
 	occupant = H


### PR DESCRIPTION
## About The Pull Request

60 clone damage at tier 1 --> 80 clone damage at tier 1
No clone damage at full tier 4 --> 10 clone damage at tier 4
No mutation at tier 4/50% chance of mutation at tier 1 (rng sucks too) --> always bad SE mutation
400% speed at tier 4 --> 200% speed at tier 4

All scaling is linear.

## Why It's Good For The Game

Cloning makes death too worthless at times.
I don't want to take the nuclear route of removing cloning, I also don't want to remove prescanning (at this time at the very least), autocloning is whatever and I feel like removing it will just prompt doctors to camp the cloner. (I don't agree with autocloning though, it's just that with prescanning and without autocloning you're just going to have these issues, and I haven't identified a method to solve said issues yet.)

It may be worthwhile in the future to have autocloning notify medical and be able to be postponed for cases where medical is trying to defib someone instead of clone them.

Cloning was buffed way too much by the introduction of tier 4 parts a few years back anyways. While this does knock down tier 1 effectiveness, it also makes tier 4 not an end-all entirely to cloning being imperfect in usual circumstances.

The goal here is to make cloning not almost effortless to recover from. I will never agree with stuff like "Add permanent modifiers to max health or something to make cloning suffering" or anything like that which can't be fixed through medical even if it takes effort, but since we don't have a middle ground yet I feel this would make medbay have to still treat people who are cloned yet not make cloning permanently gank you from any effectiveness in the round.

## Changelog
🆑
balance: Cloning has been nerfed.
/🆑

Side note, experimental cloners are untouched, so your duplicate army memes are safe.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
