### PR TITLE
Makes Stargazers work on Layenia too

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -35,6 +35,8 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 
 #define isspaceturf(A) (istype(A, /turf/open/space))
 
+#define iscloudturf(A) (istype(A, /turf/open/chasm/cloud))
+
 #define isfloorturf(A) (istype(A, /turf/open/floor))
 
 #define isclosedturf(A) (istype(A, /turf/closed))

--- a/code/modules/antagonists/clockcult/clock_structures/stargazer.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/stargazer.dm
@@ -47,7 +47,7 @@
 		has_starlight = FALSE
 	else
 		for(var/turf/T in view(3, src))
-			if(isspaceturf(T))
+			if(isspaceturf(T) || iscloudturf(T))
 				has_starlight = TRUE
 				break
 	if(has_starlight && anchored)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A simple fix for a simple problem.

## Why It's Good For The Game

Clockie Ts weren't being able to get enough power to kickstart their operations.

## Changelog
:cl:
tweak: Stargazers can also gaze at the stars through the clouds of Layenia.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
