### PR TITLE
Syndicate stuff

### DIFF
--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -116,8 +116,8 @@
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper_s"
 	short_desc = "You are a syndicate agent, employed in a top secret research facility developing biological weapons plants and toys."
-	flavour_text = "Fortunately, Nanotrasen's activity in this sector of space is minimal. Continue your research as best you can, and try to keep a low profile."
-	important_info = "The base is rigged with explosives, DO NOT abandon it or let it fall into enemy hands!"
+	flavour_text = "Fortunately, Nanotrasen's activity in this sector of space is minimal. Continue your research as best you can, and try to keep a low profile from both Nanotrasen and Kinaris." //Making it more clear it's Nanotrasne AND Kinaris.
+	important_info = "The base is rigged with explosives, DO NOT leave the base or let it fall into enemy hands!" //Changed 'abandon it' to 'leave the base', no more loopholes please, you know who you are.
 	outfit = /datum/outfit/lavaland_syndicate
 	assignedrole = "Lavaland Syndicate"
 	mirrorcanloadappearance = TRUE
@@ -147,7 +147,7 @@
 	job_description = "Off-station Syndicate Comms Agent"
 	short_desc = "You are a syndicate comms agent, employed in a top secret research facility developing biological weapons."
 	flavour_text = "Fortunately, Nanotrasen's activity in this sector of space is minimal. Monitor enemy activity as best you can, and try to keep a low profile. Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen or Kinaris off your trail. Do not let the base fall into enemy hands!"
-	important_info = "The base is rigged with explosives, DO NOT abandon it or let it fall into enemy hands!"
+	important_info = "The base is rigged with explosives, DO NOT leave the base or let it fall into enemy hands!" //Changed 'abandon it' to 'leave the base', no more loopholes please, you know who you are.
 	outfit = /datum/outfit/lavaland_syndicate/comms
 	mirrorcanloadappearance = TRUE
 
@@ -160,7 +160,7 @@
 /datum/outfit/lavaland_syndicate/comms
 	name = "Lavaland Syndicate Comms Agent"
 	r_hand = /obj/item/melee/transforming/energy/sword/saber
-	mask = /obj/item/clothing/mask/chameleon/gps
+	mask = /obj/item/clothing/mask/chameleon/ //Replaced from /obj/item/clothing/mask/chameleon/gps because shouldn't it be stealthy?
 	suit = /obj/item/clothing/suit/armor/vest
 
 /obj/item/clothing/mask/chameleon/gps/Initialize()

--- a/modular_citadel/code/game/machinery/cryopod.dm
+++ b/modular_citadel/code/game/machinery/cryopod.dm
@@ -384,7 +384,10 @@
 			else if(target.mind.has_antag_datum(/datum/antagonist/rev))
 				alert("<span class='userdanger'>You're a Revolutionary![generic_plsnoleave_message]</span>")
 				caught = TRUE
-
+		if(target.mind.special_role == ROLE_TRAITOR)
+			alert("<span class='userdanger'>You're a Traitor![generic_plsnoleave_message]</span>")
+			caught = TRUE
+	
 		if(caught)
 			target.client.cryo_warned = world.time
 			return


### PR DESCRIPTION

## About The Pull Request

Lets start if off right off the bat, chameleon masks from lavaland syndicate and (hopefully)  space comms agents no longer have a GPS.

Flavor text for the syndicate ghost roles more tie into a don't leave rather than abandon, while hinting Kinaris is also an enemy much like NT, just not that much of a threat (think cold war).

Lastly anyone with the mind.special_role ROLE_TRAITOR will get a notification about ahelping before cryoing.


## Why It's Good For The Game

For the GPS a lot of people more or less hate it as anyone with a GPS on hand will see an 'Encrypted signal' quickly giving a red flag (as many metagame this) to someone being a comms agent, while shouldn't comms agents not have a GPS built into their mask? This would better fit the low profile while miner's have to hunt for the location instead of going towards X,Y,Z.

There's still some buffered to work on when it comes flavor text and ruling regarding ghost roles, namely syndicate, as of late, many syndicate ghost role players have been leaving the base, only to return and mention they didn't abandon it if they were to return. This is a quality of life change for admins with those who like loopholes. Secondly Kinaris isn't that much of a enemy to the syndicate than they are to Nanotrasen, but that doesn't make them buddy buddy, with being a mega corp. and the syndicate doesn't approve of how they operate, it's more of a cold war scene than it is at war. Being an enemy, but not so direct or prioritized.

Finally if a player who has the special role ROLE_TRAITOR tries to cryo, they are given a pop up message to ahelp it whether or not staff is online. It's more quality control then anything for the staff team to monitor who actively has a need to cryo versus someone cryoing because they don't want to be an antag, ahelp it, we can remove it and pass said role to another player who is more willing.


## Changelog
:cl:
add: a new caught for traitors and cryoing.
balance: Syndicate Comms agents to be more low profile with starting equipment.
code: Tweaked a few things for flavor text
admin: Provided more abilities for staff to keep track of things and enforce ruling.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
