### PR TITLE
Pirates, Greytide, and Wocky Slush

### DIFF
--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -14,7 +14,7 @@
 	return ..()
 
 /datum/round_event/pirates
-	startWhen = 60 //2 minutes to answer
+	startWhen = 300 //5 minutes to answer
 	var/datum/comm_message/threat
 	var/payoff = 0
 	var/paid_off = FALSE

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/grey_tide
 	max_occurrences = 2
 	min_players = 5
+	map_blacklist = list("LayeniaStation.dmm")
 
 /datum/round_event/grey_tide
 	announceWhen = 50

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -18,8 +18,8 @@
 	var/grumping = 0 // is the engine currently doing grumpy things
 	var/list/grump_prefix = list("an upsetting", "an unsettling",
 	"a scary", "a loud", "a sassy", "a grouchy", "a grumpy",
-	"an awful", "a horrible", "a despicable", "a pretty rad", "a godawful")
-	var/list/grump_suffix = list("noise", "racket", "ruckus", "sound", "clatter", "fracas", "hubbub")
+	"an awful", "a horrible", "a despicable", "a pretty rad", "a godawful, a wocky")
+	var/list/grump_suffix = list("noise", "racket", "ruckus", "sound", "clatter", "fracas", "hubbub, slush")
 	var/sound_engine1 = 'sound/machines/tractor_running.ogg'
 	var/sound_engine2 = 'sound/machines/engine_highpower.ogg'
 	var/sound_tractorrev = 'sound/machines/tractorrev.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Extends the pirate payoff timer by a hell of a lot since one minute doesn't quite cut it with our movement speed/playerbase. Makes the greytide virus not occur on LayeniaStation since it's overall an extremely lame event and there will be a replacement for it in the future. And adds some new grump prefixes and suffixes for the TEG.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More support for a relaxed playerbase. And Wocky Slush
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: a wocky and slush grump_prefix and grump_suffix respectively for TEG
tweak: pirates can be paid within 5 minutes instead of 1
tweak: Greytide virus no longer occurs on Layenia
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
