### PR TITLE
stupid infinite candles superheating a room

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -19923,9 +19923,6 @@
 /area/centcom/holding)
 "Vn" = (
 /obj/structure/table/wood/fancy,
-/obj/item/candle/infinite{
-	pixel_y = 6
-	},
 /obj/effect/turf_decal/loading_area{
 	dir = 1;
 	icon_state = "drain";
@@ -19940,6 +19937,10 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
 	pixel_x = 7;
 	pixel_y = 5
+	},
+/obj/item/candle{
+	pixel_x = 1;
+	pixel_y = 6
 	},
 /turf/open/floor/wood,
 /area/centcom/control)
@@ -20694,9 +20695,9 @@
 /obj/item/reagent_containers/food/snacks/meatballspaghetti{
 	pixel_y = 14
 	},
-/obj/item/candle/infinite{
+/obj/item/candle{
 	pixel_x = 1;
-	pixel_y = 3
+	pixel_y = 6
 	},
 /turf/open/floor/wood,
 /area/centcom/control)
@@ -66005,7 +66006,7 @@ nM
 nM
 io
 mQ
-iu
+io
 rK
 iu
 tN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Just replacing the infinite candles from the escape pod bar and a little map tweak.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
the infinite candles were superheating a room so not good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Changing the infinite candles out for normal ones.
tweak: Replacing a reinforced window with a indestructible wall to prevent people from the escape pod from entering the rest of CentCom so easily.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
