### PR TITLE
Apathy Minor Revamp / Death moodlet tweak

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -194,6 +194,7 @@
 #define TRAIT_VIRILE		"virile" //you have 20% more chance of impreg
 #define TRAIT_MACROPHILE		"macrophile" //likes the big
 #define TRAIT_MICROPHILE		"microphile" //likes the small
+#define TRAIT_APATHETIC			"apathetic" //doesn't care
 
 #define TRAIT_TOUGH		"tough" //you have 10% more maxhealth
 #define TRAIT_AUTO_CATCH_ITEM	"auto_catch_item"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -16,6 +16,7 @@
 	desc = "You just don't care as much as other people. That's nice to have in a place like this, I guess."
 	value = 1
 	category = CATEGORY_MOODS
+	mob_trait = TRAIT_APATHETIC
 	mood_quirk = TRUE
 	medical_record_text = "Patient was administered the Apathy Evaluation Scale but did not bother to complete it."
 

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -19,12 +19,6 @@
 	if(SSticker.mode)
 		SSticker.mode.check_win() //Calls the rounds wincheck, mainly for wizard, malf, and changeling now
 
-	//watching someone die is traumatic
-	for(var/mob/living/carbon/human/H in oview(5, src))
-		SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "death", /datum/mood_event/deathsaw)
-		if(prob(10)) //10% chance to pump adrenaline into their body
-			H.jitteriness += 5
-
 /mob/living/carbon/gib(no_brain, no_organs, no_bodyparts)
 	var/atom/Tsec = drop_location()
 	for(var/mob/M in src)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -52,6 +52,13 @@
 	if(is_devil(src))
 		INVOKE_ASYNC(is_devil(src), /datum/antagonist/devil.proc/beginResurrectionCheck, src)
 
+	//watching someone die is traumatic
+	for(var/mob/living/carbon/human/H in oview(5, src))
+		if(!HAS_TRAIT(H, TRAIT_APATHETIC))
+			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "death", /datum/mood_event/deathsaw)
+			if(prob(10)) //10% chance to pump adrenaline into their body
+				H.jitteriness += 5
+
 /mob/living/carbon/human/proc/makeSkeleton()
 	ADD_TRAIT(src, TRAIT_DISFIGURED, TRAIT_GENERIC)
 	set_species(/datum/species/skeleton)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -54,10 +54,11 @@
 
 	//watching someone die is traumatic
 	for(var/mob/living/carbon/human/C in oview(5, src))
-		if(!HAS_TRAIT(C, TRAIT_APATHETIC))
-			SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "death", /datum/mood_event/deathsaw)
-			if(prob(10)) //10% chance to pump adrenaline into their body
-				C.jitteriness += 5
+		if(C.mind) //We don't need to give this to anything that doesn't have a mind. That's wasted processing.
+			if(!HAS_TRAIT(C, TRAIT_APATHETIC) || !C.mind.assigned_role == "Medical Doctor") //Shamelessly stolen from the Doctor's Delight
+				SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "death", /datum/mood_event/deathsaw)
+				if(prob(10)) //10% chance to pump adrenaline into their body
+					C.jitteriness += 5
 
 /mob/living/carbon/human/proc/makeSkeleton()
 	ADD_TRAIT(src, TRAIT_DISFIGURED, TRAIT_GENERIC)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -53,11 +53,11 @@
 		INVOKE_ASYNC(is_devil(src), /datum/antagonist/devil.proc/beginResurrectionCheck, src)
 
 	//watching someone die is traumatic
-	for(var/mob/living/carbon/human/H in oview(5, src))
-		if(!HAS_TRAIT(H, TRAIT_APATHETIC))
-			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "death", /datum/mood_event/deathsaw)
+	for(var/mob/living/carbon/human/C in oview(5, src))
+		if(!HAS_TRAIT(C, TRAIT_APATHETIC))
+			SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "death", /datum/mood_event/deathsaw)
 			if(prob(10)) //10% chance to pump adrenaline into their body
