### PR TITLE
Excludes Ghost Roles from certain Health Events + Autotraitor Fix Package Pt2

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -142,6 +142,7 @@
 #define TRAIT_NORUNNING			"norunning"		// You walk!
 #define TRAIT_NOMARROW			"nomarrow"		// You don't make blood, with chemicals or nanites.
 #define TRAIT_NOPULSE			"nopulse"		// Your heart doesn't beat.
+#define TRAIT_EXEMPT_HEALTH_EVENTS	"exempt-health-events"
 
  //non-mob traits
 #define TRAIT_PARALYSIS			"paralysis" //Used for limb-based paralysis, where replacing the limb will fix it
@@ -220,6 +221,7 @@
 #define ABSTRACT_ITEM_TRAIT "abstract-item"
 #define STATUS_EFFECT_TRAIT "status-effect"
 #define ROUNDSTART_TRAIT "roundstart" //cannot be removed without admin intervention
+#define GHOSTROLE_TRAIT "ghostrole"
 
 // unique trait sources, still defines
 #define STATUE_MUTE "statue"

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -259,11 +259,13 @@
 		if(is_centcom_level(player.z))
 			living_players -= player // We don't autotator people in CentCom
 			continue
-		if(is_away_level(player.z))
-			living_players -= player //We also don't autotator people in exiled roles / VR
-			continue
 		if(player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0))
 			living_players -= player // We don't autotator people with roles already
+			continue
+		if(ishuman(player))
+			var/mob/living/carbon/human/H = player
+			if(HAS_TRAIT(H,GHOSTROLE_TRAIT))
+				living_players -= player //We also don't fucking give ghost roles traitor
 
 /datum/dynamic_ruleset/midround/autotraitor/ready(forced = FALSE)
 	if (required_candidates > living_players.len)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -264,8 +264,8 @@
 			continue
 		if(ishuman(player))
 			var/mob/living/carbon/human/H = player
-			if(HAS_TRAIT(H,GHOSTROLE_TRAIT))
-				living_players -= player //We also don't fucking give ghost roles traitor
+			if(HAS_TRAIT(H,TRAIT_EXEMPT_HEALTH_EVENTS))
+				living_players -= player //We also don't fucking give ghost roles traitor. Yes I'm using the exempt health events trait given to ghost roles to do this, because piggyback ftw.
 
 /datum/dynamic_ruleset/midround/autotraitor/ready(forced = FALSE)
 	if (required_candidates > living_players.len)

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -32,6 +32,8 @@
 	new/obj/structure/fluff/empty_terrarium(get_turf(src))
 	return ..()
 
+/obj/effect/mob_spawn/human/seed_vault/special(mob/living/carbon/human/new_spawn)
+	ADD_TRAIT(new_spawn,TRAIT_EXEMPT_HEALTH_EVENTS,GHOSTROLE_TRAIT)
 //Ash walker eggs: Spawns in ash walker dens in lavaland. Ghosts become unbreathing lizards that worship the Necropolis and are advised to retrieve corpses to create more ash walkers.
 
 /obj/effect/mob_spawn/human/ash_walker
@@ -262,6 +264,9 @@
 	new/obj/structure/fluff/empty_cryostasis_sleeper(get_turf(src))
 	return ..()
 
+/obj/effect/mob_spawn/human/hermit/special(mob/living/carbon/human/new_spawn)
+	ADD_TRAIT(new_spawn,TRAIT_EXEMPT_HEALTH_EVENTS,GHOSTROLE_TRAIT)
+
 //Broken rejuvenation pod: Spawns in animal hospitals in lavaland. Ghosts become disoriented interns and are advised to search for help.
 /obj/effect/mob_spawn/human/doctor/alive/lavaland
 	name = "broken rejuvenation pod"
@@ -370,6 +375,9 @@
 /obj/effect/mob_spawn/human/hotel_staff/Destroy()
 	new/obj/structure/fluff/empty_sleeper/syndicate(get_turf(src))
 	..()
+
+/obj/effect/mob_spawn/human/hotel_staff/special(mob/living/carbon/human/new_spawn)
+	ADD_TRAIT(new_spawn,TRAIT_EXEMPT_HEALTH_EVENTS,GHOSTROLE_TRAIT)
 
 /obj/effect/mob_spawn/human/demonic_friend
 	name = "Essence of friendship"

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -37,6 +37,8 @@
 			continue
 		if(!H.client)
 			continue
+		if(HAS_TRAIT(H,TRAIT_EXEMPT_HEALTH_EVENTS))
+			continue
 		if(H.stat == DEAD)
 			continue
 		if(HAS_TRAIT(H, TRAIT_VIRUSIMMUNE)) //Don't pick someone who's virus immune, only for it to not do anything.

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -8,7 +8,7 @@
 /datum/round_event/heart_attack/start()
 	var/list/heart_attack_contestants = list()
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
-		if(!H.client || H.z != SSmapping.station_start || H.stat == DEAD || H.InCritical() || !H.can_heartattack() || H.has_status_effect(STATUS_EFFECT_EXERCISED) || (/datum/disease/heart_failure in H.diseases) || H.undergoing_cardiac_arrest())
+		if(!H.client || H.z != SSmapping.station_start || H.stat == DEAD || H.InCritical() || !H.can_heartattack() || H.has_status_effect(STATUS_EFFECT_EXERCISED) || (/datum/disease/heart_failure in H.diseases) || H.undergoing_cardiac_arrest() || HAS_TRAIT(H,TRAIT_EXEMPT_HEALTH_EVENTS))
 			continue
 		if(H.satiety <= -60) //Multiple junk food items recently
 			heart_attack_contestants[H] = 3

--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -35,4 +35,6 @@
 												/datum/hallucination/delusion,
 												/datum/hallucination/oh_yeah)
 			for(var/mob/living/carbon/C in GLOB.alive_mob_list)
+				if(HAS_TRAIT(C,TRAIT_EXEMPT_HEALTH_EVENTS))
+					continue
 				new picked_hallucination(C, TRUE)

--- a/code/modules/events/spontaneous_appendicitis.dm
+++ b/code/modules/events/spontaneous_appendicitis.dm
@@ -17,6 +17,8 @@
 			continue
 		if(H.z != SSmapping.station_start) //Let's not fucking give Appendicitis to ghost roles or people not on station, shall we?
 			continue
+		if(HAS_TRAIT(H,TRAIT_EXEMPT_HEALTH_EVENTS)) //Do they have the trait that makes them exempt from health conditions?
+			continue
 		if(!H.getorgan(/obj/item/organ/appendix)) //Don't give the disease to some who lacks it, only for it to be auto-cured
 			continue
 		if(!(MOB_ORGANIC & H.mob_biotypes)) //biotype sleeper bugs strike again, once again making appendicitis pick a target that can't take it

--- a/hyperstation/code/game/objects/structures/ghost_role_spawners.dm
+++ b/hyperstation/code/game/objects/structures/ghost_role_spawners.dm
@@ -47,6 +47,9 @@
 	new/obj/structure/fluff/empty_cryostasis_sleeper(get_turf(src))
 	return ..()
 
+/obj/effect/mob_spawn/human/duohermit/special(mob/living/carbon/human/new_spawn)
+	ADD_TRAIT(new_spawn,TRAIT_EXEMPT_HEALTH_EVENTS,GHOSTROLE_TRAIT)
+
 //Exiles: Stranded exiles that have been left in Snowdin. Can be easily adapted for other roles as well.
 /obj/effect/mob_spawn/human/exiled
 	name = "used bed"
@@ -105,3 +108,6 @@
 /obj/effect/mob_spawn/human/exiled/Destroy()
 	new/obj/structure/bed(get_turf(src))
 	return ..()
+
+/obj/effect/mob_spawn/human/exiled/special(mob/living/carbon/human/new_spawn)
+	ADD_TRAIT(new_spawn,TRAIT_EXEMPT_HEALTH_EVENTS,GHOSTROLE_TRAIT)

--- a/hyperstation/code/modules/mob/mob_helpers.dm
+++ b/hyperstation/code/modules/mob/mob_helpers.dm
@@ -18,7 +18,7 @@ mob/proc/checkloadappearance()
 					idCard.update_label(H.real_name, idCard.assignment)
 					idCard.registered_name = H.real_name
 				H.mirrorcanloadappearance = FALSE //Prevents them from using the mirror again.
-				ADD_TRAIT(H,TRAIT_EXEMPT_HEALTH_EVENTS,GHOSTROLE_TRAIT) //Makes them exempt from health events and adds gives them the ghostrole trait. This is a special tool we'll use later.
+				ADD_TRAIT(H,TRAIT_EXEMPT_HEALTH_EVENTS,GHOSTROLE_TRAIT) //Makes sure they are exempt from health events.
 				SEND_SOUND(H, 'sound/magic/charge.ogg') //Fluff
 				to_chat(H, "<span class='boldannounce'>Your head aches for a second. You feel like this is how things should have been.</span>")
 				log_game("[key_name(H)] has loaded their default appearance for a ghost role.")

--- a/hyperstation/code/modules/mob/mob_helpers.dm
+++ b/hyperstation/code/modules/mob/mob_helpers.dm
@@ -18,6 +18,7 @@ mob/proc/checkloadappearance()
 					idCard.update_label(H.real_name, idCard.assignment)
 					idCard.registered_name = H.real_name
 				H.mirrorcanloadappearance = FALSE //Prevents them from using the mirror again.
+				ADD_TRAIT(H,TRAIT_EXEMPT_HEALTH_EVENTS,GHOSTROLE_TRAIT) //Makes them exempt from health events and adds gives them the ghostrole trait. This is a special tool we'll use later.
 				SEND_SOUND(H, 'sound/magic/charge.ogg') //Fluff
 				to_chat(H, "<span class='boldannounce'>Your head aches for a second. You feel like this is how things should have been.</span>")
 				log_game("[key_name(H)] has loaded their default appearance for a ghost role.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Pulls https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10320

And piggybacking on the ghost role trait, this should also prevent ghost roles from getting autotraitor, something which was also happening fairly often.

## Why It's Good For The Game

Fixes, fixes...

## Changelog
🆑
fix: fixes some ghost roles from dying of stupid shit
fix(?): ghost roles getting traitor
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
