### PR TITLE
We're off to see the wizard

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/wizardden.dmm
+++ b/_maps/RandomRuins/SpaceRuins/wizardden.dmm
@@ -1,0 +1,277 @@
+"a" = (/turf/open/space/basic,/area/space)
+"f" = (/obj/structure/fans/tiny/invisible,/turf/open/floor/fakepit,/area/ruin/space/has_grav/powered/wiz_home)
+"h" = (/obj/structure/bed,/obj/item/bedsheet/wiz,/obj/machinery/light_switch{pixel_y = -24},/turf/open/floor/wood,/area/ruin/space/has_grav/powered/wiz_home)
+"j" = (/obj/structure/table/wood,/obj/item/book/codex_gigas,/obj/machinery/light{dir = 8},/turf/open/floor/wood,/area/ruin/space/has_grav/powered/wiz_home)
+"p" = (/obj/machinery/door/airlock/external,/obj/effect/mapping_helpers/airlock/cyclelink_helper,/turf/open/floor/plating,/area/ruin/space/has_grav/powered/wiz_home)
+"t" = (/obj/structure/table/wood,/obj/item/gun/magic/staff,/turf/open/floor/wood,/area/ruin/space/has_grav/powered/wiz_home)
+"v" = (/obj/structure/destructible/cult/tome,/turf/open/floor/wood,/area/ruin/space/has_grav/powered/wiz_home)
+"w" = (/turf/closed/indestructible/wood,/area/ruin/space/has_grav/powered/wiz_home)
+"y" = (/turf/open/floor/carpet,/area/ruin/space/has_grav/powered/wiz_home)
+"z" = (/obj/structure/table/wood,/obj/item/storage/pill_bottle/dice{icon_state = "magicdicebag"},/turf/open/floor/wood,/area/ruin/space/has_grav/powered/wiz_home)
+"B" = (/obj/structure/chair/wood/wings{dir = 1},/turf/open/floor/carpet,/area/ruin/space/has_grav/powered/wiz_home)
+"G" = (/obj/structure/showcase{desc = "A historical figure of great importance to the wizard federation. He spent his long life learning magic, stealing artifacts, and harassing idiots with swords. May he rest forever, Rodney."; icon = 'icons/mob/mob.dmi'; icon_state = "nim"; name = "wizard of yendor showcase"},/turf/open/floor/wood,/area/ruin/space/has_grav/powered/wiz_home)
+"I" = (/obj/machinery/vending/magivend_novirus,/turf/open/floor/wood,/area/ruin/space/has_grav/powered/wiz_home)
+"K" = (/obj/item/clothing/shoes/sandal/marisa,/obj/item/clothing/suit/wizrobe/marisa,/obj/item/clothing/head/wizard/marisa,/obj/effect/decal/remains/human,/turf/open/floor/carpet,/area/ruin/space/has_grav/powered/wiz_home)
+"P" = (/obj/structure/table/wood,/obj/item/book/granter/spell/smoke,/turf/open/floor/wood,/area/ruin/space/has_grav/powered/wiz_home)
+"S" = (/obj/machinery/light,/turf/open/floor/wood,/area/ruin/space/has_grav/powered/wiz_home)
+"U" = (/obj/machinery/light{dir = 4},/turf/open/floor/wood,/area/ruin/space/has_grav/powered/wiz_home)
+"V" = (/turf/open/floor/wood,/area/ruin/space/has_grav/powered/wiz_home)
+"W" = (/obj/structure/destructible/cult/talisman{desc = "An altar dedicated to the Wizards' Federation"},/obj/item/kitchen/knife/ritual,/turf/open/floor/wood,/area/ruin/space/has_grav/powered/wiz_home)
+"X" = (/obj/structure/table/wood,/obj/item/spellbook{name = "Magical Grimoire"; owner = "Chloe Zadovsky"; uses = 0},/turf/open/floor/wood,/area/ruin/space/has_grav/powered/wiz_home)
+"Y" = (/obj/machinery/door/airlock/external,/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 1},/turf/open/floor/plating,/area/ruin/space/has_grav/powered/wiz_home)
+
+(1,1,1) = {"
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aawwwwwwwwwwaaa
+aawztPvWVVIwaaa
+aawXKyByyyVwaaa
+aawjyyyyyyUwaaa
+aawVVVhGSVVwaaa
+aawwwwwwwpwwaaa
+aaaaaaaawfwaaaa
+aaaaaaaawYwaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+"}
+(1,1,2) = {"
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+"}
+(1,1,3) = {"
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+"}
+(1,1,4) = {"
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+"}
+(1,1,5) = {"
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+"}
+(1,1,6) = {"
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+"}
+(1,1,7) = {"
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+"}
+(1,1,8) = {"
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+"}
+(1,1,9) = {"
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+"}
+(1,1,10) = {"
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+"}
+(1,1,11) = {"
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+"}
+(1,1,12) = {"
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+"}
+(1,1,13) = {"
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+"}
+(1,1,14) = {"
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+"}
+(1,1,15) = {"
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaa
+"}

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -58,6 +58,9 @@
 /area/ruin/space/has_grav/powered/cat_man
 	name = "Kitty Den"
 
+/area/ruin/space/has_grav/powered/wiz_home/area/ruin/space/has_grav/powered/wiz_home
+	name = "Wizard's Cabin"
+
 /area/ruin/space/has_grav/powered/authorship
 	name = "Authorship"
 
@@ -177,13 +180,6 @@
 /area/ruin/space/has_grav/powered/mechtransport
 	name = "Mech Transport"
 	icon_state = "green"
-
-
-//Ruin of gas the lizard
-
-/area/ruin/space/has_grav/gasthelizard
-	name = "Gas the lizard"
-
 
 //Ruin of Deep Storage
 

--- a/code/modules/vending/magivend.dm
+++ b/code/modules/vending/magivend.dm
@@ -16,3 +16,22 @@
 	contraband = list(/obj/item/reagent_containers/glass/bottle/wizarditis = 1)	//No one can get to the machine to hack it anyways; for the lulz - Microwave
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50, "magic" = 100)
 	resistance_flags = FIRE_PROOF
+
+/obj/machinery/vending/magivend_novirus
+	name = "\improper MagiVend"
+	desc = "A magic vending machine."
+	icon_state = "MagiVend"
+	product_slogans = "Sling spells the proper way with MagiVend!;Be your own Houdini! Use MagiVend!"
+	vend_reply = "Have an enchanted evening!"
+	product_ads = "EI NATH;Destroy the station!;Admin conspiracies since forever!;Space-time bending hardware!;Now-magic proofing venders!"
+	products = list(/obj/item/clothing/head/wizard = 1,
+		            /obj/item/clothing/suit/wizrobe = 1,
+		            /obj/item/clothing/head/wizard/red = 1,
+		            /obj/item/clothing/suit/wizrobe/red = 1,
+		            /obj/item/clothing/head/wizard/yellow = 1,
+		            /obj/item/clothing/suit/wizrobe/yellow = 1,
+		            /obj/item/clothing/shoes/sandal/magic = 1,
+		            /obj/item/staff = 2)
+	contraband = list(/obj/item/coin/antagtoken = 1)
+	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50, "magic" = 100)
+	resistance_flags = FIRE_PROOF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new wizard themed space ruin, with special grimoire.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We need more space ruins, and I wanted to make something with sdmm
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Wizard's Cabin space ruin
add: MagiVend that has an antag token rather than wizarditis
remove: gasthelizards reference that was missed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
