### PR TITLE
Loadout equipment override job outfit

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -390,6 +390,7 @@ SUBSYSTEM_DEF(job)
 	var/datum/job/job = GetJob(rank)
 
 	H.job = rank
+	equip_loadout(N, H)		//Before job outfits are put in place
 
 	//If we joined at roundstart we should be positioned at our workstation
 	if(!joined_late)
@@ -416,8 +417,6 @@ SUBSYSTEM_DEF(job)
 		H.mind.assigned_role = rank
 
 	if(job)
-		if(!job.dresscodecompliant)// CIT CHANGE - dress code compliance
-			equip_loadout(N, H) // CIT CHANGE - allows players to spawn with loadout items
 		var/new_mob = job.equip(H, null, null, joined_late)
 		if(ismob(new_mob))
 			H = new_mob
@@ -449,10 +448,7 @@ SUBSYSTEM_DEF(job)
 		H.add_memory("Your account ID is [wageslave.account_id].")
 
 	if(job && H)
-		if(job.dresscodecompliant)// CIT CHANGE - dress code compliance
-			equip_loadout(N, H) // CIT CHANGE - allows players to spawn with loadout items
 		job.after_spawn(H, M, joined_late) // note: this happens before the mob has a key! M will always have a client, H might not.
-		equip_loadout(N, H, TRUE)//CIT CHANGE - makes players spawn with in-backpack loadout items properly. A little hacky but it works
 
 	return H
 

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -390,7 +390,6 @@ SUBSYSTEM_DEF(job)
 	var/datum/job/job = GetJob(rank)
 
 	H.job = rank
-	equip_loadout(N, H)		//Before job outfits are put in place
 
 	//If we joined at roundstart we should be positioned at our workstation
 	if(!joined_late)
@@ -417,6 +416,8 @@ SUBSYSTEM_DEF(job)
 		H.mind.assigned_role = rank
 
 	if(job)
+		if(!job.dresscodecompliant)// CIT CHANGE - dress code compliance
+			equip_loadout(N, H) // CIT CHANGE - allows players to spawn with loadout items
 		var/new_mob = job.equip(H, null, null, joined_late)
 		if(ismob(new_mob))
 			H = new_mob
@@ -448,7 +449,10 @@ SUBSYSTEM_DEF(job)
 		H.add_memory("Your account ID is [wageslave.account_id].")
 
 	if(job && H)
+		if(job.dresscodecompliant)// CIT CHANGE - dress code compliance
+			equip_loadout(N, H) // CIT CHANGE - allows players to spawn with loadout items
 		job.after_spawn(H, M, joined_late) // note: this happens before the mob has a key! M will always have a client, H might not.
+		equip_loadout(N, H, TRUE)//CIT CHANGE - makes players spawn with in-backpack loadout items properly. A little hacky but it works
 
 	return H
 

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -390,6 +390,7 @@ SUBSYSTEM_DEF(job)
 	var/datum/job/job = GetJob(rank)
 
 	H.job = rank
+	equip_loadout(N, H)
 
 	//If we joined at roundstart we should be positioned at our workstation
 	if(!joined_late)
@@ -416,8 +417,6 @@ SUBSYSTEM_DEF(job)
 		H.mind.assigned_role = rank
 
 	if(job)
-		if(!job.dresscodecompliant)// CIT CHANGE - dress code compliance
-			equip_loadout(N, H) // CIT CHANGE - allows players to spawn with loadout items
 		var/new_mob = job.equip(H, null, null, joined_late)
 		if(ismob(new_mob))
 			H = new_mob
@@ -449,8 +448,6 @@ SUBSYSTEM_DEF(job)
 		H.add_memory("Your account ID is [wageslave.account_id].")
 
 	if(job && H)
-		if(job.dresscodecompliant)// CIT CHANGE - dress code compliance
-			equip_loadout(N, H) // CIT CHANGE - allows players to spawn with loadout items
 		job.after_spawn(H, M, joined_late) // note: this happens before the mob has a key! M will always have a client, H might not.
 		equip_loadout(N, H, TRUE)//CIT CHANGE - makes players spawn with in-backpack loadout items properly. A little hacky but it works
 

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -40,31 +40,44 @@
 
 	//Start with uniform,suit,backpack for additional slots
 	if(uniform)
