### PR TITLE
Separates dragon's blood abilities and makes it more common

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -135,7 +135,7 @@ Difficulty: Medium
 				last_legion = FALSE
 				break
 		if(last_legion)
-			loot = list(/obj/item/staff/storm)
+			loot = list(/obj/structure/closet/crate/necropolis/legion)
 			elimination = 0
 		else if(prob(5))
 			loot = list(/obj/structure/closet/crate/necropolis/tendril)
@@ -147,64 +147,3 @@ Difficulty: Medium
 	desc = "The message repeats."
 	invisibility = 100
 
-
-//Loot
-
-/obj/item/staff/storm
-	name = "staff of storms"
-	desc = "An ancient staff retrieved from the remains of Legion. The wind stirs as you move it."
-	icon_state = "staffofstorms"
-	item_state = "staffofstorms"
-	icon = 'icons/obj/guns/magic.dmi'
-	slot_flags = ITEM_SLOT_BACK
-	w_class = WEIGHT_CLASS_BULKY
-	force = 25
-	damtype = BURN
-	hitsound = 'sound/weapons/sear.ogg'
-	var/storm_type = /datum/weather/ash_storm
-	var/storm_cooldown = 0
-	var/static/list/excluded_areas = list(/area/reebe/city_of_cogs)
-
-/obj/item/staff/storm/attack_self(mob/user)
-	if(storm_cooldown > world.time)
-		to_chat(user, "<span class='warning'>The staff is still recharging!</span>")
-		return
-
-	var/area/user_area = get_area(user)
-	var/turf/user_turf = get_turf(user)
-	if(!user_area || !user_turf || (user_area.type in excluded_areas))
-		to_chat(user, "<span class='warning'>Something is preventing you from using the staff here.</span>")
-		return
-	var/datum/weather/A
-	for(var/V in SSweather.processing)
-		var/datum/weather/W = V
-		if((user_turf.z in W.impacted_z_levels) && W.area_type == user_area.type)
-			A = W
-			break
-
-	if(A)
-		if(A.stage != END_STAGE)
-			if(A.stage == WIND_DOWN_STAGE)
-				to_chat(user, "<span class='warning'>The storm is already ending! It would be a waste to use the staff now.</span>")
-				return
-			user.visible_message("<span class='warning'>[user] holds [src] skywards as an orange beam travels into the sky!</span>", \
-			"<span class='notice'>You hold [src] skyward, dispelling the storm!</span>")
-			playsound(user, 'sound/magic/staff_change.ogg', 200, 0)
-			A.wind_down()
-			log_game("[user] ([key_name(user)]) has dispelled a storm at [AREACOORD(user_turf)]")
-			return
-	else
-		A = new storm_type(list(user_turf.z))
-		A.name = "staff storm"
-		log_game("[user] ([key_name(user)]) has summoned [A] at [AREACOORD(user_turf)]")
-		if (is_special_character(user))
-			message_admins("[A] has been summoned in [ADMIN_VERBOSEJMP(user_turf)] by [user] ([key_name_admin(user)], a non-antagonist")
-		A.area_type = user_area.type
-		A.telegraph_duration = 100
-		A.end_duration = 100
-
-	user.visible_message("<span class='warning'>[user] holds [src] skywards as red lightning crackles into the sky!</span>", \
-	"<span class='notice'>You hold [src] skyward, calling down a terrible storm!</span>")
-	playsound(user, 'sound/magic/staff_change.ogg', 200, 0)
-	A.telegraph()
-	storm_cooldown = world.time + 200


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
AKA this is a rework, and changes are described below. See the changelog for the previous values. Dragon's blood only does two things now: chance of being a dragon, and chance of being immune to lava

**Ash Drake Drops**
25% Chance for a Ghost Sword
25% Chance for a Fireball wand, Sacred Flame spell, and Lava Staff
50% Chance for Dragon's Blood

**Colossus Drops**
Previous drops, plus a bottle of acid

**The Legion Drops**
10% chance for each head split to drop a tendril crate, from the previous 5%
On death, gives its previous drop, plus a bottle of acid

**Dragon's Blood**
On Consumption:
50% Chance to become resistant to lava
50% Chance to gain the ability of turning into an Ash Drake

**Bottle of Acid**
A new item, which simply turns the consumer into a skeleton

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Horrible RNG. Just horrible.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: bottle of acid, which turns the user into a living skeleton
add: bottle of acid to colossus and the legion drops
remove: dragon's blood no longer turns the user into a lizard, nor does it turn the user into a skeleton
tweak: ash drake increased chance to drop dragon's blood
tweak: lava staff now spawns with the wizard-related items
code: moves the legion drops to code/modules/mining/lavaland/necropolis_chests.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
