### PR TITLE
A few lewd hydroponic plant changes + fixing

### DIFF
--- a/code/modules/hydroponics/grown/chili.dm
+++ b/code/modules/hydroponics/grown/chili.dm
@@ -93,7 +93,8 @@
 	yield = 3
 	rarity = 20
 	mutatelist = list()
-	reagents_add = list("aphro" = 0.2, "penis_enlarger" = 0.08, "vitamin" = 0.04, "nutriment" = 0.04)
+	genes = list(/datum/plant_gene/reagent/fragile/penischem, /datum/plant_gene/reagent/fragile/crocin)
+	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.04)
 
 /obj/item/reagent_containers/food/snacks/grown/pink_chili
 	seed = /obj/item/seeds/chili/pink

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -68,14 +68,9 @@
 	icon_grow = "spacemanstrumpet-grow"
 	icon_dead = "spacemanstrumpet-dead"
 	mutatelist = list()
-	genes = list(/datum/plant_gene/reagent/polypyr)
+	genes = list(/datum/plant_gene/reagent/fragile/polypyr)
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.05)
 	rarity = 30
-
-/obj/item/seeds/poppy/lily/trumpet/Initialize(mapload, nogenes = FALSE)
-	. = ..()
-	if(!nogenes)
-		unset_mutability(/datum/plant_gene/reagent/polypyr, PLANT_GENE_EXTRACTABLE)
 
 /obj/item/reagent_containers/food/snacks/grown/trumpet
 	seed = /obj/item/seeds/poppy/lily/trumpet

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -72,13 +72,14 @@
 	plantname = "Milk Melon Vines"
 	product = /obj/item/reagent_containers/food/snacks/grown/milkmelon
 	mutatelist = list()
-	reagents_add = list("milk" = 0.2, "breast_enlarger" = 0.08, "vitamin" = 0.04, "nutriment" = 0.1)
+	genes = list(/datum/plant_gene/reagent/fragile/breastchem)
+	reagents_add = list(/datum/reagent/consumable/milk = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 20
 
 /obj/item/reagent_containers/food/snacks/grown/milkmelon
 	seed = /obj/item/seeds/watermelon/milk
 	name = "milkmelon"
-	desc = "A softer, rounder-looking watermelon that audibly sloshes with milk."
+	desc = "A softer watermelon that audibly sloshes with milk."
 	icon_state = "milkmelon"
 	filling_color = "#FFAABB"
 	dried_type = null

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -212,14 +212,13 @@
 	endurance = 8
 	yield = 4
 	growthstages = 2
-	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/reagent/teslium, /datum/plant_gene/trait/plant_type/carnivory)
+	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/reagent/fragile/teslium, /datum/plant_gene/trait/plant_type/carnivory)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/seeds/chanterelle/jupitercup/Initialize(mapload, nogenes = FALSE)
 	. = ..()
 	if(!nogenes)
-		unset_mutability(/datum/plant_gene/reagent/teslium, PLANT_GENE_EXTRACTABLE)
 		unset_mutability(/datum/plant_gene/trait/plant_type/carnivory, PLANT_GENE_REMOVABLE)
 
 /obj/item/reagent_containers/food/snacks/grown/mushroom/jupitercup

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -109,7 +109,7 @@
 // Reagent genes store reagent ID and reagent ratio. Amount of reagent in the plant = 1 + (potency * rate)
 /datum/plant_gene/reagent
 	name = "Nutriment"
-	var/reagent_id = "nutriment"
+	var/reagent_id = /datum/reagent/consumable/nutriment
 	var/rate = 0.04
 
 /datum/plant_gene/reagent/get_name()
@@ -153,15 +153,34 @@
 			return FALSE
 	return TRUE
 
-/datum/plant_gene/reagent/polypyr
+/datum/plant_gene/reagent/fragile
+	name = "Fragile Gene"
+	mutability_flags = PLANT_GENE_REMOVABLE	//Cannot be extracted
+
+/datum/plant_gene/reagent/fragile/polypyr
 	name = "Polypyrylium Oligomers"
-	reagent_id = "polypyr"
+	reagent_id = /datum/reagent/medicine/polypyr
 	rate = 0.15
 
-/datum/plant_gene/reagent/teslium
+/datum/plant_gene/reagent/fragile/teslium
 	name = "Teslium"
-	reagent_id = "teslium"
+	reagent_id = /datum/reagent/teslium
 	rate = 0.1
+
+/datum/plant_gene/reagent/fragile/breastchem
+	name = "Succubus Milk"
+	reagent_id = /datum/reagent/fermi/breast_enlarger
+	rate = 0.04	//5 units at 100 potency
+
+/datum/plant_gene/reagent/fragile/penischem
+	name = "Incubus Draft"
+	reagent_id = /datum/reagent/fermi/penis_enlarger
+	rate = 0.04
+
+/datum/plant_gene/reagent/fragile/crocin
+	name = "Crocin"
+	reagent_id = /datum/reagent/drug/aphrodisiac
+	rate = 0.2
 
 // Various traits affecting the product.
 /datum/plant_gene/trait


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the pink pepper/melon plants' lewd reagents unextractable, so they cannot be placed into other plants. Changes their production rate from 8% to 4%, each harvest containing 5 units of a growth chem when at 100 potency.

Also fixes some plant reagents
![image](https://user-images.githubusercontent.com/26515331/105961006-34cb2e80-603b-11eb-8646-e00452c68aa8.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixe + less chance of abuse by putting lewd chems in non-lewd items

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
change: updated milk melon description
tweak: lewd plants' lewd reagents cant be extracted
balance: reduced the lewd plants' lewd chem production down from 8% to 4%
fix: some plants not having chems
code: removed unnecessary lines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
