### PR TITLE
Gives felinids like and dislike foods

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -10,6 +10,9 @@
 	mutantears = /obj/item/organ/ears/cat
 	mutanttail = /obj/item/organ/tail/cat
 
+	liked_food = MEAT | RAW | DAIRY
+	disliked_food = FRIED | FRUIT
+
 /datum/species/human/felinid/qualifies_for_rank(rank, list/features)
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes felinids enjoy meat, raw, and dairy products, but in turn makes them dislike fried and fruit products

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Someone requested to make felinids enjoy mice. I noticed they don't have any disliked or liked foods, so I added liked foods that would seem like what a cat would want. To balance it out a teeny bit, I gave them disliked foods.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: felinids like and dislike food types
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
