### PR TITLE
Adds the Engineers to the Clockwork Slab Uplink Whitelist and the Cook to the Arcane Tome Whitelist

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1791,7 +1791,7 @@ datum/uplink_item/stealthy_weapons/taeclowndo_shoes
 	item = /obj/item/clockwork/slab/traitor
 	cost = 20
 	refundable = TRUE
-	restricted_roles = list("Chaplain","Curator","Station Engineer", "Atmospheric Technician")
+	restricted_roles = list("Chaplain","Curator","Station Engineer","Atmospheric Technician")
 	cant_discount = TRUE
 
 /datum/uplink_item/role_restricted/arcane_tome

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1791,7 +1791,7 @@ datum/uplink_item/stealthy_weapons/taeclowndo_shoes
 	item = /obj/item/clockwork/slab/traitor
 	cost = 20
 	refundable = TRUE
-	restricted_roles = list("Chaplain","Curator")
+	restricted_roles = list("Chaplain","Curator","Station Engineer", "Atmospheric Technician")
 	cant_discount = TRUE
 
 /datum/uplink_item/role_restricted/arcane_tome
@@ -1800,7 +1800,7 @@ datum/uplink_item/stealthy_weapons/taeclowndo_shoes
 	item = /obj/item/tome/traitor
 	cost = 20
 	refundable = TRUE
-	restricted_roles = list("Chaplain","Curator")
+	restricted_roles = list("Chaplain","Curator","Cook")
 	cant_discount = TRUE
 
 /datum/uplink_item/role_restricted/explosive_hot_potato


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows engineer traitors to get the clockwork slab in the uplink and the cook to acquire the arcane tome.

## Why It's Good For The Game

I do believe cooks, which have the most underwhelming role restricted traitor items of the game should be allowed to have a little bit more options, while it is also very fitting for engineers to have access to the clockwork slab. I propose at least a test for this instead of restricting those items simply to chaplain/curator.

## Changelog
:cl:
add: engineers should be able to take the clockwork slab uplink item
add: cooks should be able to take the arcane tome uplink item
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
