### PR TITLE
Syndicate Less Than Lethal option

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -393,3 +393,14 @@
 	new /obj/item/gun/ballistic/automatic/pistol/m1911/kitchengun(src)
 	new /obj/item/ammo_box/magazine/m45/kitchengun(src)
 	new /obj/item/ammo_box/magazine/m45/kitchengun(src)
+
+//Chemlight less than lethal addition
+/obj/item/storage/box/syndie_kit/soporific_bundle
+	name = "box"
+
+/obj/item/storage/box/syndie_kit/soporific_bundle/PopulateContents() // A total of 48 rounds, don't shoot it all in one place!
+	new	/obj/item/ammo_box/magazine/m10mm/soporific(src)
+	new	/obj/item/ammo_box/magazine/m10mm/soporific(src)
+	new	/obj/item/ammo_box/magazine/m10mm/soporific(src)
+	new	/obj/item/ammo_box/c10mm/soporific(src)
+//End of Chemlight changes

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -711,7 +711,7 @@ datum/uplink_item/stealthy_weapons/taeclowndo_shoes
 	desc = "An additional 8-round 10mm magazine; compatible with the Stechkin Pistol. Loaded with soporific rounds that put the target to sleep. \
 			NOTE: Soporific is not instant acting due to the constraints of the round's scale. Will usually require three shots to take effect."
 	item = /obj/item/ammo_box/magazine/m10mm/soporific
-	cost = 2
+	cost = 1
 
 /datum/uplink_item/ammo/shotgun
 	cost = 2
@@ -904,6 +904,17 @@ datum/uplink_item/stealthy_weapons/taeclowndo_shoes
 	item = /obj/item/ammo_box/foambox/riot
 	cost = 2
 	surplus = 0
+
+//Chemlight Changes
+/datum/uplink_item/ammo/pistolzzz_bundle
+	name = "Box of 10mm Soporific Ammo"
+	desc = "A bundle of three 8-round 10mm magazine; compatible with the Stechkin Pistol. Loaded with soporific rounds that put the target to sleep. \
+		Due to a stockpile in soporific munitions, buy now and we'll throw in a ammo box holding 24 rounds for free! Enough to restock all magazines included. \
+		NOTE: Soporific is not instant acting due to the constraints of the round's scale. Will usually require three shots to take effect."
+	item = /obj/item/storage/box/syndie_kit/soporific_bundle
+	cost = 3
+	limited_stock = 1
+//End of Chemlight changes
 
 /datum/uplink_item/ammo/bioterror
 	name = "Box of Bioterror Syringes"


### PR DESCRIPTION
## About The Pull Request

Thought I'd provide a better way on how to approach doing a maroon objective or rather theft antag related stuff. lately I've been seeing a lot of traitors go with the more lethal option for insurance.

## Why It's Good For The Game

Simply enough a lot of traitor gear that's easier to get tends to be the more lethal option, so by dumbing down the cost of soporific rounds to 1 TC to match the stechkin pistols normal munition purchase, this will give a fair choice of lethal or non lethal ammo ontop of a one time purchase to buy 3 get 3 free (in a whole ammo box form), since lets be real, you can get more pistol ammo from a hacked autolathe, like the .357 revolver ammo. (Might add soporific rounds into illegal tech in the future maybe, who knows.)

## Changelog
:cl:
add: A one time ammo uplink purchase.
tweak: soporific ammo having 2 TC to 1 TC
balance: gives equal choice and effort to spend with lethal vs non lethal ammo
/:cl:

