### PR TITLE
Antag role changes

### DIFF
--- a/code/game/gamemodes/bloodsucker/bloodsucker.dm
+++ b/code/game/gamemodes/bloodsucker/bloodsucker.dm
@@ -22,7 +22,7 @@
 	required_enemies = 2
 	recommended_enemies = 4
 	reroll_friendly = FALSE
-	enemy_minimum_age = 7
+	enemy_minimum_age = 21
 	round_ends_with_antag_death = FALSE
 
 

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -136,7 +136,7 @@ Credit where due:
 	required_players = 35
 	required_enemies = 3
 	recommended_enemies = 5
-	enemy_minimum_age = 7
+	enemy_minimum_age = 28
 	protected_jobs = list("AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain") //Silicons can eventually be converted
 	restricted_jobs = list("Chaplain", "Captain")
 	announce_span = "brass"

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -43,7 +43,7 @@
 	required_players = 30
 	required_enemies = 3
 	recommended_enemies = 5
-	enemy_minimum_age = 7
+	enemy_minimum_age = 28
 
 	announce_span = "cult"
 	announce_text = "Some crew members are trying to start a cult to Nar'Sie!\n\

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -275,7 +275,7 @@
 //                LEWD                  //
 //                                      //
 //////////////////////////////////////////
-
+/* //Putting Lewd traitor on the backburner until we can buffer it a bit.
 /datum/dynamic_ruleset/midround/autotraitor/lewd
 	name = "Horny Traitor"
 	persistent = TRUE
@@ -375,7 +375,7 @@
 	var/datum/antagonist/traitor/lewd/newTraitor = new
 	M.mind.add_antag_datum(newTraitor)
 	return TRUE
-
+*/
 //////////////////////////////////////////////
 //                                          //
 //         Malfunctioning AI                //

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -66,7 +66,7 @@
 //                LEWD                  //
 //                                      //
 //////////////////////////////////////////
-
+/* //Putting Lewd traitor on the backburner until we can buffer it a bit.
 /datum/dynamic_ruleset/roundstart/traitor/lewd
 	name = "Horny Traitor"
 	persistent = TRUE
@@ -115,7 +115,7 @@
 		M.mind.restricted_roles = restricted_roles
 	return TRUE
 
-
+*/
 //////////////////////////////////////////
 //                                      //
 //           BLOOD BROTHERS             //

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -34,7 +34,7 @@
 	var/round_converted = 0 //0: round not converted, 1: round going to convert, 2: round converted
 	var/reroll_friendly 	//During mode conversion only these are in the running
 	var/continuous_sanity_checked	//Catches some cases where config options could be used to suggest that modes without antagonists should end when all antagonists die
-	var/enemy_minimum_age = 7 //How many days must players have been playing before they can play this antagonist
+	var/enemy_minimum_age = 21 //How many days must players have been playing before they can play this antagonist
 
 	var/announce_span = "warning" //The gamemode's name will be in this span during announcement.
 	var/announce_text = "This gamemode forgot to set a descriptive text! Uh oh!" //Used to describe a gamemode when it's announced.

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -6,7 +6,7 @@
 	required_enemies = 2
 	recommended_enemies = 5
 	antag_flag = ROLE_OPERATIVE
-	enemy_minimum_age = 7
+	enemy_minimum_age = 21
 
 	announce_span = "danger"
 	announce_text = "Syndicate forces are approaching the station in an attempt to destroy it!\n\

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -16,7 +16,7 @@
 	required_players = 30
 	required_enemies = 2
 	recommended_enemies = 3
-	enemy_minimum_age = 14
+	enemy_minimum_age = 28
 
 	announce_span = "danger"
 	announce_text = "Some crewmembers are attempting a coup!\n\

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -16,7 +16,7 @@
 	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1
-	enemy_minimum_age = 0
+	enemy_minimum_age = 21
 
 	announce_span = "danger"
 	announce_text = "There are Syndicate agents on the station!\n\

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -10,7 +10,7 @@
 	required_players = 20
 	required_enemies = 1
 	recommended_enemies = 1
-	enemy_minimum_age = 7
+	enemy_minimum_age = 21
 	round_ends_with_antag_death = 1
 	announce_span = "danger"
 	announce_text = "There is a space wizard attacking the station!\n\


### PR DESCRIPTION
## About The Pull Request

First of all removed Lewd Traitor from the round start as well as mid round system, leaving it only as a admin given role as the role itself is still a WIP, further more pumped up the play time requirement with antags to 3 weeks (21 days).

## Why It's Good For The Game

With the change on time requirement on antags, this will give players a bit of time to understand the flow and environment of the game, allowing them to better understand roleplay instead of going out guns blazing without knowing much about the server.

As for Lewd Traitor, off request of creator they wanted to to be removed from the midround/roundstart rotation, but left in the code to work as a side project in time.

## Changelog
:cl:
del: Roundstart/midround lewd traitor role.
tweak: Tweaked a few number so that way a player has to be X days old to be an antag.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
