### PR TITLE
More Job Titles

### DIFF
--- a/code/modules/jobs/job_types/job_alt_titles.dm
+++ b/code/modules/jobs/job_types/job_alt_titles.dm
@@ -17,10 +17,10 @@
 	alt_titles = list("Civilian", "Morale Officer", "Stripper", "Off-Duty", "Escort", "Visitor", "Businessman", "Trader", "Entertainer", "Tourist")
 
 /datum/job/cook
-	alt_titles = list("Cook", "Culinary Artist", "Butcher", "Chef de partie")
+	alt_titles = list("Cook", "Culinary Artist", "Butcher", "Chef de partie", "Poissonier")
 
 /datum/job/hydro
-	alt_titles = list("Gardener", "Herbalist", "Botanical Researcher", "Hydroponicist", "Farmer", "Beekeeper")
+	alt_titles = list("Gardener", "Herbalist", "Botanical Researcher", "Hydroponicist", "Farmer", "Beekeeper", "Vintner")
 
 /datum/job/curator
 	alt_titles = list("Journalist", "Librarian", "Keeper")
@@ -41,7 +41,7 @@
 	alt_titles = list("Performer", "Pantomime", "Mimic")
 	
 /datum/job/bartender
-	alt_titles = list("Mixologist", "Bar Owner", "Barmaid")
+	alt_titles = list("Mixologist", "Sommelier", "Bar Owner", "Barmaid", "Expediter")
 
 //Science
 /datum/job/rd


### PR DESCRIPTION
## About The Pull Request
Adds job titles to the Botanist, Cook, and Bartender.

Chef:
Poissonier, a person who specializes in cooking fish

Botanist:
Vintner, another word for winemaker

Bartender:
Sommelier, another word for wine steward
Expediter, a person who takes food from the kitchen and hands it out

## Changelog
:cl:
add: poissonier job title for cook
add: vintner job title for botanist
add: sommelier job title for bartender
add: expediter job title for bartender
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
