### PR TITLE
Adds a DCS signal sent on mob size change

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -195,6 +195,8 @@
 
 
 #define COMSIG_MICRO_PICKUP_FEET "micro_force_grabbed"			//From /datum/element/mob_holder/micro
+
+#define COMSIG_MOBSIZE_CHANGED "mobsize_changed"				//Adding this in so items and whatnot can check when someone changes size. -Cap'n
 // /area signals
 
 ///from base of area/Entered(): (atom/movable/M)

--- a/hyperstation/code/game/objects/items/storage/big_bag.dm
+++ b/hyperstation/code/game/objects/items/storage/big_bag.dm
@@ -1,0 +1,44 @@
+/obj/item/storage/backpack/gigantic
+    name = "enormous backpack"
+    desc = "An absolutely massive backpack for particularly large crewmen."
+    icon_state = "explorerpack"
+    item_state = "explorerpack"
+
+/obj/item/storage/backpack/gigantic/ComponentInitialize()
+    . = ..()
+    var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+    STR.allow_big_nesting = TRUE
+    STR.max_combined_w_class = 35
+    STR.max_w_class = WEIGHT_CLASS_HUGE
+
+/obj/item/storage/backpack/gigantic/mob_can_equip(mob/living/M, mob/living/equipper, slot, disable_warning, bypass_equip_delay_self)
+    if(!..()) 
+        return FALSE
+    if(M.size_multiplier >= 2.0)
+        return ..()
+    else
+        return FALSE
+
+/obj/item/storage/backpack/gigantic/proc/fallOff(mob/living/wearer)
+    wearer.dropItemToGround(src, TRUE)
+    playsound(src.loc, 'sound/items/handling/cloth_drop.ogg', 50, TRUE)
+    playsound(src.loc, 'sound/items/handling/toolbelt_drop.ogg', 50, TRUE)
+    wearer.visible_message("<span class='warning'>The [src.name] slips off [wearer]'s now too-small body and falls to the ground!'</span>", "<span class='warning'>The [src.name] slips off your now too-small body and falls to the ground!'</span>")
+
+/obj/item/storage/backpack/gigantic/equipped(mob/equipper, slot)
+    . = ..()
+    if(slot == SLOT_BACK)
+        RegisterSignal(equipper, COMSIG_MOBSIZE_CHANGED, .proc/fallOff)
+    else
+        UnregisterSignal(equipper, COMSIG_MOBSIZE_CHANGED)
+
+    
+/obj/item/storage/backpack/gigantic/dropped(mob/user, silent)
+    UnregisterSignal(user, COMSIG_MOBSIZE_CHANGED)
+
+
+/obj/item/storage/backpack/gigantic/satchel
+    name = "enormous satchel"
+    desc = "An absolutely massive satchel for particularly large crewmen."
+    icon_state = "satchel-explorer"
+    item_state = "securitypack"

--- a/hyperstation/code/modules/resize/resizing.dm
+++ b/hyperstation/code/modules/resize/resizing.dm
@@ -62,6 +62,8 @@ mob/living/get_effective_size()
 	//if(src.size_multiplier >= RESIZE_A_HUGEBIG || src.size_multiplier <= RESIZE_A_TINYMICRO) Will remove clothing when too big or small. Will do later.
 	previous_size = size_multiplier //And, change this now that we are finally done.
 
+	SEND_SIGNAL(src, COMSIG_MOBSIZE_CHANGED, src) //This SHOULD allow other shit to check when a mob changes size -Capn
+
 	//Now check if the mob can get the size action
 	if(!small_sprite)
 		small_sprite = new(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3049,6 +3049,7 @@
 #include "hyperstation\code\datums\traits\neutral.dm"
 #include "hyperstation\code\game\objects\railings.dm"
 #include "hyperstation\code\game\objects\items\cosmetics.dm"
+#include "hyperstation\code\game\objects\items\storage\big_bag.dm"
 #include "hyperstation\code\game\objects\structures\ghost_role_spawners.dm"
 #include "hyperstation\code\gamemode\traitor_lewd.dm"
 #include "hyperstation\code\gamemode\traitor_thief.dm"


### PR DESCRIPTION
## About The Pull Request
For the sake of allowing more mechanics to interact with mobs changing size without hacky, intensive `process()` triggers, `/mob/living/proc/resize` now sends a DCS signal called `COMSIG_MOBSIZE_CHANGED`.

Also adds a (currently unobtainable) bag that can only be worn by macros as a proof-of-concept to demonstrate the functionality.

## Why It's Good For The Game
Convenience change to make life easier for coders.

## Changelog
:cl:
code: DCS signal `COMSIG_MOBSIZE_CHANGED` added to signals.dm
code: Sender for above signal added to resize proc
add: Gigantic Backpack proof-of-concept test item
/:cl:
