### PR TITLE
Let players know that savefile preferences got updated

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -633,8 +633,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	return 1
 
 
-#undef SAVEFILE_VERSION_MAX
-#undef SAVEFILE_VERSION_MIN
+//#undef SAVEFILE_VERSION_MAX
+//#undef SAVEFILE_VERSION_MIN
 
 #ifdef TESTING
 //DEBUG

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -32,3 +32,14 @@
 		else
 			postfix = "soon"
 		to_chat(src, "Please set up your character and select \"Ready\". The game will start [postfix].")
+
+	if(client.prefs.path)	//Hyper edit: notify of a newer preference version
+		var/savefile/S = new /savefile(client.prefs.path)
+		if(S)
+			S.cd = "/"
+			var/slot
+			S["default_slot"] >> slot
+			if(slot)
+				S.cd = "/character[slot]"
+				if(S["version"] < SAVEFILE_VERSION_MAX)
+					to_chat(src, "<span class='redtext'>Your characters are outdated from recent updates. Please make sure if everything is within reasonable levels.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Dumps this into a player's chat when the savefile version updates, and they log in when under that version:
![image](https://user-images.githubusercontent.com/26515331/119209678-c9c7bc80-ba5c-11eb-9e38-afd655711c23.png)


## Changelog
:cl:
add: notify players when the savefile version does not match
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
