### PR TITLE
Vehicle balance and holo sign buff

### DIFF
--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -1,7 +1,7 @@
 /datum/component/riding
 	var/last_vehicle_move = 0 //used for move delays
 	var/last_move_diagonal = FALSE
-	var/vehicle_move_delay = 2 //tick delay between movements, lower = faster, higher = slower
+	var/vehicle_move_delay = 3 //tick delay between movements, lower = faster, higher = slower
 	var/keytype
 
 	var/slowed = FALSE

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -65,7 +65,7 @@
 	desc = "A holographic projector that creates holographic security barriers."
 	icon_state = "signmaker_sec"
 	holosign_type = /obj/structure/holosign/barrier
-	creation_time = 30
+	creation_time = 0
 	max_signs = 6
 
 /obj/item/holosign_creator/engineering
@@ -73,7 +73,7 @@
 	desc = "A holographic projector that creates holographic engineering barriers."
 	icon_state = "signmaker_engi"
 	holosign_type = /obj/structure/holosign/barrier/engineering
-	creation_time = 30
+	creation_time = 0
 	max_signs = 6
 
 /obj/item/holosign_creator/atmos
@@ -97,7 +97,7 @@
 	desc = "A holographic projector that creates PENLITE holobarriers. Useful during quarantines since they halt those with malicious diseases."
 	icon_state = "signmaker_med"
 	holosign_type = /obj/structure/holosign/barrier/medical
-	creation_time = 30
+	creation_time = 10
 	max_signs = 3
 
 /obj/item/holosign_creator/cyborg

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -9,7 +9,7 @@
 /obj/vehicle/ridden/atv/Initialize()
 	. = ..()
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
-	D.vehicle_move_delay = 1.5
+	D.vehicle_move_delay = 2.25
 	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 4), TEXT_EAST = list(0, 4), TEXT_WEST = list( 0, 4)))
 	D.set_vehicle_dir_layer(SOUTH, ABOVE_MOB_LAYER)
 	D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)

--- a/code/modules/vehicles/bicycle.dm
+++ b/code/modules/vehicles/bicycle.dm
@@ -2,6 +2,7 @@
 	name = "bicycle"
 	desc = "Keep away from electricity."
 	icon_state = "bicycle"
+	size_sensitive = FALSE
 	var/easter_egg_chance = 1
 
 	var/static/list/bike_music = list('sound/misc/bike1.mid',
@@ -12,7 +13,7 @@
 	. = ..()
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
 	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 4), TEXT_EAST = list(0, 4), TEXT_WEST = list( 0, 4)))
-	D.vehicle_move_delay = 1.5
+	D.vehicle_move_delay = 2
 
 /obj/vehicle/ridden/bicycle/buckle_mob(mob/living/M, force = 0, check_loc = 1)
 	if(prob(easter_egg_chance) || (SSevents.holidays && SSevents.holidays[APRIL_FOOLS]))

--- a/code/modules/vehicles/ridden.dm
+++ b/code/modules/vehicles/ridden.dm
@@ -6,6 +6,9 @@
 	default_driver_move = FALSE
 	var/legs_required = 1
 	var/arms_required = 0	//why not?
+	var/max_size = 1.50
+	var/min_size = 0.75
+	var/size_sensitive = TRUE
 
 /obj/vehicle/ridden/Initialize()
 	. = ..()
@@ -34,6 +37,13 @@
 	if(M.get_num_legs() < legs_required)
 		to_chat(M, "<span class='warning'>You don't have enough legs to operate the pedals!</span>")
 		unbuckle_mob(M)
+	else if (size_sensitive)
+		if(M.size_multiplier < min_size)
+			to_chat(M, "<span class='warning'>You are too small to operate something like this!</span>")
+			unbuckle_mob(M)
+		else if(M.size_multiplier > max_size)
+			to_chat(M, "<span class='warning'>You are too big to operate something like this!</span>")
+			unbuckle_mob(M)
 	return ..()
 
 /obj/vehicle/ridden/attackby(obj/item/I, mob/user, params)

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -97,11 +97,11 @@
 	. = ..()
 	var/datum/component/riding/R = src.GetComponent(/datum/component/riding)
 	if (!adjusted_speed)
