### PR TITLE
ghosts can read contents of an air canister + examine meters by clicking

### DIFF
--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -134,6 +134,9 @@
 	else
 		to_chat(user, status())
 
+/obj/machinery/meter/attack_ghost(mob/user)
+	to_chat(user, status())
+
 /obj/machinery/meter/singularity_pull(S, current_size)
 	..()
 	if(current_size >= STAGE_FIVE)
@@ -141,6 +144,7 @@
 
 // TURF METER - REPORTS A TILE'S AIR CONTENTS
 //	why are you yelling?
+//   i hope they aren't mad
 /obj/machinery/meter/turf
 
 /obj/machinery/meter/turf/reattach_to_layer()

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -377,6 +377,11 @@
 		air_update_turf() // Update the environment if needed.
 	update_icon()
 
+/obj/machinery/portable_atmospherics/canister/attack_ghost(mob/user)
+	atmosanalyzer_scan(air_contents, user, src, FALSE)
+	if(user.client.keys_held["Ctrl"])
+		. = ..()	//Look at the UI
+
 /obj/machinery/portable_atmospherics/canister/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
 															datum/tgui/master_ui = null, datum/ui_state/state = GLOB.physical_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -378,9 +378,15 @@
 	update_icon()
 
 /obj/machinery/portable_atmospherics/canister/attack_ghost(mob/user)
+	if(user.client)
+		if(IsAdminGhost(user))
+			attack_ai(user)
+			return FALSE
+		else if(user.client.prefs.inquisitive_ghost)
+			user.examinate(src)
+			return FALSE
 	atmosanalyzer_scan(air_contents, user, src, FALSE)
-	if(user.client.keys_held["Ctrl"])
-		. = ..()	//Look at the UI
+	return FALSE
 
 /obj/machinery/portable_atmospherics/canister/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
 															datum/tgui/master_ui = null, datum/ui_state/state = GLOB.physical_state)


### PR DESCRIPTION
## Changelog
:cl:
add: Ghosts can now click on canisters to examine their contents. ctrl+click looks at the UI
add: Ghosts can click on meters to examine them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