-				H.jitteriness += 5
+				C.jitteriness += 5
 
 /mob/living/carbon/human/proc/makeSkeleton()
 	ADD_TRAIT(src, TRAIT_DISFIGURED, TRAIT_GENERIC)

--- a/hyperstation/code/datums/mood_events/events.dm
+++ b/hyperstation/code/datums/mood_events/events.dm
@@ -16,7 +16,7 @@
 /datum/mood_event/deathsaw
 	description = "<span class='boldwarning'>I saw someone die!</span>\n"
 	mood_change = -5
-	timeout = 20 MINUTES //20 minutes is too much, medical is moving around sluggishly because of this constantly.
+	timeout = 20 MINUTES //May be fine tuned in the future.
 
 /datum/mood_event/healsbadman
 	description = "<span class='warning'>I feel like I'm held together by flimsy string, and could fall apart at any moment!</span>\n"

--- a/hyperstation/code/datums/mood_events/events.dm
+++ b/hyperstation/code/datums/mood_events/events.dm
@@ -15,8 +15,8 @@
 
 /datum/mood_event/deathsaw
 	description = "<span class='boldwarning'>I saw someone die!</span>\n"
-	mood_change = -8
-	timeout = 20 MINUTES //takes a long time to get over
+	mood_change = -5
+	timeout = 3 MINUTES //20 minutes is too much, medical is moving around sluggishly because of this constantly.
 
 /datum/mood_event/healsbadman
 	description = "<span class='warning'>I feel like I'm held together by flimsy string, and could fall apart at any moment!</span>\n"

--- a/hyperstation/code/datums/mood_events/events.dm
+++ b/hyperstation/code/datums/mood_events/events.dm
@@ -16,7 +16,7 @@
 /datum/mood_event/deathsaw
 	description = "<span class='boldwarning'>I saw someone die!</span>\n"
 	mood_change = -5
-	timeout = 3 MINUTES //20 minutes is too much, medical is moving around sluggishly because of this constantly.
+	timeout = 10 MINUTES //20 minutes is too much, medical is moving around sluggishly because of this constantly.
 
 /datum/mood_event/healsbadman
 	description = "<span class='warning'>I feel like I'm held together by flimsy string, and could fall apart at any moment!</span>\n"

--- a/hyperstation/code/datums/mood_events/events.dm
+++ b/hyperstation/code/datums/mood_events/events.dm
@@ -16,7 +16,7 @@
 /datum/mood_event/deathsaw
 	description = "<span class='boldwarning'>I saw someone die!</span>\n"
 	mood_change = -5
-	timeout = 10 MINUTES //20 minutes is too much, medical is moving around sluggishly because of this constantly.
+	timeout = 20 MINUTES //20 minutes is too much, medical is moving around sluggishly because of this constantly.
 
 /datum/mood_event/healsbadman
 	description = "<span class='warning'>I feel like I'm held together by flimsy string, and could fall apart at any moment!</span>\n"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Killing anything that was a carbon in the game (including monkeys, xenos, and anything else that was a carbon was causing 20 minutes of the seeing someone die negative moodlet. This is especially bad for people that work in xenobio/medical.

This makes it so apathy will prevent one from getting that negative moodlet and also nerfs that moodlet's negative values and overall impact in the game and makes it so only human carbons dying will trigger the moodlet.

It also makes it so medical isn't affected by it. (Requires further testing)

## Why It's Good For The Game

20 minutes was way too much, -8 is way too much especially in scenarios where people are dying left and right and medical needs to act quickly whilst not being hamstringed by a -8 debuff.

## Changelog
:cl:
fix: Seeing anything that's not a human die will no longer trigger a mood debuff
add: Apathy now prevents you from getting the deathsaw negative moodlet
tweak: Seeing someone die no longer kills your movement for 20 minutes. This was especially harmful for medical personnel in busy rounds.
add: Medical doctors are no longer affected by seeing a human's death.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
