### PR TITLE
Minor TEG Update

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -89,7 +89,10 @@
 				var/energy_transfer = delta_temperature*hot_air_heat_capacity*cold_air_heat_capacity/(hot_air_heat_capacity+cold_air_heat_capacity)
 
 				var/heat = energy_transfer*(1-efficiency)
-				lastgen += LOGISTIC_FUNCTION(500000,0.0009,delta_temperature,10000)
+				if(delta_temperature < 16800) // second point where derivative of below function = 1
+					lastgen += LOGISTIC_FUNCTION(500000,0.0009,delta_temperature,10000)
+				else
+					lastgen += delta_temperature + 482102 // value of above function at 16800, or very nearly so
 
 				hot_air.temperature = hot_air.temperature - energy_transfer/hot_air_heat_capacity
 				cold_air.temperature = cold_air.temperature + heat/cold_air_heat_capacity


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports: https://github.com/Citadel-Station-13/Citadel-Station-13/pull/14351

## Why It's Good For The Game

TEG goes above the sun's core temperature but never above 2 megawatts. Kinda unfair. This fixes my previous PR that hard capped it to 2MW, making it so a regular tritium burn produces 2MW but crazier things are still rewarded with more power.

## Changelog
🆑
balance: uncapped TEG power, buffing high-temp TEGs
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
