### PR TITLE
Fixes Mediborgs/hounds and improves borg upgrade code

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -18,7 +18,11 @@
 	if(R.stat == DEAD)
 		to_chat(user, "<span class='notice'>[src] will not function on a deceased cyborg.</span>")
 		return FALSE
-	if(module_type && !istype(R.module, module_type))
+	if(module_type && !istype(R.module, module_type) && !islist(module_type))
+		to_chat(R, "Upgrade mounting error!  No suitable hardpoint detected!")
+		to_chat(user, "There's no mounting point for the module!")
+		return FALSE
+	if(module_type && islist(module_type) && !(locate(R.module) in module_type))
 		to_chat(R, "Upgrade mounting error!  No suitable hardpoint detected!")
 		to_chat(user, "There's no mounting point for the module!")
 		return FALSE
@@ -410,7 +414,10 @@
 		to produce more advanced and complex medical reagents."
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
-	module_type = /obj/item/robot_module/medical
+	module_type = list(
+		/obj/item/robot_module/medical,
+		/obj/item/robot_module/medihound)
+	
 	var/list/additional_reagents = list()
 
 /obj/item/borg/upgrade/hypospray/action(mob/living/silicon/robot/R, user = usr)
@@ -494,7 +501,9 @@
 		out procedures"
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
-	module_type = /obj/item/robot_module/medical
+	module_type = list(
+		/obj/item/robot_module/medical,
+		/obj/item/robot_module/medihound)
 
 /obj/item/borg/upgrade/processor/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
@@ -517,9 +526,8 @@
 	require_module = 1
 	module_type = list(
 		/obj/item/robot_module/medical,
-		/obj/item/robot_module/syndicate_medical,
-		/obj/item/robot_module/medihound,
-		/obj/item/robot_module/borgi)
+		/obj/item/robot_module/medihound)
+
 
 /obj/item/borg/upgrade/advhealth/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()

--- a/modular_citadel/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_citadel/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -129,6 +129,7 @@
 		/obj/item/twohanded/shockpaddles/cyborg/hound,
 		/obj/item/stack/medical/gauze/cyborg,
 		/obj/item/reagent_containers/syringe,
+		/obj/item/organ_storage,
 		/obj/item/pinpointer/crew,
 		/obj/item/sensor_device)
 	emag_modules = list(/obj/item/dogborg/pounce)


### PR DESCRIPTION
## About The Pull Request
The purpose of this PR is threefold - firstly, it makes the Cyborg Advanced Health Analyzer upgrade actually work - secondly, it adds the Organ Container surgery tool to Medihounds, from who it was long missing for unknown reasons (in spite of them having EVERY OTHER surgery tool, just not that one) - and thirdly, it improves borg upgrade code, enabling upgrades to be restricted to more than one borg module, by setting the `module_type` variable to a list of all module typepaths that should be able to equip the upgrade.

## Why It's Good For The Game
I like to think that fixing bugs and improving code versatility is almost always a good thing.

## Changelog
:cl:
fix: Medihounds now get a full set of surgery tools
fix: Cyborg Advanced Health Scanner Upgrade actually works now
code: Cyborg upgrades can now be restricted to more than one borg module.
/:cl:
