### PR TITLE
adds a button to manually refresh the stat panel

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -368,8 +368,11 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		winset(src, "mainwindow.split", "splitter=[pct]")
 
 
+/client/var/last_stat_panel_refresh = 0
 /client/verb/fix_stat_panel()
 	set name = "Fix Stat Panel"
 	set hidden = TRUE
 
-	init_verbs()
+	if(last_stat_panel_refresh > world.time + 2 SECONDS)
+		init_verbs()
+		last_stat_panel_refresh = world.time

--- a/modular_citadel/interface/skin.dmf
+++ b/modular_citadel/interface/skin.dmf
@@ -45,6 +45,16 @@ menu "menu"
 		command = "hotkeys-help"
 		category = "&Help"
 		saved-params = "is-checked"
+	elem 
+		name = ""
+		command = ""
+		category = "&Help"
+		saved-params = "is-checked"
+	elem 
+		name = "&Refresh Stat Panel"
+		command = "fix-stat-panel"
+		category = "&Help"
+		saved-params = "is-checked"
 
 
 window "mainwindow"
@@ -109,10 +119,10 @@ window "mapwindow"
 		font-family = "Arial"
 		font-size = 7
 		is-default = true
-		saved-params = "icon-size"
 		saved-params = "zoom;letterbox;zoom-mode"
-	style = ".center { text-align: center; } .maptext { font-family: 'Small Fonts'; font-size: 7px; -dm-text-outline: 1px black; color: white; line-height: 1.1; } .command_headset { font-weight: bold;\tfont-size: 8px; } .small { font-size: 6px; } .big { font-size: 8px; } .reallybig { font-size: 8px; } .extremelybig { font-size: 8px; } .greentext { color: #00FF00; font-size: 7px; } .redtext { color: #FF0000; font-size: 7px; } .clown { color: #FF69Bf; font-size: 7px;  font-weight: bold; } .his_grace { color: #15D512; } .hypnophrase { color: #0d0d0d; font-weight: bold; } .yell { font-weight: bold; } .italics { font-size: 6px; }"
-	window "infowindow"
+		style = ".center { text-align: center; } .maptext { font-family: 'Small Fonts'; font-size: 7px; -dm-text-outline: 1px black; color: white; line-height: 1.1; } .command_headset { font-weight: bold;\tfont-size: 8px; } .small { font-size: 6px; } .big { font-size: 8px; } .reallybig { font-size: 8px; } .extremelybig { font-size: 8px; } .greentext { color: #00FF00; font-size: 7px; } .redtext { color: #FF0000; font-size: 7px; } .clown { color: #FF69Bf; font-size: 7px;  font-weight: bold; } .his_grace { color: #15D512; } .hypnophrase { color: #0d0d0d; font-weight: bold; } .yell { font-weight: bold; } .italics { font-size: 6px; }"
+
+window "infowindow"
 	elem "infowindow"
 		type = MAIN
 		pos = 281,0
@@ -278,15 +288,10 @@ window "statwindow"
 		anchor2 = 100,100
 		text-color = #e0e0e0
 		background-color = #272727
+		is-visible = false
 		is-default = true
 		saved-params = ""
-		tab-text-color = #e0e0e0
-		tab-background-color = #242424
-		prefix-color = #e0e0e0
-		suffix-color = #e0e0e0
-		is-visible = false
-		on-tab = ".output statbrowser:tab_change [[*]]"
-		
+
 window "preferences_window"
 	elem "preferences_window"
 		type = MAIN
@@ -294,20 +299,16 @@ window "preferences_window"
 		size = 1280x720
 		anchor1 = none
 		anchor2 = none
-		background-color = none
 		is-visible = false
 		border = line
 		saved-params = "pos;size;is-minimized;is-maximized"
 		statusbar = false
-		outer-size = 1296x759
-		inner-size = 1280x720
 	elem "preferences_browser"
 		type = BROWSER
 		pos = 0,128
 		size = 1280x606
 		anchor1 = 0,18
 		anchor2 = 100,100
-		background-color = none
 		border = line
 		saved-params = ""
 	elem "character_preview_map"


### PR DESCRIPTION
## Changelog
:cl:
add: selection from Help dropdown to manually refresh stat panel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
