### PR TITLE
Fix TRAIT_HEAT not being removed correctly

### DIFF
--- a/modular_citadel/code/modules/arousal/arousal.dm
+++ b/modular_citadel/code/modules/arousal/arousal.dm
@@ -434,7 +434,7 @@
 					W.pregnant = 1
 					if (HAS_TRAIT(L, TRAIT_HEAT))
 						SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "heat", /datum/mood_event/heat) //well done you perv.
-						REMOVE_TRAIT(L, TRAIT_HEAT, type) //take the heat away, you satisfied it!
+						REMOVE_TRAIT(L, TRAIT_HEAT, ROUNDSTART_TRAIT) //take the heat away, you satisfied it!
 
 			 		//Make breasts produce quicker.
 					var/obj/item/organ/genital/breasts/B = L.getorganslot("breasts")


### PR DESCRIPTION
I believe proc REMOVE_TRAIT wanted you to specify what kind of trait it is that you wanted to remove. Haven't checked the proc behavior yet but when investigating its use through the code it does hint strongly that this is the case. 
Tested it on a private server and it appears to successfully remove TRAIT_HEAT when I do a var check on a character.