### PR TITLE
Adds a Modular Tablet to the loadout menu

### DIFF
--- a/hyperstation/code/modules/client/loadout/tablet.dm
+++ b/hyperstation/code/modules/client/loadout/tablet.dm
@@ -1,0 +1,5 @@
+/datum/gear/backpack/tablet
+	name = "Tablet Computer"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/modular_computer/tablet/preset/cheap/
+	cost = 3

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3021,6 +3021,7 @@
 #include "hyperstation\code\modules\traits.dm"
 #include "hyperstation\code\modules\antagonists\werewolf\werewolf.dm"
 #include "hyperstation\code\modules\client\loadout\glasses.dm"
+#include "hyperstation\code\modules\client\loadout\tablet.dm"
 #include "hyperstation\code\modules\clothing\head.dm"
 #include "hyperstation\code\modules\clothing\glasses\polychromic_glasses.dm"
 #include "hyperstation\code\modules\clothing\spacesuits\hardsuit.dm"


### PR DESCRIPTION
## About The Pull Request

Exactly what it says on the tin - adds a cheap Modular Tablet to the loadout menu for 3 loadout points.

## Why It's Good For The Game

This here addition was highly requested by a few people earlier today, and Citadel already has these as a loadout option. Figured it'd be nice to let players get these. Maybe someday people will actually use the NTNet ingame message board thing with them. A man can hope for more RP...

## Changelog
:cl:
add: cheap modular tablet in loadout
/:cl:
