### PR TITLE
fixes various bugs and runtimes

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -36,7 +36,7 @@
 	var/buckle_message_cooldown = 0
 	var/fingerprintslast
 
-	var/list/filter_data //For handling persistent filters
+	var/list/filter_data = list() //For handling persistent filters
 
 	var/datum/component/orbiter/orbiters
 
@@ -861,14 +861,15 @@ Proc for attack log creation, because really why not
 		filters += filter(arglist(arguments))
 
 /atom/movable/proc/get_filter(name)
-	if(filter_data && filter_data[name])
-		return filters[filter_data.Find(name)]
+	if(filter_data)
+		if(filter_data[name])	return filters[filter_data.Find(name)]
 
 /atom/movable/proc/remove_filter(name)
-	if(filter_data[name])
-		filter_data -= name
-		update_filters()
-		return TRUE
+	if(filter_data)
+		if(filter_data[name])
+			filter_data -= name
+			update_filters()
+			return TRUE
 
 /atom/proc/intercept_zImpact(atom/movable/AM, levels = 1)
 	. |= SEND_SIGNAL(src, COMSIG_ATOM_INTERCEPT_Z_FALL, AM, levels)

--- a/code/modules/hydroponics/grown/peas.dm
+++ b/code/modules/hydroponics/grown/peas.dm
@@ -31,11 +31,11 @@
 
 // Laughin' Peas
 /obj/item/seeds/peas/laugh
-	name = "pack of laughin' peas"
-	desc = "These seeds give off a very soft purple glow.. they should grow into Laughin' Peas."
+	name = "pack of laughing peas"
+	desc = "These seeds give off a very soft purple glow.. they should grow into Laughing Peas."
 	icon_state = "seed-laughpeas"
 	species = "laughpeas"
-	plantname = "Laughin' Peas"
+	plantname = "Laughing Peas"
 	product = /obj/item/reagent_containers/food/snacks/grown/laugh
 	maturation = 7
 	potency = 10
@@ -53,7 +53,7 @@
 
 /obj/item/reagent_containers/food/snacks/grown/laugh
 	seed = /obj/item/seeds/peas/laugh
-	name = "pod of laughin' peas"
+	name = "pod of laughing peas"
 	desc = "Ridens Cicer, guaranteed to improve your mood dramatically upon consumption!"
 	icon_state = "laughpeas"
 	filling_color = "#ee7bee"

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -167,7 +167,7 @@
 
 	for (var/obj/T in contents)//Now we find the seed we need to vend
 		var/obj/item/seeds/O = T
-		if (O.plantname == href_list["name"] && O.lifespan == href_list["li"] && O.endurance == href_list["en"] && O.maturation == href_list["ma"] && O.production == href_list["pr"] && O.yield == href_list["yi"] && O.potency == href_list["pot"])
+		if (sanitize(O.plantname) == sanitize(href_list["name"]) && O.lifespan == href_list["li"] && O.endurance == href_list["en"] && O.maturation == href_list["ma"] && O.production == href_list["pr"] && O.yield == href_list["yi"] && O.potency == href_list["pot"])
 			O.forceMove(drop_location())
 			break
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -260,7 +260,7 @@ mob/visible_message(message, self_message, blind_message, vision_distance = DEFA
 //This is just a commonly used configuration for the equip_to_slot_if_possible() proc, used to equip people when the round starts and when events happen and such.
 //Also bypasses equip delay checks, since the mob isn't actually putting it on.
 /mob/proc/equip_to_slot_or_del(obj/item/W, slot)
-	return equip_to_slot_if_possible(W, slot, TRUE, TRUE, FALSE, TRUE)
+	return equip_to_slot_if_possible(W, slot, TRUE, TRUE, FALSE, TRUE, FALSE)
 
 /mob/proc/equip_to_slot_or_store(obj/item/W, slot)
 	return equip_to_slot_if_possible(W, slot, FALSE, TRUE, FALSE, TRUE, TRUE)

--- a/hyperstation/code/controllers/subsystem/economy.dm
+++ b/hyperstation/code/controllers/subsystem/economy.dm
@@ -2,6 +2,7 @@ SUBSYSTEM_DEF(economy)
 	name = "Economy"
 	wait = 5 MINUTES
 	init_order = INIT_ORDER_ECONOMY
+	flags = SS_NO_FIRE
 	runlevels = RUNLEVEL_GAME
 	var/roundstart_paychecks = 5
 	var/budget_pool = 35000


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes some runtimes and bugs, which included:
- Loadout items duplicating onto the new_player mob
- Logging in resulting in a useless stinky runtime which cluttered world output
- Laughin' Peas couldnt be taken out of seed extractors because of the apostrophe. Renamed them from Laughin' to Laughing
- Economy subsystem now has SS_NO_FIRE

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
FIX PLS

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: refactored loadout code. job equipping now happens there, as well as only occurring once instead of having two different vars
fix: loadout duplicating backpack items onto new_player atom / mob
fix: laughing peas unable to be taken out from seed extractors
fix: squashed filters runtime
spellcheck: laughin' peas > laughing peas
tweak: economy subsystem no longer fires, to avoid a warning outputting in the world log
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
