### PR TITLE
Fire Extinguisher water goes over dense objects

### DIFF
--- a/code/game/objects/effects/effect_system/effects_water.dm
+++ b/code/game/objects/effects/effect_system/effects_water.dm
@@ -14,9 +14,10 @@
 /obj/effect/particle_effect/water/Move(turf/newloc)
 	if (--src.life < 1)
 		qdel(src)
-		return 0
+		return FALSE
 	if(newloc.density)
-		return 0
+		if(istype(newloc, /turf))
+			return FALSE
 	.=..()
 
 /obj/effect/particle_effect/water/Bump(atom/A)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title

## Why It's Good For The Game
Before, fire extinguisher particles wouldn't go over things like heaters, tables, grilles, and other things when atmos can do things like that. Don't worry, the particles won't pass through solid turf

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: fire extinguisher particles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
