### PR TITLE
Small cargo crate revamp + QoL changes

### DIFF
--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -205,3 +205,7 @@
 /obj/item/inducer/sci/combat/Initialize()
 	. = ..()
 	update_icon()
+
+/obj/item/inducer/sci/supply
+	opened = FALSE
+	cell_type = /obj/item/stock_parts/cell/inducer_supply

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -689,6 +689,7 @@ GLOBAL_LIST_INIT(plastic_recipes, list(
 	new /datum/stack_recipe("plastic flaps", /obj/structure/plasticflaps, 5, one_per_turf = TRUE, on_floor = TRUE, time = 40), \
 	new /datum/stack_recipe("water bottle", /obj/item/reagent_containers/glass/beaker/waterbottle/empty), \
 	new /datum/stack_recipe("large water bottle", /obj/item/reagent_containers/glass/beaker/waterbottle/large/empty,3), \
+	new /datum/stack_recipe("large trash cart", /obj/structure/closet/crate/bin,50),\
 	new /datum/stack_recipe("wet floor sign", /obj/item/caution, 2)))
 
 /obj/item/stack/sheet/plastic

--- a/code/game/objects/structures/crates_lockers/crates/bins.dm
+++ b/code/game/objects/structures/crates_lockers/crates/bins.dm
@@ -4,6 +4,8 @@
 	icon_state = "largebins"
 	open_sound = 'sound/effects/bin_open.ogg'
 	close_sound = 'sound/effects/bin_close.ogg'
+	material_drop = /obj/item/stack/sheet/plastic
+	material_drop_amount = 40
 	anchored = TRUE
 	horizontal = FALSE
 	delivery_icon = null

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -74,6 +74,9 @@
 		ui = new(user, src, ui_key, "tank_dispenser", name, 275, 103, master_ui, state)
 		ui.open()
 
+/obj/structure/tank_dispenser/attack_robot(mob/user)
+	ui_interact(user)
+
 /obj/structure/tank_dispenser/ui_data(mob/user)
 	var/list/data = list()
 	data["oxygen"] = oxygentanks

--- a/code/modules/cargo/packs/engineering.dm
+++ b/code/modules/cargo/packs/engineering.dm
@@ -91,15 +91,11 @@
 	crate_name = "insulated gloves crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
-/obj/item/stock_parts/cell/inducer_supply
-	maxcharge = 5000
-	charge = 5000
-
 /datum/supply_pack/engineering/inducers
 	name = "NT-75 Electromagnetic Power Inducers Crate"
 	desc = "No rechargers? No problem, with the NT-75 EPI, you can recharge any standard cell-based equipment anytime, anywhere. Contains two Inducers."
 	cost = 2300
-	contains = list(/obj/item/inducer/sci {cell_type = /obj/item/stock_parts/cell/inducer_supply; opened = 0}, /obj/item/inducer/sci {cell_type = /obj/item/stock_parts/cell/inducer_supply; opened = 0}) //FALSE doesn't work in modified type paths apparently.
+	contains = list(/obj/item/inducer/sci/supply, /obj/item/inducer/sci/supply)
 	crate_name = "inducer crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
@@ -133,17 +129,6 @@
 	crate_name = "power tools crate"
 	crate_type = /obj/structure/closet/crate/secure/engineering
 
-/datum/supply_pack/engineering/siezedpower
-	name = "Seized Power Cell Crate"
-	desc = "We took the means of power! Contains three high-voltage plus power cells."
-	cost = 1300
-	contraband = TRUE
-	contains = list(/obj/item/stock_parts/cell/high/plus,
-					/obj/item/stock_parts/cell/high/plus,
-					/obj/item/stock_parts/cell/high/plus)
-	crate_name = "seized crate"
-	crate_type = /obj/structure/closet/crate/engineering/electrical
-
 /datum/supply_pack/engineering/shuttle_engine
 	name = "Shuttle Engine Crate"
 	desc = "Through advanced bluespace-shenanigans, our engineers have managed to fit an entire shuttle engine into one tiny little crate. Requires CE access to open."
@@ -152,22 +137,6 @@
 	contains = list(/obj/structure/shuttle/engine/propulsion/burst/cargo)
 	crate_name = "shuttle engine crate"
 	crate_type = /obj/structure/closet/crate/secure/engineering
