### PR TITLE
Makes it so the arcane tome and clockwork slab cannot be discounted

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1792,6 +1792,7 @@ datum/uplink_item/stealthy_weapons/taeclowndo_shoes
 	item = /obj/item/clockwork/slab/traitor
 	cost = 20
 	refundable = TRUE
+	cant_discount = TRUE
 	//restricted_roles = list("Chaplain","Curator")
 
 ///datum/uplink_item/role_restricted/arcane_tome
@@ -1801,6 +1802,7 @@ datum/uplink_item/stealthy_weapons/taeclowndo_shoes
 	item = /obj/item/tome/traitor
 	cost = 20
 	refundable = TRUE
+	cant_discount = TRUE
 	//restricted_roles = list("Chaplain","Curator")
 
 /datum/uplink_item/role_restricted/explosive_hot_potato


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

## Why It's Good For The Game

Since these items are a full kit in themselves, this makes it so under no circumstances they can be discounted, as selling them below 20TC would propose a balance problem.

## Changelog
:cl:
tweak: Arcane Tome and Clockwork Slab will always cost 20TC.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
