### PR TITLE
stop exploiting constructible showers ree

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -50,9 +50,6 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	//END OF CIT CHANGES
 	new/datum/stack_recipe("bed", /obj/structure/bed, 2, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \
-	//add this when I can find a way to make them easily constructible > new/datum/stack_recipe("sink", /obj/structure/sink, 2, one_per_turf = TRUE, on_floor = TRUE),
-	new/datum/stack_recipe("shower", /obj/machinery/shower/crafted, 2, one_per_turf = TRUE, on_floor = TRUE), \
-	null, \
 	new/datum/stack_recipe("rack parts", /obj/item/rack_parts), \
 	new/datum/stack_recipe("closet", /obj/structure/closet, 2, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -219,8 +219,8 @@
 	var/watertemp = "normal"	//freezing, normal, or boiling
 	var/datum/looping_sound/showering/soundloop
 
-/obj/machinery/shower/crafted	//When created from sheets of metal
-	anchored = FALSE
+/*/obj/machinery/shower/crafted	//When created from sheets of metal
+	anchored = FALSE */	//Stop exploiting this ree
 
 /obj/machinery/shower/Initialize()
 	. = ..()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -292,43 +292,19 @@
 	if (user.a_intent != INTENT_HELP)
 		return ..()
 
-	switch (I.tool_behaviour)
-		if (TOOL_WRENCH)
-			if (!anchored)
-				user.visible_message("<span class='notice'>[user] starts to take apart [src]...</span>", "<span class='notice'>You start dismantling [src]...</span>")
-				I.play_tool_sound(src)
-				if(I.use_tool(src, user, 20))
-					deconstruct(TRUE)
-			else
-				to_chat(user, "<span class='notice'>You begin to adjust the temperature valve with \the [I]...</span>")
-				if(I.use_tool(src, user, 50))
-					switch(watertemp)
-						if("normal")
-							watertemp = "freezing"
-						if("freezing")
-							watertemp = "boiling"
-						if("boiling")
-							watertemp = "normal"
-					user.visible_message("<span class='notice'>[user] adjusts the shower with \the [I].</span>", "<span class='notice'>You adjust the shower with \the [I] to [watertemp] temperature.</span>")
-					log_game("[key_name(user)] has wrenched a shower to [watertemp] at ([x],[y],[z])")
-					add_hiddenprint(user)
-
-		if (TOOL_SCREWDRIVER)
-			if (!anchored)
-				to_chat(user, "<span class='notice'>You begin screwing in [src] to the floor...</span>")
-				I.play_tool_sound(src)
-				if(I.use_tool(src, user, 30))
-					user.visible_message("<span class='notice'>[user] connects [src] to the floor.</span>", "<span class='notice'>You connect [src] to the floor.</span>")
-					anchored = TRUE
-			else
-				to_chat(user, "<span class='notice'>You start to take out [src]'s screws...</span>")
-				on = FALSE
-				soundloop.stop()
-				update_icon()
-				I.play_tool_sound(src)
-				if(I.use_tool(src, user, 20))
-					user.visible_message("<span class='notice'>[user] disconnects [src] from the floor.</span>", "<span class='notice'>You disconnect [src] from the floor.</span>")
-					anchored = FALSE
+	if (I.tool_behaviour == TOOL_WRENCH)
+		to_chat(user, "<span class='notice'>You begin to adjust the temperature valve with \the [I]...</span>")
+		if(I.use_tool(src, user, 50))
+			switch(watertemp)
+				if("normal")
+					watertemp = "freezing"
+				if("freezing")
+					watertemp = "boiling"
+				if("boiling")
+					watertemp = "normal"
+			user.visible_message("<span class='notice'>[user] adjusts the shower with \the [I].</span>", "<span class='notice'>You adjust the shower with \the [I] to [watertemp] temperature.</span>")
+			log_game("[key_name(user)] has wrenched a shower to [watertemp] at ([x],[y],[z])")
+			add_hiddenprint(user)
 
 /obj/machinery/shower/examine()
 	. += ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes showers from being deconstructable and crafted from sheets of metal

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People exploited this too much by placing hot af showers everywhere, making places slippery, and other whatnot that I had not taken thought into (like gaining more metal when you deconstruct then construct a shower). I'm thinking on adding a different kind of shower instead just so they cant be exploited so weirdly. And even then, my intention for their construction was not used.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: constructible showers no more
tweak: cant be deconstructed either, i dont trust people now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