-
-/datum/supply_pack/engineering/seizedproduction 
-	name = "The Means of Production"
-	desc = "We will win for we have took over the production! Contains five metal sheets, five wire, three matter bins, one manipulator and one sheet of glass."
-	cost = 1500
-	contraband = TRUE
-	contains = list(/obj/item/stock_parts/cell/high/plus,
-					/obj/item/circuitboard/machine/autolathe,
-					/obj/item/stack/cable_coil/random/five,
-					/obj/item/stack/sheet/metal/five,
-					/obj/item/stock_parts/matter_bin,
-					/obj/item/stock_parts/matter_bin,
-					/obj/item/stock_parts/matter_bin,
-					/obj/item/stock_parts/manipulator,
-					/obj/item/stack/sheet/glass,)
-	crate_name = "seized crate"
 
 /datum/supply_pack/engineering/tools
 	name = "Toolbox Crate"

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -40,9 +40,10 @@
 
 /datum/supply_pack/medical/bloodpacks
 	name = "Blood Pack Variety Crate"
-	desc = "Contains ten different blood packs for reintroducing blood to patients."
+	desc = "Contains nine different blood packs for reintroducing blood to patients, plus two universal synthetic blood packs."
 	cost = 3000
-	contains = list(/obj/item/reagent_containers/blood/random,
+	contains = list(/obj/item/reagent_containers/blood/synthetics,
+					/obj/item/reagent_containers/blood/synthetics,
 					/obj/item/reagent_containers/blood/random,
 					/obj/item/reagent_containers/blood/APlus,
 					/obj/item/reagent_containers/blood/AMinus,
@@ -53,18 +54,6 @@
 					/obj/item/reagent_containers/blood/lizard,
 					/obj/item/reagent_containers/blood/jellyblood,
 					/obj/item/reagent_containers/blood/insect)
-	crate_name = "blood freezer"
-	crate_type = /obj/structure/closet/crate/freezer
-
-/datum/supply_pack/medical/bloodpackssynth
-	name = "Synthetics Blood Pack Crate"
-	desc = "Contains five synthetics blood packs for reintroducing blood to patients."
-	cost = 3000
-	contains = list(/obj/item/reagent_containers/blood/synthetics,
-					/obj/item/reagent_containers/blood/synthetics,
-					/obj/item/reagent_containers/blood/synthetics,
-					/obj/item/reagent_containers/blood/synthetics,
-					/obj/item/reagent_containers/blood/synthetics)
 	crate_name = "blood freezer"
 	crate_type = /obj/structure/closet/crate/freezer
 

--- a/code/modules/cargo/packs/misc.dm
+++ b/code/modules/cargo/packs/misc.dm
@@ -311,19 +311,6 @@
 					)
 	crate_name = "religious supplies crate"
 
-/datum/supply_pack/misc/randomised/promiscuous
-	name = "Promiscuous Organs"
-	desc = "Do YOU want to have more genital? Well we have just the thing for you~. This crate has two autosurgeon, that will let you have a new sex, organ to impress that hot stud and or chick."
-	cost = 4000 //Only get 2!
-	contraband = TRUE
-	var/num_contained = 2
-	contains = list(/obj/item/autosurgeon/penis,
-					/obj/item/autosurgeon/testicles,
-					/obj/item/autosurgeon/vagina,
-					/obj/item/autosurgeon/breasts,
-					/obj/item/autosurgeon/womb)
-	crate_name = "promiscuous organs"
-
 /datum/supply_pack/misc/shower
 	name = "Shower Supplies"
 	desc = "Everyone needs a bit of R&R. Make sure you get can get yours by ordering this crate filled with towels, rubber duckies, and some soap!"

--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -226,23 +226,39 @@
 
 /datum/supply_pack/service/carpet
 	name = "Premium Carpet Crate"
-	desc = "Plasteel floor tiles getting on your nerves? These stacks of extra soft carpet will tie any room together.  Contains the classics."
+	desc = "Plasteel floor tiles getting on your nerves? These stacks of extra soft carpet will tie any room together. Contains one of each pattern: classic, black, black-red and monochrome."
 	cost = 1000
 	contains = list(/obj/item/stack/tile/carpet/fifty,
-					/obj/item/stack/tile/carpet/fifty,
+					/obj/item/stack/tile/carpet/blackred/fifty,
 					/obj/item/stack/tile/carpet/black/fifty,
-					/obj/item/stack/tile/carpet/black/fifty)
+					/obj/item/stack/tile/carpet/monochrome/fifty)
 	crate_name = "premium carpet crate"
 
