### PR TITLE
Food Trays hold more and fixes Donk Pocket Boxes

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -307,7 +307,23 @@
 /obj/item/storage/bag/tray/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_items = 15		//I want my sushi god damn it
 	STR.insert_preposition = "on"
+	STR.can_hold = typecacheof(list(
+		/obj/item/reagent_containers/food,
+		/obj/item/kitchen,
+		/obj/item/storage/box/donkpockets))
+
+/obj/item/storage/bag/tray/pre_attack(atom/A, mob/living/user, params)
+	if(istype(A, /obj/structure/table) && user.a_intent == INTENT_HELP)	//I want my tray god damn it
+		if(user.transferItemToLoc(src, get_turf(A)))
+			var/list/click_params = params2list(params)
+			if(!click_params || !click_params["icon-x"] || !click_params["icon-y"])
+				return
+			pixel_x = CLAMP(text2num(click_params["icon-x"]) - 16, -(world.icon_size/2), world.icon_size/2)
+			pixel_y = CLAMP(text2num(click_params["icon-y"]) - 16, -(world.icon_size/2), world.icon_size/2)
+		return
+	..()
 
 /obj/item/storage/bag/tray/attack(mob/living/M, mob/living/user)
 	. = ..()
@@ -336,7 +352,10 @@
 /obj/item/storage/bag/tray/update_icon()
 	cut_overlays()
 	for(var/obj/item/I in contents)
-		add_overlay(new /mutable_appearance(I))
+		var/mutable_appearance/MA = new (I)	//I want my icons god damn it
+		MA.pixel_x = rand(-6, 6)
+		MA.pixel_y = rand(-6, 6)
+		add_overlay(MA)
 
 /obj/item/storage/bag/tray/Entered()
 	. = ..()

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -416,99 +416,53 @@
 	icon_state = "donkpocketbox"
 	illustration=null
 	price = 10
+	var/donktype = /obj/item/reagent_containers/food/snacks/donkpocket
+	var/warmtype = /obj/item/reagent_containers/food/snacks/donkpocket/warm
 
 /obj/item/storage/box/donkpockets/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/food/snacks/donkpocket))
+	STR.can_hold = typecacheof(list(donktype, warmtype), TRUE)
 
 /obj/item/storage/box/donkpockets/PopulateContents()
 	for(var/i in 1 to 6)
-		new /obj/item/reagent_containers/food/snacks/donkpocket(src)
+		new donktype(src)
 
 /obj/item/storage/box/donkpockets/donkpocketspicy
 	name = "box of spicy-flavoured donk-pockets"
 	icon_state = "donkpocketboxspicy"
-	var/donktype = /obj/item/reagent_containers/food/snacks/donkpocket/spicy
-
-/obj/item/storage/box/donkpockets/donkpocketspicy/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/food/snacks/donkpocket/spicy))
-
-/obj/item/storage/box/donkpockets/donkpocketspicy/PopulateContents()
-	for(var/i in 1 to 6)
-		new /obj/item/reagent_containers/food/snacks/donkpocket/spicy(src)
+	donktype = /obj/item/reagent_containers/food/snacks/donkpocket/spicy
+	warmtype = /obj/item/reagent_containers/food/snacks/donkpocket/warm/spicy
 
 /obj/item/storage/box/donkpockets/donkpocketteriyaki
 	name = "box of teriyaki-flavoured donk-pockets"
 	icon_state = "donkpocketboxteriyaki"
-	var/donktype = /obj/item/reagent_containers/food/snacks/donkpocket/teriyaki
-
-/obj/item/storage/box/donkpockets/donkpocketteriyaki/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/food/snacks/donkpocket/teriyaki))
-
-/obj/item/storage/box/donkpockets/donkpocketteriyaki/PopulateContents()
-	for(var/i in 1 to 6)
-		new /obj/item/reagent_containers/food/snacks/donkpocket/teriyaki(src)
+	donktype = /obj/item/reagent_containers/food/snacks/donkpocket/teriyaki
+	warmtype = /obj/item/reagent_containers/food/snacks/donkpocket/warm/teriyaki
 
 /obj/item/storage/box/donkpockets/donkpocketpizza
 	name = "box of pizza-flavoured donk-pockets"
 	icon_state = "donkpocketboxpizza"
-	var/donktype = /obj/item/reagent_containers/food/snacks/donkpocket/pizza
-
-/obj/item/storage/box/donkpockets/donkpocketpizza/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/food/snacks/donkpocket/pizza))
-
-/obj/item/storage/box/donkpockets/donkpocketpizza/PopulateContents()
-	for(var/i in 1 to 6)
-		new /obj/item/reagent_containers/food/snacks/donkpocket/pizza(src)
+	donktype = /obj/item/reagent_containers/food/snacks/donkpocket/pizza
+	warmtype = /obj/item/reagent_containers/food/snacks/donkpocket/warm/pizza
 
 /obj/item/storage/box/donkpockets/donkpocketgondola
 	name = "box of gondola-flavoured donk-pockets"
 	icon_state = "donkpocketboxgondola"
-	var/donktype = /obj/item/reagent_containers/food/snacks/donkpocket/gondola
-
-/obj/item/storage/box/donkpockets/donkpocketgondola/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/food/snacks/donkpocket/gondola))
-
-/obj/item/storage/box/donkpockets/donkpocketgondola/PopulateContents()
-	for(var/i in 1 to 6)
-		new /obj/item/reagent_containers/food/snacks/donkpocket/gondola(src)
+	donktype = /obj/item/reagent_containers/food/snacks/donkpocket/gondola
+	warmtype = /obj/item/reagent_containers/food/snacks/donkpocket/warm/gondola
 
 /obj/item/storage/box/donkpockets/donkpocketberry
 	name = "box of berry-flavoured donk-pockets"
 	icon_state = "donkpocketboxberry"
-	var/donktype = /obj/item/reagent_containers/food/snacks/donkpocket/berry
-
-/obj/item/storage/box/donkpockets/donkpocketberry/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/food/snacks/donkpocket/berry))
-
-/obj/item/storage/box/donkpockets/donkpocketberry/PopulateContents()
-	for(var/i in 1 to 6)
-		new /obj/item/reagent_containers/food/snacks/donkpocket/berry(src)
+	donktype = /obj/item/reagent_containers/food/snacks/donkpocket/berry
+	warmtype = /obj/item/reagent_containers/food/snacks/donkpocket/warm/berry
 
 /obj/item/storage/box/donkpockets/donkpockethonk
 	name = "box of banana-flavoured donk-pockets"
 	icon_state = "donkpocketboxbanana"
-	var/donktype = /obj/item/reagent_containers/food/snacks/donkpocket/honk
-
-/obj/item/storage/box/donkpockets/donkpockethonk/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/food/snacks/donkpocket/honk))
-
-/obj/item/storage/box/donkpockets/donkpockethonk/PopulateContents()
-	for(var/i in 1 to 6)
-		new /obj/item/reagent_containers/food/snacks/donkpocket/honk(src)
+	donktype = /obj/item/reagent_containers/food/snacks/donkpocket/honk
+	warmtype = /obj/item/reagent_containers/food/snacks/donkpocket/warm/honk
 
 /obj/item/storage/box/monkeycubes
 	name = "monkey cube box"

--- a/code/modules/food_and_drinks/food/snacks_pizza.dm
+++ b/code/modules/food_and_drinks/food/snacks_pizza.dm
@@ -25,7 +25,7 @@
 	foodtype = GRAIN | VEGETABLES
 
 /obj/item/reagent_containers/food/snacks/pizza/margherita/robo/Initialize()
-	bonus_reagents += list("nanomachines" = 70)
+	bonus_reagents += list(/datum/reagent/nanomachines = 70)
 	return ..()
 
 /obj/item/reagent_containers/food/snacks/pizzaslice/margherita


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases the food tray's capacity from 5 food items to 15. I wanna be able to hold a damn buffet in my tray before I'm allowed to leave, I NEED MY SUSHI, I WANT FULL-COURSE MEALS, I DONT WANNA PICK UP MY FOOD ONE BY ONE OFF THE COUNTER

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Set out full-course meals. Complete and furbished with chiggen nuckies!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: food trays hold more food items, from 5 to 15
add: you can set food trays on tables with help intent, any other intent will dump the food onto the counter
add: food tray mutable_appearances have random pixel_x and pixel_y each icon update
fix: donk pocket boxes couldn't hold heated versions of themselves
fix: invalid reagent in robot pizza
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
