### PR TITLE
Makes Gibbers Useful.dm

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -23,7 +23,7 @@
 /obj/machinery/gibber/RefreshParts()
 	var/gib_time = 40
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
-		meat_produced += B.rating
+		meat_produced += 1.6 * B.rating
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		gib_time -= 5 * M.rating
 		gibtime = gib_time


### PR DESCRIPTION
## About The Pull Request

Rebalances gibbers to use a 1.6 matter bin scaler, meaning that at tier 4 parts, it produces 8 meat per monkey, making it 3 meat more effecient than the meat rack. Basically chefs waste a fuckload of time killing monkeys, and, the gibber has kinda sat around doing sweet fuck all since 2017, so, this fixes that.

## Why It's Good For The Game

-Makes cooking faster
-Gives the gibber a use again, while it's not useful immediately on roundstart, it outscales the meat rack
-Actually gives a reason to update the gibber.

## Changelog
:cl:

balance: Changes matter bin scaling from 1 to 1.6

/:cl:

