### PR TITLE
Disables the ability to right-click eye lighting effects

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -362,6 +362,7 @@
 		on_mob.set_light(1, 1, current_color_string)
 
 /obj/effect/abstract/eye_lighting
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	var/obj/item/organ/eyes/robotic/glow/parent
 
 /obj/effect/abstract/eye_lighting/Initialize()


### PR DESCRIPTION
## About The Pull Request
See title
:cl:
tweak: eye lighting effect no longer shows up in right-click dropdown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
