### PR TITLE
Fleshlight condomed use impreg fix

### DIFF
--- a/hyperstation/code/obj/fleshlight.dm
+++ b/hyperstation/code/obj/fleshlight.dm
@@ -166,7 +166,12 @@
 			M.do_jitter_animation() //make your partner shake too!
 			if (C.getArousalLoss() >= 100 && ishuman(C) && C.has_dna())
 				var/mob/living/carbon/human/O = C
-				O.mob_climax_partner(P, M, FALSE, TRUE, FALSE, TRUE) //climax with their partner remotely, and impreg because people keep asking!
+
+				if( (P.condom == 1) || (P.sounding == 1))  //If coundomed and/or sounded, do not fire impreg chance
+					O.mob_climax_partner(P, M, FALSE, FALSE, FALSE, TRUE)
+				else                                       //Else, fire impreg chance
+					O.mob_climax_partner(P, M, FALSE, TRUE, FALSE, TRUE) //climax with their partner remotely, and impreg because people keep asking!
+
 		if(option == "Lick")
 			to_chat(M, "<span class='love'>You feel a tongue lick you through the portal against your vagina.</span>")
 			M.adjustArousalLoss(10)


### PR DESCRIPTION
Using a fleshlight with a condom would end up with the partner ending up pregnant.
the code and comments should be crystal clear as to what was changed.

This was lightly tested and appears to work, condomed AND sounding both prevents impreg chance when using a portal fleshlight.

Possibly important reference:
mob_climax_partner(
                                 obj/item/organ/genital/G, 
                                 mob/living/L, 
                                 spillage = TRUE, 
                                 impreg = FALSE,
                                 cover = FALSE,
                                 remote = FALSE, 
                                 mb_time = 30) 