### PR TITLE
Sleep tight, Disky - Bed Tucking Element

### DIFF
--- a/code/datums/elements/bed_tucking.dm
+++ b/code/datums/elements/bed_tucking.dm
@@ -1,0 +1,60 @@
+/// Tucking element, for things that can be tucked into bed.
+/datum/element/bed_tuckable
+	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	id_arg_index = 2
+	/// our pixel_x offset - how much the item moves x when in bed (+x is closer to the pillow)
+	var/x_offset = 0
+	/// our pixel_y offset - how much the item move y when in bed (-y is closer to the middle)
+	var/y_offset = 0
+	/// our rotation degree - how much the item turns when in bed (+degrees turns it more parallel)
+	var/rotation_degree = 0
+
+/datum/element/bed_tuckable/Attach(obj/target, x = 0, y = 0, rotation = 0)
+	. = ..()
+	if(!isitem(target))
+		return ELEMENT_INCOMPATIBLE
+
+	x_offset = x
+	y_offset = y
+	rotation_degree = rotation
+	RegisterSignal(target, COMSIG_ITEM_ATTACK_OBJ, .proc/tuck_into_bed)
+
+/datum/element/bed_tuckable/Detach(obj/target)
+	. = ..()
+	UnregisterSignal(target, list(COMSIG_ITEM_ATTACK_OBJ, COMSIG_ITEM_PICKUP))
+
+/**
+ * Tuck our object into bed.
+ *
+ * tucked - the object being tucked
+ * target_bed - the bed we're tucking them into
+ * tucker - the guy doing the tucking
+ */
+/datum/element/bed_tuckable/proc/tuck_into_bed(obj/item/tucked, obj/structure/bed/target_bed, mob/living/tucker)
+
+
+	if(!istype(target_bed))
+		return
+
+	if(!tucker.transferItemToLoc(tucked, target_bed.drop_location()))
+		return
+
+	to_chat(tucker, "<span class='notice'>You lay [tucked] out on [target_bed].</span>")
+	tucked.pixel_x = x_offset
+	tucked.pixel_y = y_offset
+	if(rotation_degree)
+		tucked.transform = turn(tucked.transform, rotation_degree)
+		RegisterSignal(tucked, COMSIG_ITEM_PICKUP, .proc/untuck)
+
+	return COMPONENT_NO_AFTERATTACK
+
+/**
+ * If we rotate our object, then we need to un-rotate it when it's picked up
+ *
+ * tucked - the object that is tucked
+ */
+/datum/element/bed_tuckable/proc/untuck(obj/item/tucked)
+
+
+	tucked.transform = turn(tucked.transform, -rotation_degree)
+	UnregisterSignal(tucked, COMSIG_ITEM_PICKUP)

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -17,6 +17,7 @@
 /obj/item/paicard/Initialize()
 	SSpai.pai_card_list += src
 	add_overlay("pai-off")
+	AddElement(/datum/element/bed_tuckable, 6, -5, 90)
 	return ..()
 
 /obj/item/paicard/Destroy()

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -34,6 +34,7 @@
 /obj/item/toy/plush/Initialize()
 	. = ..()
 	AddComponent(/datum/component/squeak, squeak_override)
+	AddElement(/datum/element/bed_tuckable, 6, -5, 90)
 
 	//have we decided if Pinocchio goes in the blue or pink aisle yet?
 	if(gender == NEUTER)

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -40,6 +40,16 @@
 	if(istype(W, /obj/item/wrench) && !(flags_1&NODECONSTRUCT_1))
 		W.play_tool_sound(src)
 		deconstruct(TRUE)
+	else if(istype(W, /obj/item/bedsheet))
+		if(user.transferItemToLoc(W, drop_location()))
+			to_chat(user, "<span class='notice'>You make \the [src] with [W].</span>")
+			W.pixel_x = 0
+			W.pixel_y = 0
+	else if(istype(W, /obj/item/disk/nuclear))
+		if(user.transferItemToLoc(W, drop_location()))
+			to_chat(user, "<span class='notice'>You tuck little disky into bed. Good night disky.</span>")
+			W.pixel_x = 6 //make sure they reach the pillow
+			W.pixel_y = -6
 	else
 		return ..()
 

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -22,6 +22,10 @@ LINEN BINS
 	dog_fashion = /datum/dog_fashion/head/ghost
 	var/list/dream_messages = list("white")
 
+/obj/item/bedsheet/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/bed_tuckable, 0, 0, 0)
+
 /obj/item/bedsheet/attack(mob/living/M, mob/user)
 	if(!attempt_initiate_surgery(src, M, user))
 		..()

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -623,6 +623,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 	var/fake = FALSE
 	var/turf/lastlocation
 	var/last_disk_move
+	var/process_tick = 0
 
 /obj/item/disk/nuclear/Initialize()
 	. = ..()
@@ -638,6 +639,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 	AddComponent(/datum/component/stationloving, !fake)
 
 /obj/item/disk/nuclear/process()
+	++process_tick
 	if(fake)
 		STOP_PROCESSING(SSobj, src)
 		CRASH("A fake nuke disk tried to call process(). Who the fuck and how the fuck")
@@ -654,7 +656,8 @@ This is here to make the tiles around the station mininuke change when it's arme
 				disk_comfort_level++
 
 		if(disk_comfort_level >= 2) //Sleep tight, disky.
-			visible_message("<span class='notice'>[src] sleeps soundly. Sleep tight, disky.</span>")
+			if(process_tick % 30)
+				visible_message("<span class='notice'>[src] sleeps soundly. Sleep tight, disky.</span>")
 		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.0001))
 			var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
 			if(istype(loneop))

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -639,7 +639,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 	AddComponent(/datum/component/stationloving, !fake)
 
 /obj/item/disk/nuclear/process()
-	++process_tick
+	process_tick++
 	if(fake)
 		STOP_PROCESSING(SSobj, src)
 		CRASH("A fake nuke disk tried to call process(). Who the fuck and how the fuck")
@@ -656,7 +656,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 				disk_comfort_level++
 
 		if(disk_comfort_level >= 2) //Sleep tight, disky.
-			if(process_tick % 30)
+			if(!(process_tick % 30))
 				visible_message("<span class='notice'>[src] sleeps soundly. Sleep tight, disky.</span>")
 		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.0001))
 			var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -626,6 +626,8 @@ This is here to make the tiles around the station mininuke change when it's arme
 
 /obj/item/disk/nuclear/Initialize()
 	. = ..()
+	AddElement(/datum/element/bed_tuckable, 6, -6, 0)
+
 	if(!fake)
 		GLOB.poi_list |= src
 		last_disk_move = world.time
@@ -640,7 +642,19 @@ This is here to make the tiles around the station mininuke change when it's arme
 		STOP_PROCESSING(SSobj, src)
 		CRASH("A fake nuke disk tried to call process(). Who the fuck and how the fuck")
 	var/turf/newturf = get_turf(src)
+
 	if(newturf && lastlocation == newturf)
+
+	// How comfy is disky?
+		var/disk_comfort_level = 0
+
+		// Checking for items that make disky comfy
+		for(var/obj/comfort_item in loc)
+			if(istype(comfort_item, /obj/item/bedsheet) || istype(comfort_item, /obj/structure/bed))
+				disk_comfort_level++
+
+		if(disk_comfort_level >= 2) //Sleep tight, disky.
+			visible_message("<span class='notice'>[src] sleeps soundly. Sleep tight, disky.</span>")
 		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.0001))
 			var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
 			if(istype(loneop))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -463,6 +463,7 @@
 #include "code\datums\diseases\advance\symptoms\weight.dm"
 #include "code\datums\diseases\advance\symptoms\youth.dm"
 #include "code\datums\elements\_element.dm"
+#include "code\datums\elements\bed_tucking.dm"
 #include "code\datums\elements\cleaning.dm"
 #include "code\datums\elements\earhealing.dm"
 #include "code\datums\elements\flavor_text.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

We all know this.

Disks can be tired too, and deserve to be treated well.

Ports:
https://github.com/Citadel-Station-13/Citadel-Station-13/pull/13965
And subsequent fixes.


From:
https://github.com/tgstation/tgstation/pull/55940


![image](https://user-images.githubusercontent.com/16510935/103530288-5f630680-4e44-11eb-9ad4-13b503043ef3.gif)

```
Adds an element, the tuckable element. Objects with this element can be tucked into bed by hitting a bed with it.

You can now make beds by hitting them with a blanket.
You can now tuck plushes into bed.
You can now tuck the disk into bed, too.
```
![image](https://user-images.githubusercontent.com/53913550/119252160-0ab8f180-bb81-11eb-904a-a61870343135.png)
![image](https://user-images.githubusercontent.com/53913550/119252526-33da8180-bb83-11eb-8746-36dc8ca39001.png)

## Why It's Good For The Game

Disky has been on watch for almost two decades, and no one has allowed them to rest. Sleep tight, disky.

You can tuck various things into bed for that immersion.

## Changelog
🆑
add: You can now tuck disky into bed
add: You can now make beds by applying a bed sheet to them
add: You can now tuck in pai cards into bed
add: Added bed tucking element, can be added to any held object to allow tucking into beds
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
