### PR TITLE
fixes "set flavor text" verb

### DIFF
--- a/code/__HELPERS/_cit_helpers.dm
+++ b/code/__HELPERS/_cit_helpers.dm
@@ -112,7 +112,7 @@ GLOBAL_VAR_INIT(miscreants_allowed, FALSE)
 
 	var/new_flavor = input(src, "Enter your new flavor text:", "Flavor text", null) as message|null
 	if(!isnull(new_flavor))
-		flavor_text = sanitize(new_flavor)
+		flavor_text = html_encode(new_flavor)
 		to_chat(src, "Your flavor text has been updated.")
 
 //LOOC toggles


### PR DESCRIPTION
### Do not merge this if #1088 will be merged

## Changelog
:cl:
fix: set flavor text verb no longer sanitizes text. this means new lines and tabs don't turn into pound signs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
