### PR TITLE
Borg equipment changes

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -489,7 +489,9 @@
 		out procedures"
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
-	module_type = /obj/item/robot_module/medical
+	module_type = list(
+		/obj/item/robot_module/medical,
+		/obj/item/robot_module/medihound)
 
 /obj/item/borg/upgrade/processor/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
@@ -620,31 +622,6 @@
 		if (RPED)
 			R.module.remove_module(RPED, TRUE)
 
-/obj/item/borg/upgrade/circuit_app
-	name = "circuit manipulation apparatus"
-	desc = "An engineering cyborg upgrade allowing for manipulation of circuit boards."
-	icon_state = "cyborg_upgrade3"
-	require_module = TRUE
-	module_type = list(/obj/item/robot_module/engineering)
-
-/obj/item/borg/upgrade/circuit_app/action(mob/living/silicon/robot/R, user = usr)
-	. = ..()
-	if(.)
-		var/obj/item/borg/apparatus/circuit/C = locate() in R.module.modules
-		if(C)
-			to_chat(user, "<span class='warning'>This unit is already equipped with a circuit apparatus!</span>")
-			return FALSE
-
-		C = new(R.module)
-		R.module.basic_modules += C
-		R.module.add_module(C, FALSE, TRUE)
-
-/obj/item/borg/upgrade/circuit_app/deactivate(mob/living/silicon/robot/R, user = usr)
-	. = ..()
-	if (.)
-		var/obj/item/borg/apparatus/circuit/C = locate() in R.module.modules
-		if (C)
-			R.module.remove_module(C, TRUE)
 
 /obj/item/borg/upgrade/pinpointer
 	name = "medical cyborg crew pinpointer"

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -489,9 +489,7 @@
 		out procedures"
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
-	module_type = list(
-		/obj/item/robot_module/medical,
-		/obj/item/robot_module/medihound)
+	module_type = /obj/item/robot_module/medical
 
 /obj/item/borg/upgrade/processor/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -329,6 +329,7 @@
 		/obj/item/stack/sheet/rglass/cyborg,
 		/obj/item/stack/rods/cyborg,
 		/obj/item/stack/tile/plasteel/cyborg,
+		/obj/item/weapon/gripper,
 		/obj/item/stack/cable_coil/cyborg)
 	emag_modules = list(/obj/item/borg/stun)
 	ratvar_modules = list(

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -768,15 +768,6 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
-/datum/design/borg_upgrade_circuit_app
-	name = "Cyborg Upgrade (Circuit Manipulator)"
-	id = "borg_upgrade_circuitapp"
-	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/circuit_app
-	materials = list(MAT_METAL=2000, MAT_TITANIUM=500)
-	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
-
 /datum/design/borg_upgrade_pinpointer
 	name = "Cyborg Upgrade (Crew pinpointer)"
 	id = "borg_upgrade_pinpointer"

--- a/modular_citadel/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_citadel/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -43,6 +43,7 @@
 /obj/item/robot_module/k9
 	name = "Security K-9 Unit"
 	basic_modules = list(
+		/obj/item/assembly/flash/cyborg,
 		/obj/item/restraints/handcuffs/cable/zipties,
 		/obj/item/storage/bag/borgdelivery,
 		/obj/item/dogborg/jaws/big,
@@ -106,6 +107,7 @@
 /obj/item/robot_module/medihound
 	name = "MediHound"
 	basic_modules = list(
+		/obj/item/assembly/flash/cyborg,
 		/obj/item/dogborg/jaws/small,
 		/obj/item/storage/bag/borgdelivery,
 		/obj/item/analyzer/nose,
@@ -116,6 +118,13 @@
 		/obj/item/roller/robo,
 		/obj/item/crowbar/cyborg,
 		/obj/item/borg/apparatus/beaker,
+		/obj/item/surgical_drapes,
+		/obj/item/retractor,
+		/obj/item/hemostat,
+		/obj/item/cautery,
+		/obj/item/surgicaldrill,
+		/obj/item/scalpel,
+		/obj/item/circular_saw,
 		/obj/item/reagent_containers/borghypo,
 		/obj/item/twohanded/shockpaddles/cyborg/hound,
 		/obj/item/stack/medical/gauze/cyborg,
@@ -172,6 +181,7 @@
 /obj/item/robot_module/scrubpup
 	name = "Scrub Pup"
 	basic_modules = list(
+		/obj/item/assembly/flash/cyborg,
 		/obj/item/dogborg/jaws/small,
 		/obj/item/analyzer/nose,
 		/obj/item/crowbar/cyborg,
@@ -225,6 +235,7 @@
 /obj/item/robot_module/borgi
 	name = "Borgi"
 	basic_modules = list(
+		/obj/item/assembly/flash/cyborg,
 		/obj/item/dogborg/jaws/small,
 		/obj/item/storage/bag/borgdelivery,
 		/obj/item/analyzer/nose,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR gives borgs that were missing flashes flashes, replaces the engineering circuit gripper upgrade with a more useful gripper which is a shift start item rather than an upgrade, and finally gives medihound surgery tools.

Gripper nabbed from Skyrat-Citadel

## Why It's Good For The Game
Flashes: Consistency 
Gripper: Allows borgs to setup more engine types, and generally makes it a better module. Old one was also broken.
Surgery tools: Allows medihound to be more useful, still differences between the normal medical module as they lack an organ box and surgical processor, preventing more advanced surgeries.

## Changelog
:cl:
tweak: Changed various borg module items.
add: Added a item gripper for engineering borgs
del: Old circuitry gripper
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
