### PR TITLE
Heirloom Objective Framework

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -41,6 +41,8 @@
 	var/obj/item/heirloom
 	var/where
 
+GLOBAL_LIST_EMPTY(family_heirlooms)
+
 /datum/quirk/family_heirloom/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/heirloom_type
@@ -79,6 +81,7 @@
 		/obj/item/lighter,
 		/obj/item/dice/d20)
 	heirloom = new heirloom_type(get_turf(quirk_holder))
+	GLOB.family_heirlooms += heirloom
 	var/list/slots = list(
 		"in your left pocket" = SLOT_L_STORE,
 		"in your right pocket" = SLOT_R_STORE,

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -883,3 +883,40 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 /datum/objective/changeling_team_objective/impersonate_department/impersonate_heads
 	explanation_text = "Have X or more heads of staff escape on the shuttle disguised as heads, while the real heads are dead"
 	command_staff_only = TRUE
+
+/datum/objective/hoard
+	explanation_text = "Hoard items!"
+	var/obj/item/hoarded_item = null
+
+/datum/objective/hoard/get_target()
+	return hoarded_item
+
+/datum/objective/hoard/proc/set_target(obj/item/I)
+	if(I)
+		hoarded_item = I
+		explanation_text = "Keep [I] on your person at all times."
+		return hoarded_item
+	else
+		explanation_text = "Free objective"
+		return
+
+/datum/objective/hoard/check_completion()
+	var/list/datum/mind/owners = get_owners()
+	if(!hoarded_item)
+		return TRUE
+	for(var/datum/mind/M in owners)
+		if(!isliving(M.current))
+			continue
+
+		var/list/all_items = M.current.GetAllContents()	//this should get things in cheesewheels, books, etc.
+
+		for(var/obj/I in all_items) //Check for items
+			if(I == hoarded_item)
+				return TRUE
+	return FALSE
+
+/datum/objective/hoard/heirloom
+	explanation_text = "Steal target heirloom!"
+
+/datum/objective/hoard/heirloom/find_target()
+	set_target(pick(GLOB.family_heirlooms))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports the framework for using the hoard and heirloom stealing objectives from: https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10623

## Why It's Good For The Game

This is simply a backend addition for these objectives. I have not changed thief traitor to consider the heirloom objective, but I know this is something that @Jay-Sparrow once wanted. If they wish to add it to their thief traitor, it should be fully functional.

## Changelog
:cl:
add: framework for hoard objective
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
