### PR TITLE
Don't touch me! (neutral trait)

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -169,6 +169,7 @@
 #define	TRAIT_MUSICIAN			"musician"
 #define	TRAIT_CROCRIN_IMMUNE    "crocin_immune"
 #define TRAIT_NYMPHO			"nymphomania"
+#define TRAIT_DISTANT			"headpat_hater"
 //#define TRAIT_FLUID_LEAK	"leaky_fluids" removed because milk snail trails are not okay
 #define TRAIT_MASO              "masochism"
 #define TRAIT_CHOKE_SLUT		"choke_slut"

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -134,4 +134,11 @@
 	desc = "You like headpats, alot, maybe even a little bit too much. Headpats give you a bigger mood boost and cause arousal"
 	mob_trait = TRAIT_HEADPAT_SLUT
 	value = 0
-	medical_record_text = "Patient seems overly affectionate"
+	medical_record_text = "Patient seems overly affectionate."
+
+/datum/quirk/headpat_hater
+	name = "Distant"
+	desc = "You don't seem to show much care for being touched. Whether it's because you're reserved or due to self control, you won't wag your tail outside of your own control should you possess one."
+	mob_trait = TRAIT_DISTANT
+	value = 0
+	medical_record_text = "Patient cares little with or dislikes being touched."

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -286,7 +286,19 @@
 			var/mob/living/carbon/human/H = src
 			var/datum/species/pref_species = H.dna.species
 			
-			if(HAS_TRAIT(H, TRAIT_HEADPAT_SLUT))
+			if(HAS_TRAIT(H, TRAIT_DISTANT)) //No mood buff since you're not really liking it.
+				M.visible_message("<span class='notice'>[M] gives [H] a pat on the head to make [p_them()] feel better! They seem annoyed...</span>", \
+					"<span class='warning'>You give [H] a pat on the head to make [p_them()] feel better! They seem annoyed as they're now glaring towards you...</span>")
+				H.adjustArousalLoss(-5) //Why are you touching me?
+				if(prob(5))
+					M.visible_message("<span class='warning'>[H] quickly twists [M]\'s arm!</span>", \
+						"<span class='boldwarning'>Your arm gets twisted in [H]\'s grasp. Maybe you should have taken the hint...</span>")
+					playsound(get_turf(H), 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+					M.emote("scream")
+					M.dropItemToGround(M.get_active_held_item())
+					M.apply_damage(50, STAMINA, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
+					M.Knockdown(60)//STOP TOUCHING ME! For those spam head pat individuals
+			else if(HAS_TRAIT(H, TRAIT_HEADPAT_SLUT))
 				M.visible_message("<span class='notice'>[M] gives [H] a pat on the head to make [p_them()] feel better! They seem incredibly pleased!</span>", \
 							"<span class='notice'>You give [H] a pat on the head to make [p_them()] feel better! They seem to like it way too much</span>")
 				SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "lewd_headpat", /datum/mood_event/lewd_headpat)
@@ -302,7 +314,10 @@
 					SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "friendly_hug", /datum/mood_event/besthug, M)
 				else if (mood.sanity >= SANITY_DISTURBED)
 					SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "friendly_hug", /datum/mood_event/betterhug, M)
-			if(H.dna.species.can_wag_tail(H))
+			
+			if(HAS_TRAIT(H, TRAIT_DISTANT))
+				return
+			else if(H.dna.species.can_wag_tail(H))
 				if("tail_human" in pref_species.default_features)
 					if(H.dna.features["tail_human"] == "None")
 						return


### PR DESCRIPTION

## About The Pull Request

Adds a new neutral trait called distant, kind of like apathetic but focused solely on head pats, while removing the mood buff for a trade on a 5% chance to twist someone's arm (non lethally).

## Why It's Good For The Game

For a lot of players trying to be serious in the moment having someone just head pat you during a serious scene can really remove tension, leaving this happy wagging during an anger filled moment, this trait will help prevent said headpatting. Also the arm twist is to get a point across with spam clicking on petting a head (fuck around and find out).

## Changelog
:cl:
add: A new trait
code: changed a little bit with head help intent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
