### PR TITLE
Removes 'bot (securitron and medibot) voice modules from Integrated Circuitry

### DIFF
--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -174,43 +174,6 @@
 		)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/output/sound/beepsky
-	name = "securitron sound circuit"
-	desc = "Takes a sound name as an input, and will play said sound when pulsed. This circuit is similar to those used in Securitrons."
-	sounds = list(
-		"creep"			= 'sound/voice/beepsky/creep.ogg',
-		"criminal"		= 'sound/voice/beepsky/criminal.ogg',
-		"freeze"		= 'sound/voice/beepsky/freeze.ogg',
-		"god"			= 'sound/voice/beepsky/god.ogg',
-		"i am the law"	= 'sound/voice/beepsky/iamthelaw.ogg',
-		"insult"		= 'sound/voice/beepsky/insult.ogg',
-		"radio"			= 'sound/voice/beepsky/radio.ogg',
-		"secure day"	= 'sound/voice/beepsky/secureday.ogg',
-		)
-	spawn_flags = IC_SPAWN_RESEARCH
-
-/obj/item/integrated_circuit/output/sound/medbot
-	name = "medbot sound circuit"
-	desc = "Takes a sound name as an input, and will play said sound when pulsed. This circuit is often found in medical robots."
-	sounds = list(
-		"surgeon"		= 'sound/voice/medbot/surgeon.ogg',
-		"radar"			= 'sound/voice/medbot/radar.ogg',
-		"feel better"	= 'sound/voice/medbot/feelbetter.ogg',
-		"patched up"	= 'sound/voice/medbot/patchedup.ogg',
-		"injured"		= 'sound/voice/medbot/injured.ogg',
-		"insult"		= 'sound/voice/medbot/insult.ogg',
-		"coming"		= 'sound/voice/medbot/coming.ogg',
-		"help"			= 'sound/voice/medbot/help.ogg',
-		"live"			= 'sound/voice/medbot/live.ogg',
-		"lost"			= 'sound/voice/medbot/lost.ogg',
-		"flies"			= 'sound/voice/medbot/flies.ogg',
-		"catch"			= 'sound/voice/medbot/catch.ogg',
-		"delicious"		= 'sound/voice/medbot/delicious.ogg',
-		"apple"			= 'sound/voice/medbot/apple.ogg',
-		"no"			= 'sound/voice/medbot/no.ogg',
-		)
-	spawn_flags = IC_SPAWN_RESEARCH
-
 /obj/item/integrated_circuit/output/sound/vox
 	name = "ai vox sound circuit"
 	desc = "Takes a sound name as an input, and will play said sound when pulsed. This circuit is often found in AI announcement systems."


### PR DESCRIPTION
## About The Pull Request
Exactly what it says on the tin.

## Why It's Good For The Game
There was LITERALLY no valid use for these things gameplay-wise, and all anyone ever did with them was make useless bots that annoy people.

## Changelog
:cl:
del: Securitron Voice Module and Medibot Voice Module
/:cl:
