### PR TITLE
Removes Randomness of Seed Vault

### DIFF
--- a/ghost_role_spawners.dm
+++ b/ghost_role_spawners.dm
@@ -1,0 +1,625 @@
+//Objects that spawn ghosts in as a certain role when they click on it, i.e. away mission bartenders.
+
+//Preserved terrarium/seed vault: Spawns in seed vault structures in lavaland. Ghosts become plantpeople and are advised to begin growing plants in the room near them.
+/obj/effect/mob_spawn/human/seed_vault
+	name = "preserved terrarium"
+	desc = "An ancient machine that seems to be used for storing plant matter. The glass is obstructed by a mat of vines."
+	mob_name = "a lifebringer"
+	job_description = "Lifebringer"
+	icon = 'icons/obj/lavaland/spawners.dmi'
+	icon_state = "terrarium"
+	density = TRUE
+	roundstart = FALSE
+	death = FALSE
+	mob_species = /datum/species/pod
+	short_desc = "You are a sentient ecosystem, an example of the mastery over life that your creators possessed."
+	flavour_text = "Your masters, benevolent as they were, created uncounted seed vaults and spread them across \
+	the universe to every planet they could chart. You are in one such seed vault. \
+	Your goal is to cultivate and spread life wherever it will go while waiting for contact from your creators. \
+	Estimated time of last contact: Deployment, 5000 millennia ago."
+	assignedrole = "Lifebringer"
+
+/obj/effect/mob_spawn/human/seed_vault/special(mob/living/new_spawn)
+	var/plant_name = pick("Tomato", "Potato", "Broccoli", "Carrot", "Ambrosia", "Pumpkin", "Ivy", "Kudzu", "Banana", "Moss", "Flower", "Bloom", "Root", "Bark", "Glowshroom", "Petal", "Leaf", \
+	"Venus", "Sprout","Cocoa", "Strawberry", "Citrus", "Oak", "Cactus", "Pepper", "Juniper")
+	new_spawn.fully_replace_character_name(null,plant_name)
+	if(ishuman(new_spawn))
+		var/mob/living/carbon/human/H = new_spawn
+		H.underwear = "Nude" //You're a plant, partner
+		H.update_body()
+
+/obj/effect/mob_spawn/human/seed_vault/Destroy()
+	new/obj/structure/fluff/empty_terrarium(get_turf(src))
+	return ..()
+
+//Ash walker eggs: Spawns in ash walker dens in lavaland. Ghosts become unbreathing lizards that worship the Necropolis and are advised to retrieve corpses to create more ash walkers.
+
+/obj/effect/mob_spawn/human/ash_walker
+	name = "ash walker egg"
+	desc = "A man-sized yellow egg, spawned from some unfathomable creature. A humanoid silhouette lurks within."
+	mob_name = "an ash walker"
+	job_description = "Ashwalker"
+	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
+	icon_state = "large_egg"
+	mob_species = /datum/species/lizard/ashwalker
+	outfit = /datum/outfit/ashwalker
+	roundstart = FALSE
+	death = FALSE
+	anchored = FALSE
+	move_resist = MOVE_FORCE_NORMAL
+	density = FALSE
+	short_desc = "You are an ash walker. Your tribe worships the Necropolis."
+	flavour_text = "The wastes are sacred ground, its monsters a blessed bounty. You would never willingly leave your homeland behind. \
+	You have seen lights in the distance... they foreshadow the arrival of outsiders to your domain. However, their intentions have yet to be judged.\
+	Ensure your nest remains protected at all costs."
+	assignedrole = "Ash Walker"
+
+/obj/effect/mob_spawn/human/ash_walker/special(mob/living/new_spawn)
+	new_spawn.real_name = random_unique_lizard_name(gender)
+	to_chat(new_spawn, "<b>Drag the corpses of men and beasts to your nest. It will absorb them to create more of your kind. Glory to the Necropolis!</b>")
+
+	new_spawn.grant_language(/datum/language/draconic)
+	var/datum/language_holder/holder = new_spawn.get_language_holder()
+	holder.selected_default_language = /datum/language/draconic
+
+	if(ishuman(new_spawn))
+		var/mob/living/carbon/human/H = new_spawn
+		H.underwear = "Nude"
+		H.update_body()
+
+/obj/effect/mob_spawn/human/ash_walker/Initialize(mapload)
+	. = ..()
+	var/area/A = get_area(src)
+	if(A)
+		notify_ghosts("An ash walker egg is ready to hatch in \the [A.name].", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_ASHWALKER)
+
+/datum/outfit/ashwalker
+	name ="Ashwalker"
+	head = /obj/item/clothing/head/helmet/gladiator
+	uniform = /obj/item/clothing/under/gladiator/ash_walker
+
+
+//Timeless prisons: Spawns in Wish Granter prisons in lavaland. Ghosts become age-old users of the Wish Granter and are advised to seek repentance for their past.
+/obj/effect/mob_spawn/human/exile
+	name = "timeless prison"
+	desc = "Although this stasis pod looks medicinal, it seems as though it's meant to preserve something for a very long time."
+	mob_name = "a penitent exile"
+	job_description = "Exiled Prisoner"
+	icon = 'icons/obj/machines/sleeper.dmi'
+	icon_state = "sleeper"
+	roundstart = FALSE
+	death = FALSE
+	mob_species = /datum/species/shadow
+	short_desc = "You are cursed."
+	flavour_text = "Years ago, you sacrificed the lives of your trusted friends and the humanity of yourself to reach the Wish Granter. Though you \
+	did so, it has come at a cost: your very body rejects the light, dooming you to wander endlessly in this horrible wasteland."
+	assignedrole = "Exile"
+
+/obj/effect/mob_spawn/human/exile/Destroy()
+	new/obj/structure/fluff/empty_sleeper(get_turf(src))
+	return ..()
+
+/obj/effect/mob_spawn/human/exile/special(mob/living/new_spawn)
+	new_spawn.real_name = "Wish Granter's Victim ([rand(1,999)])"
+	var/wish = rand(1,4)
+	switch(wish)
+		if(1)
+			to_chat(new_spawn, "<b>You wished to kill, and kill you did. You've lost track of how many, but the spark of excitement that murder once held has winked out. You feel only regret.</b>")
+		if(2)
+			to_chat(new_spawn, "<b>You wished for unending wealth, but no amount of money was worth this existence. Maybe charity might redeem your soul?</b>")
+		if(3)
+			to_chat(new_spawn, "<b>You wished for power. Little good it did you, cast out of the light. You are the [gender == MALE ? "king" : "queen"] of a hell that holds no subjects. You feel only remorse.</b>")
+		if(4)
+			to_chat(new_spawn, "<b>You wished for immortality, even as your friends lay dying behind you. No matter how many times you cast yourself into the lava, you awaken in this room again within a few days. There is no escape.</b>")
+
+//Golem shells: Spawns in Free Golem ships in lavaland. Ghosts become mineral golems and are advised to spread personal freedom.
+/obj/effect/mob_spawn/human/golem
+	name = "inert free golem shell"
+	desc = "A humanoid shape, empty, lifeless, and full of potential."
+	mob_name = "a free golem"
+	job_description = "Free Golem"
+	icon = 'icons/obj/wizard.dmi'
+	icon_state = "construct"
+	mob_species = /datum/species/golem
+	roundstart = FALSE
+	death = FALSE
+	anchored = FALSE
+	move_resist = MOVE_FORCE_NORMAL
+	density = FALSE
+	var/has_owner = FALSE
+	var/can_transfer = TRUE //if golems can switch bodies to this new shell
+	var/mob/living/owner = null //golem's owner if it has one
+	short_desc = "You are a Free Golem. Your family worships The Liberator."
+	flavour_text = "In his infinite and divine wisdom, he set your clan free to \
+	travel the stars with a single declaration: \"Yeah go do whatever.\" Though you are bound to the one who created you, it is customary in your society to repeat those same words to newborn \
+	golems, so that no golem may ever be forced to serve again."
+
+/obj/effect/mob_spawn/human/golem/Initialize(mapload, datum/species/golem/species = null, mob/creator = null)
+	if(species) //spawners list uses object name to register so this goes before ..()
+		name += " ([initial(species.prefix)])"
+		mob_species = species
+	. = ..()
+	var/area/A = get_area(src)
+	if(!mapload && A)
+		notify_ghosts("\A [initial(species.prefix)] golem shell has been completed in \the [A.name].", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_GOLEM)
+	if(has_owner && creator)
+		short_desc = "You are a golem."
+		flavour_text = "You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools."
+		important_info = "Serve [creator], and assist [creator.p_them()] in completing [creator.p_their()] goals at any cost."
+		owner = creator
+
+/obj/effect/mob_spawn/human/golem/special(mob/living/new_spawn, name)
+	var/datum/species/golem/X = mob_species
+	to_chat(new_spawn, "[initial(X.info_text)]")
+	if(!owner)
+		to_chat(new_spawn, "Build golem shells in the autolathe, and feed refined mineral sheets to the shells to bring them to life! You are generally a peaceful group unless provoked.")
+	else
+		new_spawn.mind.store_memory("<b>Serve [owner.real_name], your creator.</b>")
+		new_spawn.mind.enslave_mind_to_creator(owner)
+		log_game("[key_name(new_spawn)] possessed a golem shell enslaved to [key_name(owner)].")
+		log_admin("[key_name(new_spawn)] possessed a golem shell enslaved to [key_name(owner)].")
+	if(ishuman(new_spawn))
+		var/mob/living/carbon/human/H = new_spawn
+		if(has_owner)
+			var/datum/species/golem/G = H.dna.species
+			G.owner = owner
+		H.set_cloned_appearance()
+		if(!name)
+			if(has_owner)
+				H.real_name = "[initial(X.prefix)] Golem ([rand(1,999)])"
+			else
+				H.real_name = H.dna.species.random_name()
+		else
+			H.real_name = name
+	if(has_owner)
+		new_spawn.mind.assigned_role = "Servant Golem"
+	else
+		new_spawn.mind.assigned_role = "Free Golem"
+
+/obj/effect/mob_spawn/human/golem/attack_hand(mob/user)
+	. = ..()
+	if(.)
+		return
+	if(isgolem(user) && can_transfer)
+		var/transfer_choice = alert("Transfer your soul to [src]? (Warning, your old body will die!)",,"Yes","No")
+		if(transfer_choice != "Yes")
+			return
+		if(QDELETED(src) || uses <= 0)
+			return
+		log_game("[key_name(user)] golem-swapped into [src]")
+		user.visible_message("<span class='notice'>A faint light leaves [user], moving to [src] and animating it!</span>","<span class='notice'>You leave your old body behind, and transfer into [src]!</span>")
+		show_flavour = FALSE
+		create(ckey = user.ckey,name = user.real_name)
+		user.death()
+		return
+
+/obj/effect/mob_spawn/human/golem/servant
+	has_owner = TRUE
+	name = "inert servant golem shell"
+	job_description = "Servant Golem"
+
+
+/obj/effect/mob_spawn/human/golem/adamantine
+	name = "dust-caked free golem shell"
+	desc = "A humanoid shape, empty, lifeless, and full of potential."
+	mob_name = "a free golem"
+	can_transfer = FALSE
+	mob_species = /datum/species/golem/adamantine
+
+//Malfunctioning cryostasis sleepers: Spawns in makeshift shelters in lavaland. Ghosts become hermits with knowledge of how they got to where they are now.
+/obj/effect/mob_spawn/human/hermit
+	name = "malfunctioning cryostasis sleeper"
+	desc = "A humming sleeper with a silhouetted occupant inside. Its stasis function is broken and it's likely being used as a bed."
+	mob_name = "a stranded hermit"
+	job_description = "Lavaland Hermit"
+	icon = 'icons/obj/lavaland/spawners.dmi'
+	icon_state = "cryostasis_sleeper"
+	roundstart = FALSE
+	death = FALSE
+	random = TRUE
+	mob_species = /datum/species/human
+	short_desc = "You've been stranded in this godless prison of a planet for longer than you can remember."
+	flavour_text = "Each day you barely scrape by, and between the terrible conditions of your makeshift shelter, \
+	the hostile creatures, and the ash drakes swooping down from the cloudless skies, all you can wish for is the feel of soft grass between your toes and \
+	the fresh air of Earth. These thoughts are dispelled by yet another recollection of how you got here... "
+	assignedrole = "Hermit"
+	mirrorcanloadappearance = TRUE
+
+/obj/effect/mob_spawn/human/hermit/Initialize(mapload)
+	. = ..()
+	var/arrpee = rand(1,4)
+	switch(arrpee)
+		if(1)
+			flavour_text += "you were a [pick("arms dealer", "shipwright", "docking manager")]'s assistant on a small trading station several sectors from here. Raiders attacked, and there was \
+			only one pod left when you got to the escape bay. You took it and launched it alone, and the crowd of terrified faces crowding at the airlock door as your pod's engines burst to \
+			life and sent you to this hell are forever branded into your memory."
+			outfit.uniform = /obj/item/clothing/under/assistantformal
+			outfit.shoes = /obj/item/clothing/shoes/sneakers/black
+			outfit.back = /obj/item/storage/backpack
+		if(2)
+			flavour_text += "you're an exile from the Tiger Cooperative. Their technological fanaticism drove you to question the power and beliefs of the Exolitics, and they saw you as a \
+			heretic and subjected you to hours of horrible torture. You were hours away from execution when a high-ranking friend of yours in the Cooperative managed to secure you a pod, \
+			scrambled its destination's coordinates, and launched it. You awoke from stasis when you landed and have been surviving - barely - ever since."
+			outfit.uniform = /obj/item/clothing/under/rank/prisoner
+			outfit.shoes = /obj/item/clothing/shoes/sneakers/orange
+			outfit.back = /obj/item/storage/backpack
+		if(3)
+			flavour_text += "you were a doctor on one of Nanotrasen's space stations, but you left behind that damn corporation's tyranny and everything it stood for. From a metaphorical hell \
+			to a literal one, you find yourself nonetheless missing the recycled air and warm floors of what you left behind... but you'd still rather be here than there."
+			outfit.uniform = /obj/item/clothing/under/rank/medical
+			outfit.suit = /obj/item/clothing/suit/toggle/labcoat
+			outfit.back = /obj/item/storage/backpack/medic
+			outfit.shoes = /obj/item/clothing/shoes/sneakers/black
+		if(4)
+			flavour_text += "you were always joked about by your friends for \"not playing with a full deck\", as they so kindly put it. It seems that they were right when you, on a tour \
+			at one of Nanotrasen's state-of-the-art research facilities, were in one of the escape pods alone and saw the red button. It was big and shiny, and it caught your eye. You pressed \
+			it, and after a terrifying and fast ride for days, you landed here. You've had time to wisen up since then, and you think that your old friends wouldn't be laughing now."
+			outfit.uniform = /obj/item/clothing/under/color/grey/glorf
+			outfit.shoes = /obj/item/clothing/shoes/sneakers/black
+			outfit.back = /obj/item/storage/backpack
+
+/obj/effect/mob_spawn/human/hermit/Destroy()
+	new/obj/structure/fluff/empty_cryostasis_sleeper(get_turf(src))
+	return ..()
+
+//Broken rejuvenation pod: Spawns in animal hospitals in lavaland. Ghosts become disoriented interns and are advised to search for help.
+/obj/effect/mob_spawn/human/doctor/alive/lavaland
+	name = "broken rejuvenation pod"
+	desc = "A small sleeper typically used to instantly restore minor wounds. This one seems broken, and its occupant is comatose."
+	job_description = "Lavaland Veterinarian"
+	mob_name = "a translocated vet"
+	short_desc = "You are an animal doctor who just woke up in lavaland"
+	flavour_text = "What...? Where are you? Where are the others? This is still the animal hospital - you should know, you've been an intern here for weeks - but \
+	you see them right now. So where is \
+	everyone? Where did they go? What happened to the hospital? And is that smoke you smell? You need to find someone else. Maybe everyone's gone. One of the cats scratched you just a few minutes ago. That's why you were in the pod - to heal the scratch. The scabs are still fresh; and tell you what happened."
+	assignedrole = "Translocated Vet"
+	mirrorcanloadappearance = TRUE
+
+/obj/effect/mob_spawn/human/doctor/alive/lavaland/Destroy()
+	var/obj/structure/fluff/empty_sleeper/S = new(drop_location())
+	S.setDir(dir)
+	return ..()
+
+//Prisoner containment sleeper: Spawns in crashed prison ships in lavaland. Ghosts become escaped prisoners and are advised to find a way out of the mess they've gotten themselves into.
+/obj/effect/mob_spawn/human/prisoner_transport
+	name = "prisoner containment sleeper"
+	desc = "A sleeper designed to put its occupant into a deep coma, unbreakable until the sleeper turns off. This one's glass is cracked and you can see a pale, sleeping face staring out."
+	mob_name = "an escaped prisoner"
+	job_description = "Escaped Prisoner"
+	icon = 'icons/obj/machines/sleeper.dmi'
+	icon_state = "sleeper_s"
+	outfit = /datum/outfit/lavalandprisoner
+	roundstart = FALSE
+	death = FALSE
+	short_desc = "You're a prisoner, sentenced to hard work in one of Nanotrasen's labor camps, but it seems as \
+	though fate has other plans for you."
+	flavour_text = "Good. It seems as though your ship crashed. You remember that you were convicted of "
+	assignedrole = "Escaped Prisoner"
+
+/obj/effect/mob_spawn/human/prisoner_transport/special(mob/living/L)
+	L.real_name = "NTP #LL-0[rand(111,999)]" //Nanotrasen Prisoner #Lavaland-(numbers)
+	L.name = L.real_name
+
+/obj/effect/mob_spawn/human/prisoner_transport/Initialize(mapload)
+	. = ..()
+	var/list/crimes = list("murder", "larceny", "embezzlement", "unionization", "dereliction of duty", "kidnapping", "gross incompetence", "grand theft", "collaboration with the Syndicate", \
+	"worship of a forbidden deity", "interspecies relations", "mutiny")
+	flavour_text += "[pick(crimes)]. but regardless of that, it seems like your crime doesn't matter now. You don't know where you are, but you know that it's out to kill you, and you're not going \
+	to lose this opportunity. Find a way to get out of this mess and back to where you rightfully belong - your [pick("house", "apartment", "spaceship", "station")]."
+
+/datum/outfit/lavalandprisoner
+	name = "Lavaland Prisoner"
+	uniform = /obj/item/clothing/under/rank/prisoner
+	mask = /obj/item/clothing/mask/breath
+	shoes = /obj/item/clothing/shoes/sneakers/orange
+	r_pocket = /obj/item/tank/internals/emergency_oxygen
+
+
+/obj/effect/mob_spawn/human/prisoner_transport/Destroy()
+	new/obj/structure/fluff/empty_sleeper/syndicate(get_turf(src))
+	return ..()
+
+//Space Hotel Staff
+/obj/effect/mob_spawn/human/hotel_staff //not free antag u little shits
+	name = "staff sleeper"
+	desc = "A sleeper designed for long-term stasis between guest visits."
+	mob_name = "hotel staff member"
+	job_description = "Hotel Staff"
+	icon = 'icons/obj/machines/sleeper.dmi'
+	icon_state = "sleeper_s"
+	objectives = "Cater to visiting guests with your fellow staff. Do not leave your assigned hotel and always remember: The customer is always right!"
+	death = FALSE
+	roundstart = FALSE
+	random = TRUE
+	outfit = /datum/outfit/hotelstaff
+	short_desc = "You are a staff member of a top-of-the-line space hotel!"
+	flavour_text = "You are a staff member of a top-of-the-line space hotel! Cater to guests and make sure the manager doesn't fire you."
+	important_info = "DON'T leave the hotel"
+	assignedrole = "Hotel Staff"
+	mirrorcanloadappearance = TRUE
+
+/datum/outfit/hotelstaff
+	name = "Hotel Staff"
+	uniform = /obj/item/clothing/under/assistantformal
+	shoes = /obj/item/clothing/shoes/laceup
+	r_pocket = /obj/item/radio/off
+	back = /obj/item/storage/backpack
+	implants = list(/obj/item/implant/mindshield)
+
+/obj/effect/mob_spawn/human/hotel_staff/security
+	name = "hotel security sleeper"
+	mob_name = "hotel security member"
+	job_description = "Hotel Security"
+	outfit = /datum/outfit/hotelstaff/security
+	short_desc = "You are a peacekeeper."
+	flavour_text = "You have been assigned to this hotel to protect the interests of the company while keeping the peace between \
+		guests and the staff."
+	important_info = "Do NOT leave the hotel, as that is grounds for contract termination."
+	objectives = "Do not leave your assigned hotel. Try and keep the peace between staff and guests, non-lethal force heavily advised if possible."
+	mirrorcanloadappearance = TRUE
+
+/datum/outfit/hotelstaff/security
+	name = "Hotel Secuirty"
+	uniform = /obj/item/clothing/under/rank/security/blueshirt
+	shoes = /obj/item/clothing/shoes/jackboots
+	suit = /obj/item/clothing/suit/armor/vest/blueshirt
+	head = /obj/item/clothing/head/helmet/blueshirt
+	back = /obj/item/storage/backpack/security
+	belt = /obj/item/storage/belt/security/full
+
+/obj/effect/mob_spawn/human/hotel_staff/Destroy()
+	new/obj/structure/fluff/empty_sleeper/syndicate(get_turf(src))
+	..()
+
+/obj/effect/mob_spawn/human/demonic_friend
+	name = "Essence of friendship"
+	desc = "Oh boy! Oh boy! A friend!"
+	mob_name = "Demonic friend"
+	job_description = "Demonic Friend"
+	icon = 'icons/obj/cardboard_cutout.dmi'
+	icon_state = "cutout_basic"
+	outfit = /datum/outfit/demonic_friend
+	death = FALSE
+	roundstart = FALSE
+	random = TRUE
+	id_job = "SuperFriend"
+	id_access = "assistant"
+	var/obj/effect/proc_holder/spell/targeted/summon_friend/spell
+	var/datum/mind/owner
+	assignedrole = "SuperFriend"
+
+/obj/effect/mob_spawn/human/demonic_friend/Initialize(mapload, datum/mind/owner_mind, obj/effect/proc_holder/spell/targeted/summon_friend/summoning_spell)
+	. = ..()
+	owner = owner_mind
+	flavour_text = "You have been given a reprieve from your eternity of torment, to be [owner.name]'s friend for [owner.p_their()] short mortal coil."
+	important_info = "Be aware that if you do not live up to [owner.name]'s expectations, they can send you back to hell with a single thought. [owner.name]'s death will also return you to hell."
+	var/area/A = get_area(src)
+	if(!mapload && A)
+		notify_ghosts("\A friendship shell has been completed in \the [A.name].", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE)
+	objectives = "Be [owner.name]'s friend, and keep [owner.name] alive, so you don't get sent back to hell."
+	spell = summoning_spell
+
+
+/obj/effect/mob_spawn/human/demonic_friend/special(mob/living/L)
+	if(!QDELETED(owner.current) && owner.current.stat != DEAD)
+		L.real_name = "[owner.name]'s best friend"
+		L.name = L.real_name
+		soullink(/datum/soullink/oneway, owner.current, L)
+		spell.friend = L
+		spell.charge_counter = spell.charge_max
+		L.mind.hasSoul = FALSE
+		var/mob/living/carbon/human/H = L
+		var/obj/item/worn = H.wear_id
+		var/obj/item/card/id/id = worn.GetID()
+		id.registered_name = L.real_name
+		id.update_label()
+	else
+		to_chat(L, "<span class='userdanger'>Your owner is already dead!  You will soon perish.</span>")
+		addtimer(CALLBACK(L, /mob.proc/dust, 150)) //Give em a few seconds as a mercy.
+
+/datum/outfit/demonic_friend
+	name = "Demonic Friend"
+	uniform = /obj/item/clothing/under/assistantformal
+	shoes = /obj/item/clothing/shoes/laceup
+	r_pocket = /obj/item/radio/off
+	back = /obj/item/storage/backpack
+	implants = list(/obj/item/implant/mindshield) //No revolutionaries, he's MY friend.
+	id = /obj/item/card/id
+
+/obj/effect/mob_spawn/human/syndicate
+	name = "Syndicate Operative"
+	roundstart = FALSE
+	death = FALSE
+	icon = 'icons/obj/machines/sleeper.dmi'
+	icon_state = "sleeper_s"
+	outfit = /datum/outfit/syndicate_empty
+	assignedrole = "Space Syndicate"	//I know this is really dumb, but Syndicate operative is nuke ops
+
+/datum/outfit/syndicate_empty
+	name = "Syndicate Operative Empty"
+	uniform = /obj/item/clothing/under/syndicate
+	shoes = /obj/item/clothing/shoes/combat
+	gloves = /obj/item/clothing/gloves/combat
+	ears = /obj/item/radio/headset/syndicate/alt
+	back = /obj/item/storage/backpack
+	implants = list(/obj/item/implant/weapons_auth)
+	id = /obj/item/card/id/syndicate
+
+/datum/outfit/syndicate_empty/post_equip(mob/living/carbon/human/H)
+	H.faction |= ROLE_SYNDICATE
+
+/obj/effect/mob_spawn/human/syndicate/battlecruiser
+	name = "Syndicate Battlecruiser Ship Operative"
+	short_desc = "You are a crewmember aboard the syndicate flagship: the SBC Starfury."
+	flavour_text = "Your job is to follow your captain's orders, maintain the ship, and keep the engine running. If you are not familiar with how the supermatter engine functions: do not attempt to start it."
+	important_info = "The armory is not a candy store, and your role is not to assault the station directly, leave that work to the assault operatives."
+	outfit = /datum/outfit/syndicate_empty/SBC
+	mirrorcanloadappearance = TRUE
+
+/datum/outfit/syndicate_empty/SBC
+	name = "Syndicate Battlecruiser Ship Operative"
+	l_pocket = /obj/item/gun/ballistic/automatic/pistol
+	r_pocket = /obj/item/kitchen/knife/combat/survival
+	belt = /obj/item/storage/belt/military/assault
+
+/obj/effect/mob_spawn/human/syndicate/battlecruiser/assault
+	short_desc = "You are an assault operative aboard the syndicate flagship: the SBC Starfury."
+	flavour_text = "Your job is to follow your captain's orders, keep intruders out of the ship, and assault Space Station 13. There is an armory, multiple assault ships, and beam cannons to attack the station with."
+	important_info = "Work as a team with your fellow operatives and work out a plan of attack. If you are overwhelmed, escape back to your ship!"
+	outfit = /datum/outfit/syndicate_empty/SBC/assault
+	mirrorcanloadappearance = TRUE
+
+/datum/outfit/syndicate_empty/SBC/assault
+	name = "Syndicate Battlecruiser Assault Operative"
+	uniform = /obj/item/clothing/under/syndicate/combat
+	l_pocket = /obj/item/ammo_box/magazine/m10mm
+	r_pocket = /obj/item/kitchen/knife/combat/survival
+	belt = /obj/item/storage/belt/military
+	suit = /obj/item/clothing/suit/armor/vest
+	suit_store = /obj/item/gun/ballistic/automatic/pistol
+	back = /obj/item/storage/backpack/security
+	mask = /obj/item/clothing/mask/gas/syndicate
+
+/obj/effect/mob_spawn/human/syndicate/battlecruiser/captain
+	name = "Syndicate Battlecruiser Captain"
+	short_desc = "You are the captain aboard the syndicate flagship: the SBC Starfury."
+	flavour_text = "Your job is to oversee your crew, defend the ship, and destroy Space Station 13. The ship has an armory, multiple ships, beam cannons, and multiple crewmembers to accomplish this goal."
+	important_info = "As the captain, this whole operation falls on your shoulders. You do not need to nuke the station, causing sufficient damage and preventing your ship from being destroyed will be enough."
+	outfit = /datum/outfit/syndicate_empty/SBC/assault/captain
+	id_access_list = list(150,151)
+	mirrorcanloadappearance = TRUE
+
+/datum/outfit/syndicate_empty/SBC/assault/captain
+	name = "Syndicate Battlecruiser Captain"
+	l_pocket = /obj/item/melee/transforming/energy/sword/saber/red
+	r_pocket = /obj/item/melee/classic_baton/telescopic
+	suit = /obj/item/clothing/suit/armor/vest/capcarapace/syndicate
+	suit_store = /obj/item/gun/ballistic/revolver/mateba
+	back = /obj/item/storage/backpack/satchel/leather
+	head = /obj/item/clothing/head/HoS/syndicate
+	mask = /obj/item/clothing/mask/cigarette/cigar/havana
+	glasses = /obj/item/clothing/glasses/thermal/eyepatch
+
+//Ancient cryogenic sleepers. Players become NT crewmen from a hundred year old space station, now on the verge of collapse.
+/obj/effect/mob_spawn/human/oldsec
+	name = "old cryogenics pod"
+	desc = "A humming cryo pod. You can barely recognise a security uniform underneath the built up ice. The machine is attempting to wake up its occupant."
+	mob_name = "a security officer"
+	icon = 'icons/obj/machines/sleeper.dmi'
+	icon_state = "sleeper"
+	roundstart = FALSE
+	death = FALSE
+	random = TRUE
+	mob_species = /datum/species/human
+	short_desc = "You are a security officer working for Nanotrasen, stationed onboard a state of the art research station."
+	flavour_text = "You vaguely recall rushing into a cryogenics pod due to an oncoming radiation storm. \
+	The last thing you remember is the station's Artificial Program telling you that you would only be asleep for eight hours. As you open \
+	your eyes, everything seems rusted and broken, a dark feeling swells in your gut as you climb out of your pod."
+	important_info = "Work as a team with your fellow survivors and do not abandon them."
+	uniform = /obj/item/clothing/under/rank/security
+	shoes = /obj/item/clothing/shoes/jackboots
+	id = /obj/item/card/id/away/old/sec
+	r_pocket = /obj/item/restraints/handcuffs
+	l_pocket = /obj/item/assembly/flash/handheld
+	job_description = "Oldstation Crew"
+	assignedrole = "Ancient Crew"
+	mirrorcanloadappearance = TRUE
+
+/obj/effect/mob_spawn/human/oldsec/Destroy()
+	new/obj/structure/showcase/machinery/oldpod/used(drop_location())
+	return ..()
+
+/obj/effect/mob_spawn/human/oldeng
+	name = "old cryogenics pod"
+	desc = "A humming cryo pod. You can barely recognise an engineering uniform underneath the built up ice. The machine is attempting to wake up its occupant."
+	mob_name = "an engineer"
+	icon = 'icons/obj/machines/sleeper.dmi'
+	icon_state = "sleeper"
+	job_description = "Oldstation Crew"
+	roundstart = FALSE
+	death = FALSE
+	random = TRUE
+	mob_species = /datum/species/human
+	short_desc = "You are an engineer working for Nanotrasen, stationed onboard a state of the art research station."
+	flavour_text = "You vaguely recall rushing into a cryogenics pod due to an oncoming radiation storm. The last thing \
+	you remember is the station's Artificial Program telling you that you would only be asleep for eight hours. As you open \
+	your eyes, everything seems rusted and broken, a dark feeling swells in your gut as you climb out of your pod."
+	important_info = "Work as a team with your fellow survivors and do not abandon them."
+	uniform = /obj/item/clothing/under/rank/engineer
+	shoes = /obj/item/clothing/shoes/workboots
+	id = /obj/item/card/id/away/old/eng
+	gloves = /obj/item/clothing/gloves/color/fyellow/old
+	l_pocket = /obj/item/tank/internals/emergency_oxygen
+	assignedrole = "Ancient Crew"
+	mirrorcanloadappearance = TRUE
+
+/obj/effect/mob_spawn/human/oldeng/Destroy()
+	new/obj/structure/showcase/machinery/oldpod/used(drop_location())
+	return ..()
+
+/obj/effect/mob_spawn/human/oldsci
+	name = "old cryogenics pod"
+	desc = "A humming cryo pod. You can barely recognise a science uniform underneath the built up ice. The machine is attempting to wake up its occupant."
+	mob_name = "a scientist"
+	icon = 'icons/obj/machines/sleeper.dmi'
+	icon_state = "sleeper"
+	roundstart = FALSE
+	death = FALSE
+	random = TRUE
+	mob_species = /datum/species/human
+	short_desc = "You are a scientist working for Nanotrasen, stationed onboard a state of the art research station."
+	flavour_text = "You vaguely recall rushing into a cryogenics pod due to an oncoming radiation storm. \
+	The last thing you remember is the station's Artificial Program telling you that you would only be asleep for eight hours. As you open \
+	your eyes, everything seems rusted and broken, a dark feeling swells in your gut as you climb out of your pod."
+	important_info = "Work as a team with your fellow survivors and do not abandon them."
+	uniform = /obj/item/clothing/under/rank/scientist
+	shoes = /obj/item/clothing/shoes/laceup
+	id = /obj/item/card/id/away/old/sci
+	l_pocket = /obj/item/stack/medical/bruise_pack
+	assignedrole = "Ancient Crew"
+	job_description = "Oldstation Crew"
+	mirrorcanloadappearance = TRUE
+
+/obj/effect/mob_spawn/human/oldsci/Destroy()
+	new/obj/structure/showcase/machinery/oldpod/used(drop_location())
+	return ..()
+
+/obj/effect/mob_spawn/human/pirate
+	name = "space pirate sleeper"
+	desc = "A cryo sleeper smelling faintly of rum."
+	job_description = "Space Pirate"
+	random = TRUE
+	icon = 'icons/obj/machines/sleeper.dmi'
+	icon_state = "sleeper"
+	mob_name = "a space pirate"
+	mob_species = /datum/species/skeleton/space
+	outfit = /datum/outfit/pirate/space
+	roundstart = FALSE
+	death = FALSE
+	anchored = TRUE
+	density = FALSE
+	show_flavour = FALSE //Flavour only exists for spawners menu
+	short_desc = "You are a space pirate."
+	flavour_text = "The station refused to pay for your protection, protect the ship, siphon the credits from the station and raid it for even more loot."
+	assignedrole = "Space Pirate"
+	var/rank = "Mate"
+
+/obj/effect/mob_spawn/human/pirate/special(mob/living/new_spawn)
+	new_spawn.fully_replace_character_name(new_spawn.real_name,generate_pirate_name())
+	new_spawn.mind.add_antag_datum(/datum/antagonist/pirate)
+
+/obj/effect/mob_spawn/human/pirate/proc/generate_pirate_name()
+	var/beggings = strings(PIRATE_NAMES_FILE, "beginnings")
+	var/endings = strings(PIRATE_NAMES_FILE, "endings")
+	return "[rank] [pick(beggings)][pick(endings)]"
+
+/obj/effect/mob_spawn/human/pirate/Destroy()
+	new/obj/structure/showcase/machinery/oldpod/used(drop_location())
+	return ..()
+
+/obj/effect/mob_spawn/human/pirate/captain
+	rank = "Captain"
+	outfit = /datum/outfit/pirate/space/captain
+
+/obj/effect/mob_spawn/human/pirate/gunner
+	rank = "Gunner"

