### PR TITLE
smol gentleman organs always hide under clothing

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -27,22 +27,23 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 
 //Human Overlays Indexes/////////
 //LOTS OF CIT CHANGES HERE. BE CAREFUL WHEN UPSTREAM ADDS MORE LAYERS
-#define MUTATIONS_LAYER			31		//mutations. Tk headglows, cold resistance glow, etc
-#define GENITALS_BEHIND_LAYER	30		//Some genitalia needs to be behind everything, such as with taurs (Taurs use body_behind_layer
-#define BODY_BEHIND_LAYER		29		//certain mutantrace features (tail when looking south) that must appear behind the body parts
-#define BODYPARTS_LAYER			28		//Initially "AUGMENTS", this was repurposed to be a catch-all bodyparts flag
-#define MARKING_LAYER			27		//Matrixed body markings because clashing with snouts?
-#define BODY_ADJ_LAYER			26		//certain mutantrace features (snout, body markings) that must appear above the body parts
-#define BODY_LAYER				25		//underwear, undershirts, socks, eyes, lips(makeup)
-#define FRONT_MUTATIONS_LAYER	24		//mutations that should appear above body, body_adj and bodyparts layer (e.g. laser eyes)
-#define DAMAGE_LAYER			23		//damage indicators (cuts and burns)
-#define UNIFORM_LAYER			22
-#define ID_LAYER				21
-#define HANDS_PART_LAYER		20
-#define SHOES_LAYER				19
-#define GLOVES_LAYER			18
-#define EARS_LAYER				17
-#define BODY_TAUR_LAYER			16
+#define MUTATIONS_LAYER			32		//mutations. Tk headglows, cold resistance glow, etc
+#define GENITALS_BEHIND_LAYER	31		//Some genitalia needs to be behind everything, such as with taurs (Taurs use body_behind_layer
+#define BODY_BEHIND_LAYER		30		//certain mutantrace features (tail when looking south) that must appear behind the body parts
+#define BODYPARTS_LAYER			29		//Initially "AUGMENTS", this was repurposed to be a catch-all bodyparts flag
+#define MARKING_LAYER			28		//Matrixed body markings because clashing with snouts?
+#define BODY_ADJ_LAYER			27		//certain mutantrace features (snout, body markings) that must appear above the body parts
+#define BODY_LAYER				26		//underwear, undershirts, socks, eyes, lips(makeup)
+#define FRONT_MUTATIONS_LAYER	25		//mutations that should appear above body, body_adj and bodyparts layer (e.g. laser eyes)
+#define DAMAGE_LAYER			24		//damage indicators (cuts and burns)
+#define UNIFORM_LAYER			23
+#define ID_LAYER				22
+#define HANDS_PART_LAYER		21
+#define SHOES_LAYER				20
+#define GLOVES_LAYER			19
+#define EARS_LAYER				18
+#define BODY_TAUR_LAYER			17
+#define GENITALS_UNDER_LAYER	16
 #define SUIT_LAYER				15
 #define GLASSES_LAYER			14
 #define BELT_LAYER				13		//Possible make this an overlay of somethign required to wear a belt?
@@ -58,7 +59,7 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 #define HANDS_LAYER				3
 #define BODY_FRONT_LAYER		2
 #define FIRE_LAYER				1		//If you're on fire
-#define TOTAL_LAYERS			31		//KEEP THIS UP-TO-DATE OR SHIT WILL BREAK ;_;
+#define TOTAL_LAYERS			32		//KEEP THIS UP-TO-DATE OR SHIT WILL BREAK ;_;
 
 //Human Overlay Index Shortcuts for alternate_worn_layer, layers
 //Because I *KNOW* somebody will think layer+1 means "above"

--- a/modular_citadel/code/modules/arousal/organs/genitals.dm
+++ b/modular_citadel/code/modules/arousal/organs/genitals.dm
@@ -426,14 +426,14 @@
 				continue
 
 			var/mutable_appearance/genital_overlay = mutable_appearance(S.icon, layer = -layer)
-			//genitals bigger than 26 inches / g-cup will appear over clothing, if accepted
+			//genitals bigger than 11 inches / g-cup will appear over clothing, if accepted
 			//otherwise, appear under clothing
 			if(G.slot == "penis" || G.slot == "testicles")
 				if(G.size < 3)		//is actually "less than 11 inches"
 					genital_overlay.layer = -GENITALS_UNDER_LAYER			
 			if(G.slot == "breasts")
 				var/obj/item/organ/genital/breasts/B = G
-				if(B.cached_size < 8)
+				if(B.cached_size < 8)	//anything smaller than a g-cup
 					genital_overlay.layer = -GENITALS_UNDER_LAYER
 			
 			//Get the icon

--- a/modular_citadel/code/modules/arousal/organs/genitals.dm
+++ b/modular_citadel/code/modules/arousal/organs/genitals.dm
@@ -383,7 +383,7 @@
 	if(HAS_TRAIT(H, TRAIT_HUSK))
 		return
 	var/list/genitals_to_add = list()
-	var/list/relevant_layers = list(GENITALS_BEHIND_LAYER, GENITALS_FRONT_LAYER) //GENITALS_ADJ_LAYER removed
+	var/list/relevant_layers = list(GENITALS_BEHIND_LAYER, GENITALS_FRONT_LAYER, GENITALS_UNDER_LAYER) //GENITALS_ADJ_LAYER removed
 	var/list/standing = list()
 	var/size
 	var/aroused_state
@@ -426,14 +426,23 @@
 				continue
 
 			var/mutable_appearance/genital_overlay = mutable_appearance(S.icon, layer = -layer)
+			//genitals bigger than 26 inches / g-cup will appear over clothing, if accepted
+			//otherwise, appear under clothing
+			if(G.slot == "penis" || G.slot == "testicles")
+				if(G.size < 4)		//actually 26 inches
+					genital_overlay.layer = -GENITALS_UNDER_LAYER			
+			if(G.slot == "breasts")
+				var/obj/item/organ/genital/breasts/B = G
+				if(B.cached_size < 8)
+					genital_overlay.layer = -GENITALS_UNDER_LAYER
+			
+			//Get the icon
 			genital_overlay.icon_state = "[G.slot]_[S.icon_state]_[size]_[aroused_state]_[layertext]"
 			colourcode = S.color_src
-
-			if(G.slot == "belly") //we have a different size system to the rest of the genitals
+			if(G.slot == "belly") //we have a different size system
 				genital_overlay.icon = 'hyperstation/icons/obj/genitals/belly.dmi'
 				genital_overlay.icon_state = "belly_[size]"
 				colourcode = "belly_color"
-
 
 			if(S.center)
 				genital_overlay = center_image(genital_overlay, S.dimension_x, S.dimension_y)

--- a/modular_citadel/code/modules/arousal/organs/genitals.dm
+++ b/modular_citadel/code/modules/arousal/organs/genitals.dm
@@ -429,7 +429,7 @@
 			//genitals bigger than 26 inches / g-cup will appear over clothing, if accepted
 			//otherwise, appear under clothing
 			if(G.slot == "penis" || G.slot == "testicles")
-				if(G.size < 4)		//actually 26 inches
+				if(G.size < 3)		//is actually "less than 11 inches"
 					genital_overlay.layer = -GENITALS_UNDER_LAYER			
 			if(G.slot == "breasts")
 				var/obj/item/organ/genital/breasts/B = G


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title. Meets halfway with pr #964, and makes small organs appear under clothing items

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
a-cups appeared over bras lmao

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: smaller productive organs appear under clothing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
