### PR TITLE
Blacklist Space Pirates and Swarmers from layenia

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
@@ -14,7 +14,7 @@
 	var/list/dead_players = list()
 	var/list/list_observers = list()
 	var/list/map_blacklist = list()		//Determines if a map, "BoxStation.dmm" for example, will spawn. Has to be case-sensitive
-	var/list/map_whitelist = list()		//Blacklist/Whitelist does not check round event controllers, they are separate vars
+	var/list/map_whitelist = list()		//Blacklist/Whitelist does not check round event controllers, they are separate vars and are handled outside of dynamic mode
 
 /datum/dynamic_ruleset/event/acceptable(population=0, threat_level=0)
 	if (map_blacklist.len && (map_blacklist.Find(SSmapping.config.map_file)))
@@ -119,6 +119,7 @@
 	high_population_requirement = 15
 	occurances_max = 1
 	chaos_min = 2.0
+	map_blacklist = list("LayeniaStation.dmm")
 
 /datum/dynamic_ruleset/event/pirates/ready(forced = FALSE)
 	if (!SSmapping.empty_space)
@@ -563,6 +564,7 @@
 	//property_weights = list("extended" = -2)
 	occurances_max = 1
 	chaos_min = 1.5
+	map_blacklist = list("LayeniaStation.dmm")
 
 /datum/dynamic_ruleset/event/sentient_disease
 	name = "Sentient Disease"

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -6,6 +6,7 @@
 	min_players = 15
 	earliest_start = 50 MINUTES
 	gamemode_blacklist = list("nuclear")
+	map_blacklist = list("LayeniaStation.dmm")
 
 /datum/round_event_control/pirates/preRunEvent()
 	if (!SSmapping.empty_space)


### PR DESCRIPTION
TODO: Make certain checks for space also check the turf layenia is designed for
## Changelog
:cl:
tweak: blacklisted space pirate event controller and dynamic mode event for layenia
tweak: blacklisted swarmers dynamic mode event for layenia
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
