### PR TITLE
Blacklists the immovable rod from Layenia Station

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -13,6 +13,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	min_players = 15
 	max_occurrences = 5
 	var/atom/special_target
+	map_blacklist = list("LayeniaStation.dmm")
 
 
 /datum/round_event_control/immovable_rod/admin_setup()


### PR DESCRIPTION
Because it doesn't even spawn at all, regardless if it's blacklisted or not. The event warns the crew of the rod and tells ghosts to orbit, but it does not appear.

## Changelog
:cl:
tweak: blacklisted immovable rod from layenia station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
