### PR TITLE
adds a button to manually refresh the stat panel

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -373,6 +373,6 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	set name = "Fix Stat Panel"
 	set hidden = TRUE
 
-	if(last_stat_panel_refresh > world.time + 2 SECONDS)
+	if(world.time > last_stat_panel_refresh + 2 SECONDS)
 		init_verbs()
 		last_stat_panel_refresh = world.time

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -368,8 +368,11 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		winset(src, "mainwindow.split", "splitter=[pct]")
 
 
+/client/var/last_stat_panel_refresh = 0
 /client/verb/fix_stat_panel()
 	set name = "Fix Stat Panel"
 	set hidden = TRUE
 
-	init_verbs()
+	if(last_stat_panel_refresh > world.time + 2 SECONDS)
+		init_verbs()
+		last_stat_panel_refresh = world.time

--- a/modular_citadel/interface/skin.dmf
+++ b/modular_citadel/interface/skin.dmf
@@ -45,6 +45,16 @@ menu "menu"
 		command = "hotkeys-help"
 		category = "&Help"
 		saved-params = "is-checked"
+	elem 
+		name = ""
+		command = ""
+		category = "&Help"
+		saved-params = "is-checked"
+	elem 
+		name = "&Refresh Stat Panel"
+		command = "fix-stat-panel"
+		category = "&Help"
+		saved-params = "is-checked"
 
 
 window "mainwindow"


### PR DESCRIPTION
## Changelog
:cl:
add: selection from Help dropdown to manually refresh stat panel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
