### PR TITLE
Hide Ckey on Roundend Pref

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -510,7 +510,7 @@
 	var/jobtext = ""
 	if(ply.assigned_role)
 		jobtext = " the <b>[ply.assigned_role]</b>"
-	var/text = "<b>[ply.key]</b> was <b>[ply.name]</b>[jobtext] and"
+	var/text = "<b>[ply.hide_ckey ? "<b>[ply.name]</b>[jobtext] " : "[ply.key]</b> was <b>[ply.name]</b>[jobtext] and "]"
 	if(ply.current)
 		if(ply.current.stat == DEAD)
 			text += " <span class='redtext'>died</span>"

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -41,6 +41,8 @@
 	var/special_role
 	var/list/restricted_roles = list()
 
+	var/hide_ckey = FALSE
+
 	var/list/datum/objective/objectives = list()
 
 	var/list/spell_list = list() // Wizard mode & "Give Spell" badmin button.
@@ -133,6 +135,8 @@
 		if(L.client && L.client.prefs)
 			L.canbearoused = L.client.prefs.arousable //Technically this should make taking over a character mean the body gain the new minds setting...
 			L.update_arousal_hud() //Removes the old icon
+
+	hide_ckey = current.client?.prefs?.hide_ckey
 
 /datum/mind/proc/store_memory(new_text)
 	if((length_char(memory) + length_char(new_text)) <= MAX_MESSAGE_LEN)
@@ -853,6 +857,7 @@
 	if(!mind.name)
 		mind.name = real_name
 	mind.current = src
+	mind.hide_ckey = client?.prefs?.hide_ckey
 
 /mob/living/carbon/mind_initialize()
 	..()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -240,6 +240,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/list/bgstate_options = list("000", "midgrey", "hiro", "FFF", "white", "steel", "techmaint", "dark", "plating", "reinforced")
 
 	var/show_mismatched_markings = FALSE //determines whether or not the markings lists should show markings that don't match the currently selected species. Intentionally left unsaved.
+	var/hide_ckey = FALSE //pref for hiding if your ckey shows round-end or not
 
 /datum/preferences/New(client/C)
 	parent = C
@@ -368,6 +369,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dat += "[medical_records]"
 			else
 				dat += "[TextPreview(medical_records)]...<BR>"
+			dat += "<br><a href='?_src_=prefs;preference=hide_ckey;task=input'><b>Hide ckey: [hide_ckey ? "Enabled" : "Disabled"]</b></a><br>"
 			dat += "</tr></table>"
 
 		//Character Appearance
@@ -1688,6 +1690,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					if(msg)
 						msg = msg
 						features["flavor_text"] = msg
+
+				if("hide_ckey")
+					hide_ckey = !hide_ckey
+					if(user)
+						user.mind?.hide_ckey = hide_ckey
 
 				if("hair")
 					var/new_hair = input(user, "Choose your character's hair colour:", "Character Preference","#"+hair_color) as color|null

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -337,7 +337,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["feature_human_ears"]				>> features["ears"]
 	S["feature_deco_wings"]				>> features["deco_wings"]
 
-
+	S["hide_ckey"]						>> hide_ckey //saved per-character
 
 
 	//Custom names
@@ -591,6 +591,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	//Record Flavor Text
 	WRITE_FILE(S["security_records"]		, security_records)
 	WRITE_FILE(S["medical_records"]			, medical_records)
+	//hide c-key
+	WRITE_FILE(S["hide_ckey"]		, hide_ckey)
 	//Quirks
 	WRITE_FILE(S["all_quirks"]			, all_quirks)
 

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -52,4 +52,5 @@
 				var/datum/callback/CB = foo
 				CB.Invoke()
 
+	mind?.hide_ckey = client?.prefs?.hide_ckey
 	log_message("Client [key_name(src)] has taken ownership of mob [src]([src.type])", LOG_OWNERSHIP)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows one to hide their ckey on roundend reports, per character.

Port based on: https://github.com/Citadel-Station-13/Citadel-Station-13/pull/13316


Pref set to true:
![image](https://user-images.githubusercontent.com/53913550/104499392-cbb7d580-55bb-11eb-93a9-41b9222a29cf.png)

Pref set to false:
![image](https://user-images.githubusercontent.com/53913550/104500351-171eb380-55bd-11eb-9a61-fec6d329aed8.png)

## Why It's Good For The Game

Widely requested feature. This should not interfere admin logs and if any role still shows the player's ckey, it can easily be fixed by looking at what displays it and implementing a solution similar to what is displayed in this PR, within the roundend.dm file.

## Changelog
🆑
add: you can hide your ckey now from the roundend report
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