-		H.equip_to_slot_or_del(new uniform(H),SLOT_W_UNIFORM)
+		H.equip_to_slot_or_store_and_del(new uniform(H),SLOT_W_UNIFORM)
 	if(suit)
-		H.equip_to_slot_or_del(new suit(H),SLOT_WEAR_SUIT)
+		H.equip_to_slot_or_store_and_del(new suit(H),SLOT_WEAR_SUIT)
 	if(back)
 		H.equip_to_slot_or_del(new back(H),SLOT_BACK)
+	
+	if(!visualsOnly) // Items in pockets or backpack don't show up on mob's icon.
+		if(l_pocket)
+			H.equip_to_slot_or_store_and_del(new l_pocket(H),SLOT_L_STORE)
+		if(r_pocket)
+			H.equip_to_slot_or_store_and_del(new r_pocket(H),SLOT_R_STORE)
+		if(backpack_contents)
+			for(var/path in backpack_contents)
+				var/number = backpack_contents[path]
+				if(!isnum(number))//Default to 1
+					number = 1
+				for(var/i in 1 to number)
+					H.equip_to_slot_or_del(new path(H),SLOT_IN_BACKPACK)
 	if(belt)
-		H.equip_to_slot_or_del(new belt(H),SLOT_BELT)
+		H.equip_to_slot_or_store_and_del(new belt(H),SLOT_BELT)
 	if(gloves)
-		H.equip_to_slot_or_del(new gloves(H),SLOT_GLOVES)
+		H.equip_to_slot_or_store_and_del(new gloves(H),SLOT_GLOVES)
 	if(shoes)
-		H.equip_to_slot_or_del(new shoes(H),SLOT_SHOES)
+		H.equip_to_slot_or_store_and_del(new shoes(H),SLOT_SHOES)
 	if(head)
-		H.equip_to_slot_or_del(new head(H),SLOT_HEAD)
+		H.equip_to_slot_or_store_and_del(new head(H),SLOT_HEAD)
 	if(mask)
-		H.equip_to_slot_or_del(new mask(H),SLOT_WEAR_MASK)
+		H.equip_to_slot_or_store_and_del(new mask(H),SLOT_WEAR_MASK)
 	if(neck)
-		H.equip_to_slot_or_del(new neck(H),SLOT_NECK)
+		H.equip_to_slot_or_store_and_del(new neck(H),SLOT_NECK)
 	if(ears)
-		H.equip_to_slot_or_del(new ears(H),SLOT_EARS)
+		H.equip_to_slot_or_store_and_del(new ears(H),SLOT_EARS)
 	if(glasses)
-		H.equip_to_slot_or_del(new glasses(H),SLOT_GLASSES)
+		H.equip_to_slot_or_store_and_del(new glasses(H),SLOT_GLASSES)
 	if(id)
-		H.equip_to_slot_or_del(new id(H),SLOT_WEAR_ID)
+		H.equip_to_slot_or_store_and_del(new id(H),SLOT_WEAR_ID)
 	if(suit_store)
-		H.equip_to_slot_or_del(new suit_store(H),SLOT_S_STORE)
+		H.equip_to_slot_or_store_and_del(new suit_store(H),SLOT_S_STORE)
 
 	if(accessory)
 		var/obj/item/clothing/under/U = H.w_uniform
@@ -77,19 +90,6 @@
 		H.put_in_l_hand(new l_hand(H))
 	if(r_hand)
 		H.put_in_r_hand(new r_hand(H))
-
-	if(!visualsOnly) // Items in pockets or backpack don't show up on mob's icon.
-		if(l_pocket)
-			H.equip_to_slot_or_del(new l_pocket(H),SLOT_L_STORE)
-		if(r_pocket)
-			H.equip_to_slot_or_del(new r_pocket(H),SLOT_R_STORE)
-		if(backpack_contents)
-			for(var/path in backpack_contents)
-				var/number = backpack_contents[path]
-				if(!isnum(number))//Default to 1
-					number = 1
-				for(var/i in 1 to number)
-					H.equip_to_slot_or_del(new path(H),SLOT_IN_BACKPACK)
 
 	if(!H.head && toggle_helmet && istype(H.wear_suit, /obj/item/clothing/suit/space/hardsuit))
 		var/obj/item/clothing/suit/space/hardsuit/HS = H.wear_suit

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -224,7 +224,7 @@
 	if(!J)
 		J = SSjob.GetJob(H.job)
 
