### PR TITLE
Makes ninja shoes visible on people again

### DIFF
--- a/code/modules/ninja/suit/shoes.dm
+++ b/code/modules/ninja/suit/shoes.dm
@@ -2,7 +2,7 @@
 	name = "ninja shoes"
 	desc = "A pair of running shoes. Excellent for running and even better for smashing skulls."
 	icon_state = "s-ninja"
-	item_state = "secshoes"
+	item_state = "s-ninja"
 	permeability_coefficient = 0.01
 	clothing_flags = NOSLIP
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the item_state of ninja shoes to the actual fucking sprite name. WHO WOULDA THUNK IT? I swear to god I'm gonna lose my shit here. Anyway. Ninja shoes won't be invisible on humanoid legs anymore. Can't make any promises for digi.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
~~Because Chemlight and many others have developed PTSD from seeing ninja socks.~~
Because invisible sprites bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Ninja shoes no longer try to assume the appearance of a nonexistent sprite, and instead call upon their own already existing sprite.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
