### PR TITLE
Removes unusable teg computer

### DIFF
--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_teg.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_teg.dmm
@@ -165,16 +165,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"fO" = (
-/obj/machinery/computer/atmos_control/tank/mix_tank{
-	dir = 8;
-	input_tag = "teg_in";
-	name = "TEG Mix Tank Control";
-	output_tag = null;
-	sensors = list("teg_sensor" = "TEG Mix Tank")
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "go" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/delivery,
@@ -402,9 +392,6 @@
 /area/engine/engineering)
 "nc" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
-/obj/machinery/air_sensor/atmos{
-	id_tag = "teg_sensor"
-	},
 /turf/open/floor/engine/vacuum,
 /area/engine/engineering)
 "nk" = (
@@ -1037,6 +1024,7 @@
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "Ei" = (
@@ -1695,11 +1683,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "TS" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "Ue" = (
@@ -2553,7 +2541,7 @@ PK
 cK
 Ok
 OK
-fO
+Ok
 aq
 kK
 MP


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I made that computer to assist our TEG engineers, however current code is not working and I'll have to make some snowflake code later for it, I assume. So this just removes it from the TEG engine. It wasn't really needed anyway, just a bit of a commodity.

## Changelog
:cl:
del: Teg mixing tank computer removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
