### PR TITLE
Removes emag from *that* uplink

### DIFF
--- a/hyperstation/code/gamemode/traitor_lewd.dm
+++ b/hyperstation/code/gamemode/traitor_lewd.dm
@@ -74,8 +74,6 @@ GLOBAL_LIST_INIT(hyper_special_roles, list(
 		/datum/uplink_item/stealthy_tools/syndigaloshes,
 		/datum/uplink_item/stealthy_tools/jammer,
 		/datum/uplink_item/stealthy_tools/smugglersatchel,
-		/datum/uplink_item/device_tools/emag,
-		/datum/uplink_item/device_tools/emagrecharge,
 		/datum/uplink_item/device_tools/binary,
 		/datum/uplink_item/device_tools/compressionkit,
 		/datum/uplink_item/device_tools/briefcase_launchpad,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I don't think anyone ever realized how bad of an idea it was/is to give *that* uplink access to emags.

## Why It's Good For The Game

Let's not have an antag that is not an antag having something that allows them to disable cloners, disable grinder safeties, override robots and give the crew free cargo access to traitor gear. Thank you.

## Changelog
:cl:
del: Removes emag from lewd uplink.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