-	if(H.nameless && J.dresscodecompliant)
+	if(H.nameless)
 		if(J.title in GLOB.command_positions)
 			H.real_name = J.title
 		else

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -235,15 +235,19 @@ mob/visible_message(message, self_message, blind_message, vision_distance = DEFA
 //set qdel_on_fail to have it delete W if it fails to equip
 //set disable_warning to disable the 'you are unable to equip that' warning.
 //unset redraw_mob to prevent the mob from being redrawn at the end.
-/mob/proc/equip_to_slot_if_possible(obj/item/W, slot, qdel_on_fail = FALSE, disable_warning = FALSE, redraw_mob = TRUE, bypass_equip_delay_self = FALSE)
+/mob/proc/equip_to_slot_if_possible(obj/item/W, slot, qdel_on_fail = FALSE, disable_warning = FALSE, redraw_mob = TRUE, bypass_equip_delay_self = FALSE, store = FALSE)
 	if(!istype(W))
 		return FALSE
 	if(!W.mob_can_equip(src, null, slot, disable_warning, bypass_equip_delay_self))
+		if(store && istype(src, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = src
+			var/obj/item/storage/backpack/BP = H.back
+			if(BP)
+				return SEND_SIGNAL(BP, COMSIG_TRY_STORAGE_INSERT, W, null, TRUE, TRUE)
 		if(qdel_on_fail)
 			qdel(W)
-		else
-			if(!disable_warning)
-				to_chat(src, "<span class='warning'>You are unable to equip that!</span>")
+		else if(!disable_warning)
+			to_chat(src, "<span class='warning'>You are unable to equip that!</span>")
 		return FALSE
 	equip_to_slot(W, slot, redraw_mob) //This proc should not ever fail.
 	return TRUE
@@ -257,6 +261,12 @@ mob/visible_message(message, self_message, blind_message, vision_distance = DEFA
 //Also bypasses equip delay checks, since the mob isn't actually putting it on.
 /mob/proc/equip_to_slot_or_del(obj/item/W, slot)
 	return equip_to_slot_if_possible(W, slot, TRUE, TRUE, FALSE, TRUE)
+
+/mob/proc/equip_to_slot_or_store(obj/item/W, slot)
+	return equip_to_slot_if_possible(W, slot, FALSE, TRUE, FALSE, TRUE, TRUE)
+
+/mob/proc/equip_to_slot_or_store_and_del(obj/item/W, slot)
+	return equip_to_slot_if_possible(W, slot, TRUE, TRUE, FALSE, TRUE, TRUE)
 
 //puts the item "W" into an appropriate slot in a human's inventory
 //returns 0 if it cannot, 1 if successful

--- a/modular_citadel/code/modules/jobs/dresscode_values.dm
+++ b/modular_citadel/code/modules/jobs/dresscode_values.dm
@@ -1,8 +1,0 @@
-//This file controls whether or not a job complies with dresscodes.
-//If a job complies with dresscodes, loadout items will not be equipped instead of the job's outfit, instead placing the items into the player's backpack.
-
-/datum/job
-	var/dresscodecompliant = TRUE
-
-/datum/job/assistant
-	dresscodecompliant = FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3227,7 +3227,6 @@
 #include "modular_citadel\code\modules\events\blob.dm"
 #include "modular_citadel\code\modules\events\wizard\magicarp.dm"
 #include "modular_citadel\code\modules\integrated_electronics\subtypes\manipulation.dm"
-#include "modular_citadel\code\modules\jobs\dresscode_values.dm"
 #include "modular_citadel\code\modules\mentor\follow.dm"
 #include "modular_citadel\code\modules\mentor\mentor.dm"
 #include "modular_citadel\code\modules\mentor\mentor_memo.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Applies loadout equipment before job outfits now, and job outfits will be stored in your backpack if a loadout took its place
![image](https://user-images.githubusercontent.com/26515331/110389742-2f8dd600-8022-11eb-8d6b-3aed1df1fef2.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
So you don't have to continuously take off ALL your stuff at the start of the round, trying to look for your ID under the pile of clothes

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: loadout applies before job outfit datum
tweak: job outfits get placed in the backpack if they cannot be equipped
code: removed dress code compliance from assistants
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
