### PR TITLE
Removes VR sleepers from pubby + disables crafting VR sleeper boards.

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -14718,9 +14718,8 @@
 /turf/open/floor/plasteel/white/side,
 /area/crew_quarters/dorms)
 "aDk" = (
-/obj/machinery/vr_sleeper{
-	dir = 8;
-	icon_state = "sleeper"
+/obj/machinery/cryopod{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
@@ -56851,13 +56850,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"dbi" = (
-/obj/machinery/vr_sleeper{
-	dir = 8;
-	icon_state = "sleeper"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "dci" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser/practice,
@@ -105609,8 +105601,8 @@ fIu
 rTZ
 aIh
 azA
-dbi
-dbi
+rTZ
+rTZ
 aDk
 aEd
 aFb

--- a/code/modules/research/designs/machine_desings/machine_designs_all_misc.dm
+++ b/code/modules/research/designs/machine_desings/machine_designs_all_misc.dm
@@ -95,6 +95,6 @@
 	name = "Machine Design (VR Sleeper Board)"
 	desc = "The circuit board for a VR sleeper."
 	id = "vr_sleeper"
-	build_path = /obj/item/circuitboard/machine/vr_sleeper
+	build_path = /obj/item/circuitboard/machine/cell_charger //Replaced with a cell charger until someone takes the job to fix VR sleepers.
 	departmental_flags = DEPARTMENTAL_FLAG_ALL
 	category = list ("Medical Machinery")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. VR sleepers have been broken for ages here and have been removed from a lot of stations as they can be easily exploited.

This PR simply removes the sleepers from pubby, exchanging them for cryo sleepers and changes the circuitboard path to the cell charger path in the design.

## Why It's Good For The Game

VR sleepers are a mistake

## Changelog
:cl:
del: Vr sleepers removed from pubby.
del: crafting VR sleeper circuit boards has been disabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
