### PR TITLE
Atmos drip

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -61,7 +61,7 @@
 /obj/machinery/suit_storage_unit/atmos
 	suit_type = /obj/item/clothing/suit/space/hardsuit/engine/atmos
 	mask_type = /obj/item/clothing/mask/gas
-	storage_type = /obj/item/watertank/atmos
+	storage_type = /obj/item/clothing/shoes/magboots/atmos
 
 /obj/machinery/suit_storage_unit/mining
 	suit_type = /obj/item/clothing/suit/hooded/explorer/standard


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces the firefighter backpack tank in the atmospherics suit storage unit with a pair of atmos magboots.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You already get a firefighter backpack tank in both of the lockers, and the atmos magboots have existed in the code but been unobtainable for a while now. They had a sprite issue but I fixed that AGES ago. The only functional difference they have is being fireproof. Fires create a lot of pressure differences, pushing our poor firefighters around. Sure, they could go steal Engineering's standard magboots, or wait for science to research magboots so they can print some, but the colors are all wrong and they aren't cut out for fire management. These boots would benefit atmos a lot more than a THIRD backpack tank.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Replaced the backpack firefighter tank in the atmos suit storage unit with atmos ~~drip~~ magboots.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