-/datum/supply_pack/service/carpet2
-	name = "Premium Carpet Crate #2"
-	desc = "Plasteel floor tiles getting on your nerves? These stacks of extra soft carpet will tie any room together.  Contains red, and monochrome"
-	cost = 1000
-	contains = list(/obj/item/stack/tile/carpet/blackred/fifty,
+/datum/supply_pack/service/carpet_exotic
+	name = "Exotic Carpet Crate"
+	desc = "Exotic carpets straight from Space Russia, for all your decorating needs. Contains 100 tiles each of 10 different flooring patterns."
+	cost = 7000
+	contains = list(/obj/item/stack/tile/carpet/blue/fifty,
+					/obj/item/stack/tile/carpet/blue/fifty,
+					/obj/item/stack/tile/carpet/cyan/fifty,
+					/obj/item/stack/tile/carpet/cyan/fifty,
+					/obj/item/stack/tile/carpet/green/fifty,
+					/obj/item/stack/tile/carpet/green/fifty,
+					/obj/item/stack/tile/carpet/orange/fifty,
+					/obj/item/stack/tile/carpet/orange/fifty,
+					/obj/item/stack/tile/carpet/purple/fifty,
+					/obj/item/stack/tile/carpet/purple/fifty,
+					/obj/item/stack/tile/carpet/red/fifty,
+					/obj/item/stack/tile/carpet/red/fifty,
+					/obj/item/stack/tile/carpet/royalblue/fifty,
+					/obj/item/stack/tile/carpet/royalblue/fifty,
+					/obj/item/stack/tile/carpet/royalblack/fifty,
+					/obj/item/stack/tile/carpet/royalblack/fifty,
+					/obj/item/stack/tile/carpet/blackred/fifty,
 					/obj/item/stack/tile/carpet/blackred/fifty,
 					/obj/item/stack/tile/carpet/monochrome/fifty,
 					/obj/item/stack/tile/carpet/monochrome/fifty)
-	crate_name = "premium carpet crate #2"
+	crate_name = "exotic carpet crate"
 
 /datum/supply_pack/service/lightbulbs
 	name = "Replacement Lights"

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -134,7 +134,7 @@
 
 /datum/language_holder/synthetic
 	languages = list(/datum/language/common)
-	shadow_languages = list(/datum/language/common, /datum/language/machine, /datum/language/draconic)
+	shadow_languages = list(/datum/language/common, /datum/language/machine, /datum/language/draconic, /datum/language/slime)
 
 /datum/language_holder/empty
 	languages = list()

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -359,3 +359,7 @@
 	var/area/A = get_area(src)
 	if(!A.lightswitch || !A.light_power)
 		charge = 0 //For naturally depowered areas, we start with no power
+
+//found inside the inducers ordered from cargo.
+/obj/item/stock_parts/cell/inducer_supply
+	maxcharge = 5000

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -135,6 +135,9 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	addtimer(CALLBACK(src, .proc/convey, affecting), 1)
 
 /obj/machinery/conveyor/proc/convey(list/affecting)
+	var/turf/T = get_step(src, movedir)
+	if(length(T.contents) > 150)
+		return
 	for(var/atom/movable/A in affecting)
 		if((A.loc == loc) && A.has_gravity())
 			A.ConveyorMove(movedir)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports:
https://github.com/Citadel-Station-13/Citadel-Station-13/pull/9975
https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10038
https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10122

Alongside some QoL fixes.

## Why It's Good For The Game

QoL fixes

## Changelog
🆑
del: Removed a few useless supply packs: "Siezed" power cells, means of production and promiscous organs.
tweak: Merged the synthetic blood supply pack into the standard blood supply pack, effectively removing a random type blood pack in favor of two synthetic ones.
tweak: Merged together premium carpet pack n°1 and n°2 to hold one of each standard pattern.
add: plastic trash cart crafting with plastic
del: conveyors can only stack items on tiles to 150 now
add: robots can now understand slime
add: robots can now interact with fuel tank dispensers
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
