### PR TITLE
Fixes species tongues changing speech in emotes

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -99,8 +99,9 @@
 	var/static/regex/lizard_hiSS = new("S+", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
-		message = lizard_hiss.Replace(message, "sss")
-		message = lizard_hiSS.Replace(message, "Sss")
+		var/asterisk_loc = findtext(message, "*")+1	//Don't calculate this every time
+		message = lizard_hiss.Replace(message, "sss", asterisk_loc)
+		message = lizard_hiSS.Replace(message, "Sss", asterisk_loc)
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/tongue/kitty
@@ -117,8 +118,9 @@
 	var/static/regex/taja_puRR = new("R+", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
-		message = taja_purr.Replace(message, "rrr")
-		message = taja_puRR.Replace(message, "Rrr")
+		var/asterisk_loc = findtext(message, "*")+1	//Don't calculate this every time
+		message = taja_purr.Replace(message, "rrr", asterisk_loc)
+		message = taja_puRR.Replace(message, "Rrr", asterisk_loc)
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/tongue/fly
@@ -135,8 +137,9 @@
 	var/static/regex/fly_buZZ = new("Z+", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
-		message = fly_buzz.Replace(message, "zzz")
-		message = fly_buZZ.Replace(message, "ZZZ")
+		var/asterisk_loc = findtext(message, "*")+1	//Don't calculate this every time
+		message = fly_buzz.Replace(message, "zzz", asterisk_loc)
+		message = fly_buZZ.Replace(message, "ZZZ", asterisk_loc)
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/tongue/abductor
@@ -294,13 +297,14 @@
 /obj/item/organ/tongue/fluffy/handle_speech(datum/source, list/speech_args)
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
-		message = replacetext(message, "ne", "nye")
-		message = replacetext(message, "nu", "nyu")
-		message = replacetext(message, "na", "nya")
-		message = replacetext(message, "no", "nyo")
-		message = replacetext(message, "ove", "uv")
-		message = replacetext(message, "l", "w")
-		message = replacetext(message, "r", "w")
+		var/asterisk_loc = findtext(message, "*")+1	//Don't calculate this every time
+		message = replacetext(message, "ne", "nye", asterisk_loc)
+		message = replacetext(message, "nu", "nyu", asterisk_loc)
+		message = replacetext(message, "na", "nya", asterisk_loc)
+		message = replacetext(message, "no", "nyo", asterisk_loc)
+		message = replacetext(message, "ove", "uv", asterisk_loc)
+		message = replacetext(message, "l", "w", asterisk_loc)
+		message = replacetext(message, "r", "w", asterisk_loc)
 	message = lowertext(message)
 	speech_args[SPEECH_MESSAGE] = message
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a bug known with emoting and having a lizard/fly/felinid tongue, and that's changing messages before asterisks/emotes

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Changes this: "Thermite loomsss over the sssalt, 'But I'm a fressshwater fisssh...'"
To this:
![image](https://user-images.githubusercontent.com/26515331/109599978-8868e600-7ad9-11eb-951f-8b25e9011840.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: tongue emoting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
