### PR TITLE
Gives Catnip a Mood Boost to felinids

### DIFF
--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -127,10 +127,9 @@
 	mood_change = 2
 	timeout = 15 MINUTES
 
-/datum/mood_event/catnip
-	description = "<span class='nicegreen'>Whatever I ate was a-<i>nya</i>-zing!</span>\n"	//hate
-	mood_change = 4
-	//No timeout, handled by reagent
+/datum/mood_event/catnip	//Used by datum/reagent/catnip
+	description = "<span class='nicegreen'>Whatever I ate was a-<i>nya</i>-zing!</span>\n"
+	mood_change = 8		//Felinids become pacified from catnip, so give a bigger mood boost
 
 //Bloodsucker stuff below.
 /datum/mood_event/drankblood

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -116,7 +116,7 @@
 
 /datum/mood_event/happy_empath/add_effects(var/mob/happytarget)
 	description = "<span class='nicegreen'>[happytarget.name]'s happiness is infectious!</span>\n"
-	
+
 /datum/mood_event/lewd_headpat
 	description = "<span class='nicegreen'>I love headpats so much!</span>\n"
 	mood_change = 3
@@ -126,6 +126,11 @@
 	description = "<span class='nicegreen'>Nothing like a hearty breakfast to start the shift.</span>\n"
 	mood_change = 2
 	timeout = 15 MINUTES
+
+/datum/mood_event/catnip
+	description = "<span class='nicegreen'>Whatever I ate was a-<i>nya</i>-zing!</span>\n"	//hate
+	mood_change = 4
+	//No timeout, handled by reagent
 
 //Bloodsucker stuff below.
 /datum/mood_event/drankblood
@@ -158,5 +163,5 @@
 	mood_change = 5
 
 /datum/mood_event/radiant
-	description = "<span class='nicegreen'>I have seen the light of The Phoenix; I cannot be stopped.</span>\n" 
+	description = "<span class='nicegreen'>I have seen the light of The Phoenix; I cannot be stopped.</span>\n"
 	mood_change = 12

--- a/code/modules/hydroponics/grown/tea_coffee.dm
+++ b/code/modules/hydroponics/grown/tea_coffee.dm
@@ -53,7 +53,7 @@
 	species = "catnip"
 	plantname = "Catnip Plant"
 	product = /obj/item/reagent_containers/food/snacks/grown/tea/catnip
-	reagents_add = list(/datum/reagent/pax/catnip = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.06, /datum/reagent/toxin/teapowder = 0.3)
+	reagents_add = list(/datum/reagent/catnip = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.06, /datum/reagent/toxin/teapowder = 0.3)
 	rarity = 50
 
 /obj/item/reagent_containers/food/snacks/grown/tea/catnip
@@ -61,7 +61,7 @@
 	name = "Catnip buds"
 	icon_state = "catnip"
 	filling_color = "#4582B4"
-	grind_results = list(/datum/reagent/pax/catnip = 2, /datum/reagent/water = 1)
+	grind_results = list(/datum/reagent/catnip = 2, /datum/reagent/water = 1)
 
 // Coffee
 /obj/item/seeds/coffee

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -380,7 +380,7 @@
 					M.IgniteMob()
 				else
 					M.adjustToxLoss(1, 0)
-					M.adjustFireLoss(1, 0)	
+					M.adjustFireLoss(1, 0)
 	if(data >= 60)	// 30 units, 135 seconds
 		if(iscultist(M, FALSE, TRUE) || is_servant_of_ratvar(M, FALSE, TRUE))
 			if(iscultist(M))
@@ -2193,18 +2193,32 @@
 	color = "#BCC740" //RGB: 188, 199, 64
 	taste_description = "plant dust"
 
-/datum/reagent/pax/catnip
+/datum/reagent/catnip
 	name = "catnip"
 	taste_description = "grass"
 	description = "A colorless liquid that makes people more peaceful and felines more happy."
 	metabolization_rate = 1.75 * REAGENTS_METABOLISM
 
-/datum/reagent/pax/catnip/on_mob_life(mob/living/carbon/M)
-	if(prob(20))
-		M.emote("nya")
+/datum/reagent/catnip/on_mob_metabolize(mob/living/carbon/L)
+	..()
+	if(iscatperson(L))
+		SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "catnip", /datum/mood_event/catnip)
+		ADD_TRAIT(L, TRAIT_PACIFISM, type)	//Just like pax, except it only works for felinids
+	else
+		SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "catnip", /datum/mood_event/gross_food)
+
+/datum/reagent/catnip/on_mob_end_metabolize(mob/living/carbon/L)
+	..()
+	if(iscatperson(L))
+		SEND_SIGNAL(L, COMSIG_CLEAR_MOOD_EVENT, "catnip")
+		REMOVE_TRAIT(L, TRAIT_PACIFISM, type)
+
+/datum/reagent/catnip/on_mob_life(mob/living/carbon/M)
 	if(prob(20))
 		to_chat(M, "<span class = 'notice'>[pick("Headpats feel nice.", "The feeling of a hairball...", "Backrubs would be nice.", "Whats behind those doors?")]</span>")
-	M.adjustArousalLoss(2)
+		if(iscatperson(M))
+			M.emote("nya")
+			M.adjustArousalLoss(-2)
 	..()
 
 // Adding new mutation toxin stuff from /code/modules/reagent/chemistry/recipes/slime_extracts.dm
@@ -2243,7 +2257,7 @@
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/insect
 	mutationtext = "<span class='danger'>The pain subsides. You feel... oddly attracted to light.</span>"
-	
+
 /datum/reagent/mutationtoxin/ipc
 	name = "IPC Mutation Toxin"
 	description = "A robotic toxin." //NANOMACHINES SON.

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2197,7 +2197,6 @@
 	name = "catnip"
 	taste_description = "grass"
 	description = "A colorless liquid that makes people more peaceful and felines more happy."
-	metabolization_rate = 1.75 * REAGENTS_METABOLISM
 
 /datum/reagent/catnip/on_mob_metabolize(mob/living/carbon/L)
 	..()
@@ -2218,7 +2217,8 @@
 		to_chat(M, "<span class = 'notice'>[pick("Headpats feel nice.", "The feeling of a hairball...", "Backrubs would be nice.", "Whats behind those doors?")]</span>")
 		if(iscatperson(M))
 			M.emote("nya")
-			M.adjustArousalLoss(-2)
+			if(prob(80))
+				M.adjustArousalLoss(3)
 	..()
 
 // Adding new mutation toxin stuff from /code/modules/reagent/chemistry/recipes/slime_extracts.dm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This gives felinids a big mood boost when they consume catnip, but as a downside it pacifies them momentarialy. This shouldn't get rid of the pacifist quirk, if it does then traits are fucked.

On the opposite side of the spectrum, non-felinids get a mood debuff, as if they just ate bad food

## Why It's Good For The Game
It only makes sense to give a mood boost to felines if they recently ate catnip. I mean, why wouldn't you be happy as a cat if you just ate catnip?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: catnip mood boost to felinids
add: catnip mood debuff to non-catpeople
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