--- a/lavaland_surface_seed_vault.dmm
+++ b/lavaland_surface_seed_vault.dmm
@@ -1,0 +1,74 @@
+"a" = (/turf/closed/mineral/volcanic/lava_land_surface,/area/lavaland/surface/outdoors)
+"b" = (/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"c" = (/obj/structure/closet/emcloset/anchored,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"d" = (/obj/structure/table/wood,/obj/item/lighter,/obj/item/lighter,/obj/item/storage/fancy/rollingpapers,/obj/item/storage/fancy/rollingpapers,/obj/item/storage/fancy/rollingpapers,/obj/item/storage/fancy/rollingpapers,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"e" = (/obj/structure/table/wood,/obj/item/storage/box/disks_plantgene,/obj/machinery/light{dir = 1},/obj/item/storage/box/disks_plantgene,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"f" = (/obj/machinery/plantgenes/seedvault{pixel_y = 6},/obj/structure/table/wood,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"g" = (/obj/structure/table/wood,/obj/machinery/smartfridge/disks{pixel_y = 2},/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"h" = (/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"i" = (/obj/structure/closet/crate/hydroponics,/obj/structure/beebox,/obj/item/melee/flyswatter,/obj/item/honey_frame,/obj/item/honey_frame,/obj/item/honey_frame,/obj/item/queen_bee/bought,/obj/item/clothing/head/beekeeper_head,/obj/item/clothing/suit/beekeeper_suit,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"j" = (/obj/structure/shuttle/engine/propulsion{dir = 8},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"k" = (/obj/structure/table/wood,/obj/item/storage/box/disks_plantgene,/obj/item/storage/box/disks_plantgene,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"l" = (/obj/machinery/door/airlock,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"m" = (/obj/machinery/door/airlock/external,/obj/structure/fans/tiny,/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 8},/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"n" = (/obj/machinery/smartfridge,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"o" = (/obj/structure/closet/crate/hydroponics,/obj/item/cultivator,/obj/item/cultivator,/obj/item/cultivator,/obj/item/cultivator,/obj/item/shovel/spade,/obj/item/shovel/spade,/obj/item/shovel/spade,/obj/item/shovel/spade,/obj/item/hatchet,/obj/item/hatchet,/obj/item/hatchet,/obj/item/hatchet,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"p" = (/obj/machinery/hydroponics/constructable,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"q" = (/obj/structure/table/wood,/obj/item/storage/box/stockparts/deluxe,/obj/item/storage/part_replacer,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"r" = (/obj/structure/table/wood,/obj/item/storage/bag/plants,/obj/item/storage/bag/plants,/obj/item/storage/bag/plants,/obj/item/storage/bag/plants,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"s" = (/obj/structure/table/wood,/obj/item/gun/energy/floragun,/obj/item/gun/energy/floragun,/obj/item/gun/energy/floragun,/obj/item/gun/energy/floragun,/obj/item/storage/box/disks_plantgene,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"t" = (/obj/effect/mob_spawn/human/seed_vault,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"u" = (/obj/structure/sink{dir = 8; pixel_x = -12; pixel_y = 2},/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"v" = (/obj/machinery/vending/hydronutrients,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"w" = (/obj/machinery/vending/hydroseeds,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"x" = (/obj/machinery/reagentgrinder{pixel_y = 5},/obj/structure/table/glass,/obj/item/reagent_containers/glass/beaker/bluespace,/obj/item/reagent_containers/glass/beaker/bluespace,/obj/item/reagent_containers/glass/beaker/bluespace,/obj/item/reagent_containers/glass/beaker/bluespace,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"y" = (/obj/structure/sink{dir = 4; pixel_x = 11},/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"z" = (/obj/machinery/door/airlock/external,/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 4},/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"A" = (/obj/structure/closet/crate,/obj/item/reagent_containers/food/snacks/grown/pink_chili,/obj/item/reagent_containers/food/snacks/grown/milkmelon,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"B" = (/obj/structure/disposalpipe/trunk,/obj/machinery/disposal/bin,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"C" = (/obj/machinery/seed_extractor,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"D" = (/obj/machinery/biogenerator,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"E" = (/obj/machinery/chem_dispenser/mutagensaltpeter,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"F" = (/obj/structure/disposalpipe/segment,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"G" = (/obj/structure/closet/crate/hydroponics,/obj/item/clothing/under/rank/hydroponics,/obj/item/clothing/under/rank/hydroponics,/obj/item/clothing/under/rank/hydroponics,/obj/item/clothing/under/rank/hydroponics,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"H" = (/obj/machinery/chem_master/condimaster,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"I" = (/obj/structure/disposalpipe/segment,/obj/machinery/vending/wardrobe/hydro_wardrobe{free = 1},/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"J" = (/obj/item/storage/toolbox/syndicate,/obj/structure/table/wood,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"K" = (/turf/open/lava/smooth/lava_land_surface,/area/lavaland/surface/outdoors)
+"L" = (/obj/structure/disposalpipe/segment{dir = 5},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"M" = (/obj/structure/disposalpipe/trunk{dir = 8},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"N" = (/obj/structure/closet/crate,/obj/item/seeds/vaporsac,/obj/item/seeds/vale,/obj/item/seeds/gatfruit,/obj/item/seeds/jurlmah,/obj/item/seeds/amauri,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"O" = (/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"P" = (/obj/machinery/hydroponics/constructable,/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"Q" = (/turf/closed/wall/r_wall,/area/ruin/powered/seedvault)
+"R" = (/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"S" = (/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"T" = (/obj/structure/table/wood,/obj/item/reagent_containers/glass/bucket,/obj/item/reagent_containers/glass/bucket,/obj/item/reagent_containers/glass/bucket,/obj/item/reagent_containers/glass/bucket,/obj/item/reagent_containers/spray/cleaner,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"U" = (/obj/machinery/light,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"V" = (/obj/structure/disposalpipe/segment,/turf/closed/wall/r_wall,/area/ruin/powered/seedvault)
+"X" = (/obj/machinery/hydroponics/constructable,/obj/machinery/light,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"Y" = (/obj/structure/closet,/obj/item/shovel,/obj/item/pickaxe,/obj/item/mining_scanner,/obj/item/storage/bag/ore,/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+"Z" = (/obj/item/disk/design_disk/plant_disk,/obj/machinery/autolathe/hacked{desc = "This autolathe seems to have its safety light off."},/turf/open/floor/plasteel/freezer,/area/ruin/powered/seedvault)
+
+(1,1,1) = {"
+aabbaaabbaabaaabaaaa
+aaaaaaaaaaaaaaaaaaaa
+aaaaQQQQQQQQQQQbaaaa
+aaaQQdekfghOiQQQjbab
+aaaQNhhhhhhhhiQQabbb
+aaaQQQQlQQQQQQQQjbbb
+aaQQnoPhppqPrsQQabaa
+QQQQRhhhhhhhhSQQjbbb
+QtOQuhpvnwxhpyQYQbbb
+Qthlhhhhhhhhphzhmbbb
+Qthlhhhhhhhhphzhmbbb
+QtUQuhpBCDEhpyQcQbbb
+QQQQRhhFhhhhhSQQjbbb
+aaQQZGXIApHXTJQQbbbb
+aaaQQQQVQQQQQQQQjbaa
+aaaaaaaLMKaaaaaaaaaa
+aaaaaaabKKKbaaaaaaaa
+aabaaaaabKbaaaaaaabb
+bbaaaaaaabaaaaaabbbb
+bbbaaaaaaaaaaaaabbba
+"}


### PR DESCRIPTION
Removes the random seeds from the seed vault and gives the Lifebringers a set pack of unique seeds along with giving them more equipment and options.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having more options for Lifebringers and giving them more unique seeds along with T4 parts and an RPED so they can actually use their Biogen properly.  Also some horny seeds because plants have feelings too.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
Removed: The 2 random lootdrop seeds
Added: Jurlmah, Amauri, Vale, Vapoursac, Gatfruit, Pink Pepper and Milk Melon as guaranteed spawns.
Added: A RPED and a box of T4 parts.
Added: A hydrobe, for fashion reasons.
Added: 2 more boxes of Plant Disks and 2 more hydroponics trays.
Added a bottle of space cleaner.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
