### PR TITLE
Dynamic Nonvoter Factor

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -1,5 +1,6 @@
 #define DYNAMIC_DEFAULT_CHAOS       1.0 //The default chaos value for low pop low vote rounds
 #define DYNAMIC_VOTE_NORMALIZATION  5   //If there are fewer than this many votes, the average will be skewed towards the default
+#define DYNAMIC_NONVOTER_FACTOR 0.5 // 1 means they count for a full vote
 
 SUBSYSTEM_DEF(vote)
 	name = "Vote"
@@ -155,8 +156,9 @@ SUBSYSTEM_DEF(vote)
 					v += 1
 			else if (voted.len < GLOB.clients.len)	//Have non-voters "vote" 2, if we're not lowpop
 				for(var/I in 1 to (GLOB.clients.len - voted.len))
-					v += 1
+					v += DYNAMIC_NONVOTER_FACTOR //Instead of a fixed value, this will now factor how much non-voter votes are 'worth' in the system.
 					numbers += 2
+				v = round(v) //This rounds the value to the nearest multiple, to make sure no calculations go fucky wucky.
 			var/total = 0
 			for (var/i in numbers)
 				total += i


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes nonvoter votes count for half the value of a voter value. This is exclusive to high pop rounds. This value can be customized to be anything one would desire to refine it to, such as 1, (full vote) 0.75, 0.5 0.33, 0.25 and so on.

## Why It's Good For The Game

Me and Jay talked about this, Megavolt also agreed that the current state of non-voters in dynamic makes the station stuck in an almost perpetual 2 Chaos, where the people that vote for low chaos rarely ever get a round with chaos lower than 2 and the people that want higher chaos don't get anything above 2, generally seemingly making people upset.

I feel that this variable could be worked with so we can achieve a more dynamic system.

## Changelog
:cl:
tweak: dynamic nonvoter factor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
