### PR TITLE
This was broken.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
@@ -357,7 +357,7 @@
 	typepath = /datum/round_event/ghost_role/operative
 	required_enemies = list(0,0,0,0,0,0,0,0,0,0)
 	weight = 0 //This is changed in nuclearbomb.dm
-	occurances_max = 1
+	occurances_max = 0
 	requirements = list(10,10,10,10,10,10,10,10,10,10) //SECURE THAT DISK
 	cost = 50
 	chaos_min = 0.5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Apparently lone operative does not spawn anymore if the disk has moved at least once in a while, Jay also fixed events with weight 0 happening by using pickweightallowzero, which is the var that actually DISALLOWS picks that have a value of 0. Funny, isn't it?

**Therefore, this is no longer needed, as lone op should only spawn if the disk is stationary for hours anyway as the mechanic is intended, instead of randomly having a chance to spawn whenever it wanted to.**

## Why It's Good For The Game

Kinda annoying to see a nuke op spawn that no one takes, only to have the role forbidden from spawning again then just see the disk remaining static for over 4 hours with no consequence whatsoever.

## Changelog
:cl:
tweak: Nuke op can proc more than once again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
