### PR TITLE
Bundle of stuff (Silver extract, Gold extract, chameleon kits)

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1505,6 +1505,10 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	var/list/blocked = list(/obj/item/reagent_containers/food/drinks/soda_cans,
 		/obj/item/reagent_containers/food/drinks/bottle
 		)
+	blocked |= typesof(/obj/item/reagent_containers/food/drinks/prospacillin,
+		/obj/item/reagent_containers/food/drinks/diminicillin
+		)
+	
 	return pick(subtypesof(/obj/item/reagent_containers/food/drinks) - blocked)
 
 //For these two procs refs MUST be ref = TRUE format like typecaches!

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -106,6 +106,7 @@
 	melee_damage_lower = 5
 	melee_damage_upper = 10
 	poison_per_bite = 3
+	gold_core_spawnable = NO_SPAWN
 	var/atom/movable/cocoon_target
 	var/fed = 0
 	var/obj/effect/proc_holder/wrap/wrap

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1181,7 +1181,6 @@ datum/uplink_item/stealthy_weapons/taeclowndo_shoes
 			Due to budget cuts, the shoes don't provide protection against slipping."
 	item = /obj/item/storage/box/syndie_kit/chameleon
 	cost = 2
-	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_tools/chameleon_proj
 	name = "Chameleon Projector"


### PR DESCRIPTION
## About The Pull Request

Number one, put the size chems on the blacklist for silver slime etracts, or rather just get_random_drink proc

Second removed nurse spiders from gold slime extracts, it gets waaaaaay too crazy the times I've seen ghosts get control of off spring spider (children of the servent of the creator don't need to listen).

Third from popular request, gives syndicate agents the ability to buy chameleon kits.

## Why It's Good For The Game

For the bottles sizechems can quickly be powered gamed, while the person who made the bottle type path intended it to be made or bought from cargo, while it being 100k just using silver slime extract to just get it seems exploitable.

Nurse spiders could be seen on par with xenos, get a monkey and they can make more sentient spiders, this can and will domino effect, lets just leave these particular spiders to the infestation events.

Lastly with chameleon kits for this gives nuke ops/lone ops to be stealthy instead of shooty shooty bang bang right off the bat.

## Changelog
:cl:
added: chameleon kits to lone/nuke ops.
balance: silver slime extracts at least for now, along with gold slime extracts.
code: minor code changes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
