### PR TITLE
Balances Gamer Food

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_vend.dm
+++ b/code/modules/food_and_drinks/food/snacks_vend.dm
@@ -85,11 +85,11 @@
 	desc = "fine print: seasoned with nanoscale mechanochemical generators. Not only does it taste good, But also self-heats when opened"
 	icon_state = "soyfood"
 	trash = /obj/item/trash/soy_food
-	list_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/sugar = 2, /datum/reagent/consumable/nutriment/vitamin = 3)
-	junkiness = 0
+	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 2)
+	junkiness = 25
 	filling_color = "#FFD700"
 	tastes = list("nanomachines" = 2, "soybeans" = 5)
-	foodtype = DAIRY | GRAIN
+	foodtype = JUNKFOOD | DAIRY | GRAIN
 
 /obj/item/reagent_containers/food/snacks/syndicake
 	name = "syndi-cakes"
@@ -106,7 +106,7 @@
 	desc = "A self-heating bag of hollowed charcoal noodles with a spicy soy sauce glaze. Does contain small traces of charcoal."
 	icon_state = "carbonnanotube_noodles"
 	trash = /obj/item/trash/carbonnanotube_noodles
-	list_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/medicine/charcoal = 1, /datum/reagent/consumable/nutriment/vitamin = 4)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/medicine/charcoal = 1, /datum/reagent/consumable/nutriment/vitamin = 4)
 	junkiness = 0
 	filling_color = "#FFD700"
 	tastes = list("charcoal" = 1, "spiciness" = 3, "soysauce" = 3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Re-balancing more food items that were added without a sense of proper balance.

Shifts Soyfood values to be more on par with junkfood, since they are "sold" as junkfood.
Removes 1 nutriment value from carbon nanotube noodles.

## Why It's Good For The Game

Making things balanced is good.

## Changelog
:cl:
balance: Carbon Nanotube Noodles and Soyfood nutritional values were adjusted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
