### PR TITLE
Disables His Grace, Restricts Cult Traitor Items

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1773,7 +1773,7 @@ datum/uplink_item/stealthy_weapons/taeclowndo_shoes
 	cost = 2
 	restricted_roles = list("Curator")
 	limited_stock = 1 //please don't spam deadchat
-
+/* Disabled because this is waaaay too chaotic for hyper
 /datum/uplink_item/role_restricted/his_grace
 	name = "His Grace"
 	desc = "An incredibly dangerous weapon recovered from a station overcome by the grey tide. Once activated, He will thirst for blood and must be used to kill to sate that thirst. \
@@ -1784,24 +1784,22 @@ datum/uplink_item/stealthy_weapons/taeclowndo_shoes
 	cost = 20
 	restricted_roles = list("Chaplain")
 	surplus = 5 //Very low chance to get it in a surplus crate even without being the chaplain
-
-///datum/uplink_item/role_restricted/clockwork_slab
-/datum/uplink_item/dangerous/clockwork_slab
+*/
+/datum/uplink_item/role_restricted/clockwork_slab
 	name = "Clockwork Slab"
 	desc = "A reverse engineered clockwork slab. Is this really a good idea?"
 	item = /obj/item/clockwork/slab/traitor
 	cost = 20
 	refundable = TRUE
-	//restricted_roles = list("Chaplain","Curator")
+	restricted_roles = list("Chaplain","Curator")
 
-///datum/uplink_item/role_restricted/arcane_tome
-/datum/uplink_item/dangerous/arcane_tome
+/datum/uplink_item/role_restricted/arcane_tome
 	name = "Arcane Tome"
 	desc = "A 'replica' of a Nar'sian tome. This is probably a bad idea..."
 	item = /obj/item/tome/traitor
 	cost = 20
 	refundable = TRUE
-	//restricted_roles = list("Chaplain","Curator")
+	restricted_roles = list("Chaplain","Curator")
 
 /datum/uplink_item/role_restricted/explosive_hot_potato
 	name = "Exploding Hot Potato"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
His Grace is now disabled and unobtainable. Cult traitor items are now restricted back again to chaplain and curator.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Too much complaints, too little ahelps. Gonna just cut the problem at the source real quick then get back to adminning.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Restricted Cult Traitor items to chaplain and curator
tweak: disabled His Grace from the traitor uplink
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
