### PR TITLE
Some Revenant Changes

### DIFF
--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -28,15 +28,15 @@
 			to_chat(target, "You feel as if you are being watched.")
 		return
 	draining = TRUE
-	essence_drained += rand(15, 20)
+	essence_drained += rand(30, 40)
 	to_chat(src, "<span class='revennotice'>You search for the soul of [target].</span>")
 	if(do_after(src, rand(10, 20), 0, target)) //did they get deleted in that second?
 		if(target.ckey)
 			to_chat(src, "<span class='revennotice'>[target.p_their(TRUE)] soul burns with intelligence.</span>")
-			essence_drained += rand(20, 30)
+			essence_drained += rand(40, 60)
 		if(target.stat != DEAD)
 			to_chat(src, "<span class='revennotice'>[target.p_their(TRUE)] soul blazes with life!</span>")
-			essence_drained += rand(40, 50)
+			essence_drained += rand(80, 100)
 		else
 			to_chat(src, "<span class='revennotice'>[target.p_their(TRUE)] soul is weak and faltering.</span>")
 		if(do_after(src, rand(15, 20), 0, target)) //did they get deleted NOW?

--- a/code/modules/antagonists/revenant/revenant_spawn_event.dm
+++ b/code/modules/antagonists/revenant/revenant_spawn_event.dm
@@ -1,4 +1,4 @@
-#define REVENANT_SPAWN_THRESHOLD 15
+#define REVENANT_SPAWN_THRESHOLD 12
 
 /datum/round_event_control/revenant
 	name = "Spawn Revenant" // Did you mean 'griefghost'?
@@ -20,7 +20,8 @@
 	if(!ignore_mobcheck)
 		var/deadMobs = 0
 		for(var/mob/living/carbon/M in GLOB.dead_mob_list)
-			deadMobs++
+			if(is_station_level(M.z))
+				deadMobs++
 		if(deadMobs < REVENANT_SPAWN_THRESHOLD)
 			message_admins("Event attempted to spawn a revenant, but there were only [deadMobs]/[REVENANT_SPAWN_THRESHOLD] dead mobs.")
 			return WAITING_FOR_SOMETHING


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so only dead bodies in the station Z level count for the threshold.
Lowers threshold from 15 to 12.
Effectively doubles the amount of essence gained per body.

If this is not enough, I'll consider having it being able to drain from every dead mob. Every single one.

## Why It's Good For The Game

Revs are currently garbo, this should help them a bit and prevent revs from being triggered by bodies in other z levels.

## Changelog
:cl:
tweak: revenant essence drained tweaks and spawn threshold tweaks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
