### PR TITLE
Allows anything that's not a human or silicon to ghost

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -300,7 +300,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		succumb()
 	if(stat == DEAD)
 		ghostize(1)
-	else if(!(ishuman(src)))
+	else if(!(ishuman(src)) && !(issilicon(src)))
 		var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you won't be able to re-enter this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
 		if(response != "Ghost")
 			return	//didn't want to ghost after-all

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -300,17 +300,15 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		succumb()
 	if(stat == DEAD)
 		ghostize(1)
-	else
-		//Low RP, removing.
-		/*
+	else if(!(ishuman(src)))
 		var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you won't be able to re-enter this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
 		if(response != "Ghost")
 			return	//didn't want to ghost after-all
 		ghostize(0)						//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 		suicide_log(TRUE)
-		*/
+	else
 		to_chat(usr, "<span class='boldnotice'>You cannot ghost, if you wish to remove yourself from the round, please locate a cryogenic freezer.</span>")
-		message_admins("[usr] attempted to ghost.")
+		message_admins("[src] attempted to ghost.")
 
 /mob/camera/verb/ghost()
 	set category = "OOC"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. 

Drones, simplemobs, tired spectral blades and whatnot are not able to ghost. This makes it so only humans and silicons aren't able to ghost without cryoing.

## Why It's Good For The Game

I... Guess it's a better alternative than using the suicide command? Sometimes you click a wrong prompt and it's not nice to just outright kill the mob the science team created.

## Changelog
:cl:
add: ghost tweaks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
