### PR TITLE
Permanently enable Gravity within Layenia Station

### DIFF
--- a/_maps/layeniastation.json
+++ b/_maps/layeniastation.json
@@ -7,5 +7,10 @@
 	    "ferry": "ferry_fancy",
 	    "whiteship": "whiteship_box",
 	    "emergency": "emergency_box"
-    }
+    },
+	"traits":[
+		{
+		   "Gravity":true
+		}
+	]
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

With this simple trick, you too can enable gravity permanently for ground stations without needing a gravity generator.

![image](https://user-images.githubusercontent.com/53913550/116655494-9617dc00-a961-11eb-9ad4-3972bbdb0132.png)


This allows @Dahlular @ToonClyde and others to use default areas instead of separate areas with a gravity suffix.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/53913550/116656048-687f6280-a962-11eb-9d92-9c78185a31f9.png)

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
