### PR TITLE
Midround antag Fixes / Autotrator Fixes

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -250,7 +250,7 @@
 		if(issilicon(player)) // Your assigned role doesn't change when you are turned into a silicon.
 			living_players -= player
 			continue
-		if(player.client && player.client.prefs.allow_midround_antag)
+		if(player.client && player.client.prefs.allow_midround_antag == 0)
 			living_players -= player
 			continue
 		if(is_centcom_level(player.z))

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -259,6 +259,9 @@
 		if(is_centcom_level(player.z))
 			living_players -= player // We don't autotator people in CentCom
 			continue
+		if(is_away_level(player.z))
+			living_players -= player //We also don't autotator people in exiled roles / VR
+			continue
 		if(player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0))
 			living_players -= player // We don't autotator people with roles already
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -250,6 +250,9 @@
 		if(issilicon(player)) // Your assigned role doesn't change when you are turned into a silicon.
 			living_players -= player
 			continue
+		if(player.client && player.client.prefs.allow_midround_antag)
+			living_players -= player
+			continue
 		if(is_centcom_level(player.z))
 			living_players -= player // We don't autotator people in CentCom
 			continue

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -247,10 +247,13 @@
 /datum/dynamic_ruleset/midround/autotraitor/trim_candidates()
 	..()
 	for(var/mob/living/player in living_players)
+		if(player.client == null) //Make sure the player has an attached client, otherwise, trim.
+			living_players -= player
+			continue
 		if(issilicon(player)) // Your assigned role doesn't change when you are turned into a silicon.
 			living_players -= player
 			continue
-		if(player.client && player.client.prefs.allow_midround_antag == 0)
+		if(player.client.prefs.allow_midround_antag == 0) //Do they have midround traitor prefs enabled? If not, trim.
 			living_players -= player
 			continue
 		if(is_centcom_level(player.z))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Logically, this should make it so people who have their midround settings set to false will not get autotraitor'd in the middle of the round.

I've not been able to fully test it, however, still, I stole this from default midround. It simply checks if the player has an attached client and if it allows midrounds, technically killing two birds with one stone by also eliminating the problem of AFK people getting midround. Also adds a check to verify if people are in away mission levels.

This was apparently broken as this preference was never checked.

## Why It's Good For The Game

Sometimes you don't wanna get T out of nowhere.

## Changelog
:cl:
fix(?): midround autotraitor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
