### PR TITLE
Research fix for arcade machines and the Autoylathe

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -255,7 +255,7 @@
 	display_name = "Games and Toys"
 	description = "For the slackers on the station."
 	prereq_ids = list("comptech")
-	design_ids = list("arcade_battle", "arcade_orion", "slotmachine", "autoylathe")
+	design_ids = list("arcade_battle", "arcade_orion", "slotmachine", "autoylathe", "arcade_minesweeper")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 	export_price = 5000
 
@@ -484,15 +484,6 @@
 	design_ids = list("hdd_basic", "hdd_advanced", "hdd_super", "hdd_cluster", "ssd_small", "ssd_micro", "netcard_basic", "netcard_advanced", "netcard_wired",
 	"portadrive_basic", "portadrive_advanced", "portadrive_super", "cardslot", "aislot", "miniprinter", "APClink", "bat_control", "bat_normal", "bat_advanced",
 	"bat_super", "bat_micro", "bat_nano", "cpu_normal", "pcpu_normal", "cpu_small", "pcpu_small")
-
-/datum/techweb_node/computer_board_gaming
-	id = "computer_board_gaming"
-	display_name = "Arcade Games"
-	description = "For the slackers on the station."
-	prereq_ids = list("comptech")
-	design_ids = list("arcade_battle", "arcade_orion", "slotmachine") // Magic money
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
-	export_price = 2000
 
 /datum/techweb_node/comp_recordkeeping
 	id = "comp_recordkeeping"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -255,9 +255,20 @@
 	display_name = "Games and Toys"
 	description = "For the slackers on the station."
 	prereq_ids = list("comptech")
-	design_ids = list("arcade_battle", "arcade_orion", "slotmachine", "autoylathe", "arcade_minesweeper")
+	design_ids = list("arcade_battle", "arcade_orion", "arcade_minesweeper", "slotmachine", "autoylathe")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 	export_price = 5000
+
+
+///datum/techweb_node/computer_board_gaming
+//	id = "computer_board_gaming"
+//	display_name = "Arcade Games"
+//	description = "For the slackers on the station."
+//	prereq_ids = list("comptech")
+//	design_ids = list("arcade_battle", "arcade_orion", "slotmachine") // Magic money
+//	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
+//	export_price = 2000
+
 
 /////////////////////////Bluespace tech/////////////////////////
 /datum/techweb_node/bluespace_basic //Bluespace-memery


### PR DESCRIPTION
## About The Pull Request

Very simple bugfix that implements the ability to make autoylathes and minesweeper arcade machines by removing a broken supurfluous tech. 

## Why It's Good For The Game

Fixing bugs and removing unneeded code is a platonic good. 

## Changelog
:cl: Fixed a bug, really too simple for this but will follow the format. 
add: Added the 'minesweeper' ID, which was already existant, but not added to research, to allow the minesweeper arcade machine to be built.
del: Deleted the tech 'arcade machines' as it was breaking 'games and toys', which contained everything it had, and also two other macihnes.
/:cl:

