### PR TITLE
Fixes sludge spawning underneath structures / Sludge minor nerf

### DIFF
--- a/hyperstation/code/modules/power/reactor/rbmk.dm
+++ b/hyperstation/code/modules/power/reactor/rbmk.dm
@@ -882,6 +882,9 @@ The reactor CHEWS through moderator. It does not do this slowly. Be very careful
 
 /obj/effect/decal/nuclear_waste/Initialize()
 	. = ..()
+	for(var/obj/A in get_turf(src))
+		if(istype(A, /obj/structure))
+			qdel(src) //It is more processing efficient to do this here rather than when searching for available turfs.
 	set_light(3)
 	AddComponent(/datum/component/radioactive, 250, src, 0)
 

--- a/hyperstation/code/modules/power/reactor/rbmk.dm
+++ b/hyperstation/code/modules/power/reactor/rbmk.dm
@@ -883,7 +883,7 @@ The reactor CHEWS through moderator. It does not do this slowly. Be very careful
 /obj/effect/decal/nuclear_waste/Initialize()
 	. = ..()
 	set_light(3)
-	AddComponent(/datum/component/radioactive, 1500, src, 0)
+	AddComponent(/datum/component/radioactive, 250, src, 0)
 
 /obj/effect/decal/nuclear_waste/epicenter //The one that actually does the irradiating. This is to avoid every bit of sludge PROCESSING
 	name = "Dense nuclear sludge"

--- a/hyperstation/code/modules/power/reactor/rbmk.dm
+++ b/hyperstation/code/modules/power/reactor/rbmk.dm
@@ -886,7 +886,7 @@ The reactor CHEWS through moderator. It does not do this slowly. Be very careful
 		if(istype(A, /obj/structure))
 			qdel(src) //It is more processing efficient to do this here rather than when searching for available turfs.
 	set_light(3)
-	AddComponent(/datum/component/radioactive, 250, src, 0)
+	AddComponent(/datum/component/radioactive, 1000, src, 0)
 
 /obj/effect/decal/nuclear_waste/epicenter //The one that actually does the irradiating. This is to avoid every bit of sludge PROCESSING
 	name = "Dense nuclear sludge"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nerfing plutonium sludge rads a bit.
Also fixes sludge spawning underneath windows/structures

## Why It's Good For The Game

Until proven otherwise, better to use lower values.

## Changelog
:cl:
tweak: plutonium sludge radiation value
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
