### PR TITLE
Something about taming vending machines

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -374,14 +374,14 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 						// the new paraplegic gets like 4 lines of losing their legs so skip them
 						visible_message("<span class='danger'>[C]'s spinal cord is obliterated with a sickening crunch!</span>", ignored_mobs = list(C))
 						C.gain_trauma(/datum/brain_trauma/severe/paralysis/paraplegic)
-					if(5) // skull squish!
+					if(5) // dismember head
 						var/obj/item/bodypart/head/O = C.get_bodypart(BODY_ZONE_HEAD)
 						if(O)
 							C.visible_message("<span class='danger'>[O] explodes in a shower of gore beneath [src]!</span>", \
 								"<span class='userdanger'>Oh f-</span>")
 							O.dismember()
-							O.drop_organs()
-							//qdel(O) Deleting people's heads makes them angy
+							/*O.drop_organs()
+							qdel(O) Deleting people's heads makes them angy*/
 							new /obj/effect/gibspawner/human/bodypartless(get_turf(C))
 				C.apply_damage(max(0, squish_damage - crit_rebate), BRUTE)
 				C.AddElement(/datum/element/squish, 60 SECONDS)

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -258,7 +258,6 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 		wires.interact(user)
 		return
 
-
 	else if(istype(I, /obj/item/stack/credits))
 		var/obj/item/stack/credits/cred = I
 		to_chat(usr, "<span class='notice'>You insert [cred] into [src].</span>")
@@ -266,38 +265,13 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 		src.ui_interact(usr)
 		del(cred)
 
-	/* we dont use this currency anymore!
 	else if(istype(I, /obj/item/coin))
-		if(coin)
-			to_chat(user, "<span class='warning'>[src] already has [coin] inserted</span>")
-			return
-		if(bill)
-			to_chat(user, "<span class='warning'>[src] already has [bill] inserted</span>")
-			return
-		if(!premium.len)
-			to_chat(user, "<span class='warning'>[src] doesn't have a coin slot.</span>")
-			return
-		if(!user.transferItemToLoc(I, src))
-			return
-		coin = I
-		to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
+		to_chat(user, "<span class='notice'>[src] doesn't seem to accept this kind of currency anymore.</span>")
 		return
 	else if(istype(I, /obj/item/stack/spacecash))
-		if(coin)
-			to_chat(user, "<span class='warning'>[src] already has [coin] inserted</span>")
-			return
-		if(bill)
-			to_chat(user, "<span class='warning'>[src] already has [bill] inserted</span>")
-			return
-		var/obj/item/stack/S = I
-		if(!premium.len)
-			to_chat(user, "<span class='warning'>[src] doesn't have a bill slot.</span>")
-			return
-		S.use(1)
-		bill = new S.type(src, 1)
-		to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
+		to_chat(user, "<span class='notice'>[src] doesn't seem to accept this kind of currency anymore.</span>")
 		return
-	*/
+
 	else if(refill_canister && istype(I, refill_canister))
 		if (!panel_open)
 			to_chat(user, "<span class='notice'>You should probably unscrew the service panel first.</span>")
@@ -318,7 +292,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 			return
 	else
 		. = ..()
-		if(tiltable && !tilted && I.force)
+		if(tiltable && !tilted && I.force && user.a_intent != INTENT_HELP) //Now we roll the dice. Thrown items do not trigger this, btw.
 			switch(rand(1, 100))
 				if(1 to 5)
 					freebie(user, 3)

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -381,7 +381,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 								"<span class='userdanger'>Oh f-</span>")
 							O.dismember()
 							O.drop_organs()
-							qdel(O)
+							//qdel(O) Deleting people's heads makes them angy
 							new /obj/effect/gibspawner/human/bodypartless(get_turf(C))
 				C.apply_damage(max(0, squish_damage - crit_rebate), BRUTE)
 				C.AddElement(/datum/element/squish, 60 SECONDS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so the user must be in anything other than help intent to actually try and tilt the vending machine and also gives the user feedback for trying to put spacecash and coins in.
Also makes them a little more tame on the double crit failure punishment

## Why It's Good For The Game

Coins not being accepted would trigger the tilt, which is bad.

## Changelog
:cl:
tweak: Vending machine feedback
tweak: Vending machines can only be tilted while in harm intent
tweak: Vending machines can no longer squish your brains out but will still dismember you if you get two critical failures.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
