### PR TITLE
Lipolicide Overdose

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -607,6 +607,14 @@
 	color = "#F0FFF0"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	toxpwr = 0
+	overdose_threshold = 40
+
+/datum/reagent/toxin/lipolicide/overdose_process(mob/living/carbon/C)
+	. = ..()
+	if(current_cycle >=41 && prob(15))
+		C.spew_organ()
+		C.vomit(0, TRUE, TRUE, 4)
+		to_chat(C, "<span class='userdanger'>You feel something lumpy come up as you vomit.</span>")
 
 /datum/reagent/toxin/lipolicide/on_mob_life(mob/living/carbon/M)
 	if(M.nutrition <= NUTRITION_LEVEL_STARVING)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -613,8 +613,11 @@
 	. = ..()
 	if(current_cycle >=41 && prob(15))
 		C.spew_organ()
-		C.vomit(0, TRUE, TRUE, 4)
+		C.vomit(10, TRUE, TRUE, 4)
 		to_chat(C, "<span class='userdanger'>You feel something lumpy come up as you vomit.</span>")
+		if(prob(1))
+			to_chat(C, "<span class='userdanger'>You feel like your organs are on fire!</span>")
+			C.IgniteMob()
 
 /datum/reagent/toxin/lipolicide/on_mob_life(mob/living/carbon/M)
 	if(M.nutrition <= NUTRITION_LEVEL_STARVING)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Now has the same effect as a spewium overdose, albeit with a higher threshold.

## Why It's Good For The Game

Let's not walk around with 300u of a toxin chem in our system without any consequences.

## Changelog
:cl:
add: Lipolicide has an overdose of 40u.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