-		R.vehicle_move_delay = 1.5
+		R.vehicle_move_delay = 2
 		to_chat(user, "<span class='notice'>You adjust the wheels on [src] to make it go faster.</span>")
 		adjusted_speed = TRUE
 	else
-		R.vehicle_move_delay = 2
+		R.vehicle_move_delay = 2.5
 		to_chat(user, "<span class='notice'>You adjust the wheels on [src] to make it go slower.</span>")
 		adjusted_speed = FALSE
 	return TRUE
@@ -172,11 +172,12 @@
 	desc = "Uses patented retractable wheel technology. Never sacrifice speed for style - not that this provides much of either."
 	icon = null
 	density = FALSE
+	size_sensitive = FALSE
 
 /obj/vehicle/ridden/scooter/wheelys/Initialize()
 	. = ..()
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
-	D.vehicle_move_delay = 2
+	D.vehicle_move_delay = 2.5
 	D.set_vehicle_dir_layer(SOUTH, ABOVE_MOB_LAYER)
 	D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)
 	D.set_vehicle_dir_layer(EAST, OBJ_LAYER)

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -8,5 +8,5 @@
 /obj/vehicle/ridden/secway/Initialize()
 	. = ..()
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
-	D.vehicle_move_delay = 1.75
+	D.vehicle_move_delay = 2.5
 	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 4), TEXT_EAST = list(0, 4), TEXT_WEST = list( 0, 4)))

--- a/code/modules/vehicles/speedbike.dm
+++ b/code/modules/vehicles/speedbike.dm
@@ -14,6 +14,7 @@
 	layer = LYING_MOB_LAYER
 	var/overlay_state = "cover_blue"
 	var/mutable_appearance/overlay
+	size_sensitive = FALSE
 
 /obj/vehicle/ridden/space/speedbike/Initialize()
 	. = ..()
@@ -46,6 +47,7 @@
 	layer = LYING_MOB_LAYER
 	var/static/mutable_appearance/overlay = mutable_appearance(icon, "speedwagon_cover", ABOVE_MOB_LAYER)
 	max_buckled_mobs = 4
+	size_sensitive = FALSE
 	var/crash_all = FALSE //CHAOS
 	pixel_y = -48
 	pixel_x = -48

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -11,11 +11,12 @@
 	density = FALSE		//Thought I couldn't fix this one easily, phew
 	// Run speed delay is multiplied with this for vehicle move delay.
 	var/delay_multiplier = 6.7
+	size_sensitive = FALSE
 
 /obj/vehicle/ridden/wheelchair/Initialize()
 	. = ..()
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
-	D.vehicle_move_delay = 1
+	D.vehicle_move_delay = 3
 	D.set_vehicle_dir_layer(SOUTH, OBJ_LAYER)
 	D.set_vehicle_dir_layer(NORTH, ABOVE_MOB_LAYER)
 	D.set_vehicle_dir_layer(EAST, OBJ_LAYER)


### PR DESCRIPTION

## About The Pull Request

Went ahead and toned down the speed of a lot of vehicles, along with making a new variable that unbuckles a player if their size is too small/big. Additionally buffed some holo sign projectors.

## Why It's Good For The Game

Since the change in speed with the removal of stamina and sprint, a lot of people have been using vehicles to get around this removal or nerf as they would call it, this change is to set things back with everything else, balancing and otherwise to tone down the flow of the game for other players.

With holo sign projectors, I made it so instead of it taking 3 seconds to deploy for engineering and security, it's now instantaneous while the medical projector takes one second now.

## Changelog
:cl:
add: A new variable that forces micros/macros to be unable to ride some vehicles.
tweak: A few numbers revolving around tick rate/speed
balance: Vehicles!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
