### PR TITLE
Increase amount of fetish items in kinkmate and makes fake handcuffs properly appear.

### DIFF
--- a/modular_citadel/code/game/machinery/vending.dm
+++ b/modular_citadel/code/game/machinery/vending.dm
@@ -64,17 +64,17 @@
 	contraband = list(/obj/item/restraints/handcuffs/fake/kinky = 5,
 				/obj/item/clothing/neck/petcollar = 5,
 				/obj/item/clothing/under/mankini = 1,
-				/obj/item/dildo/flared/huge = 1,
-				/obj/item/clothing/head/dominatrixcap = 1,
-				/obj/item/mesmetron = 1,
-				/obj/item/bdsm_whip = 1,
-				/obj/item/clothing/mask/muzzle = 1
+				/obj/item/dildo/flared/huge = 3,
+				/obj/item/clothing/head/dominatrixcap = 3,
+				/obj/item/mesmetron = 3,
+				/obj/item/bdsm_whip = 3,
+				/obj/item/clothing/mask/muzzle = 3
 				)
 	premium = list(
 				/obj/item/electropack/shockcollar = 3,
-				/obj/item/clothing/neck/petcollar/locked = 1,
-				/obj/item/restraints/handcuffs/rope = 1,
-				/obj/item/leash = 1,
+				/obj/item/clothing/neck/petcollar/locked = 3,
+				/obj/item/restraints/handcuffs/rope = 3,
+				/obj/item/leash = 3,
 				/obj/item/clothing/mask/muzzle/ballgag = 3
 				)
 	refill_canister = /obj/item/vending_refill/kink

--- a/modular_citadel/code/game/machinery/vending.dm
+++ b/modular_citadel/code/game/machinery/vending.dm
@@ -61,7 +61,8 @@
 				/obj/item/clothing/under/corset = 3,
 				/obj/item/clothing/under/jabroni = 3
 				)
-	contraband = list(/obj/item/restraints/handcuffs/fake/kinky = 5,
+	contraband = list(
+				/obj/item/restraints/handcuffs/fake/kinky = 5,
 				/obj/item/clothing/neck/petcollar = 5,
 				/obj/item/clothing/under/mankini = 1,
 				/obj/item/dildo/flared/huge = 3,


### PR DESCRIPTION
## About The Pull Request

Changes Mesmetron, Dom cap, Horsecock, Muzzle, Leash, amount in kinkmate to 3 instead of 1
Cleans up fake handcuffs in kinkmates, so they should appear properly now.

## Why It's Good For The Game

Playercount is increasing, there's a limited amount of Kinkmate's on every map, and it's often with the increased playercount to spend a lot more time than is necessary trying to find one with fetish items. Should fix the mad-dash to get the mesmetron, for all my hypnosis fetishists, since sometimes it's hard to get them.

Also makes fake cuffs appear properly.

## Changelog
:cl:
tweak: Items in kinkmates that had a quantity of 1 have been increased to 3.
fix: Fake handcuffs now appear in hacked kinkmates
/:cl:
