### PR TITLE
More mimic changes.

### DIFF
--- a/hyperstation/code/mobs/mimic.dm
+++ b/hyperstation/code/mobs/mimic.dm
@@ -21,8 +21,8 @@
 	response_harm   = "smacks"
 	melee_damage_lower = 8
 	melee_damage_upper = 12
-	attacktext = "slams"
-	attack_sound = 'sound/weapons/punch1.ogg'
+	attacktext = "glomps"
+	attack_sound = 'sound/effects/blobattack.ogg'
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	ventcrawler = VENTCRAWLER_ALWAYS
 	blood_volume = 0
@@ -60,23 +60,28 @@
 /mob/living/simple_animal/hostile/hs13mimic/Life()
 	. = ..()
 	if(src.mind && !warned)
+		SEND_SOUND(src, sound('sound/magic/mutate.ogg'))
 		to_chat(src, src.playstyle_string)
 		warned = TRUE
 
 /mob/living/simple_animal/hostile/hs13mimic/AttackingTarget()
 	. = ..()
-	if(unstealth == FALSE && knockdown_people && . && iscarbon(target))//Guaranteed knockdown if we get the first hit while in stealth. Typically, only players can do this since NPC mimics transform first before attacking.
-		unstealth = TRUE
-		restore()
+	if(iscarbon(target))
 		var/mob/living/carbon/C = target
-		C.Knockdown(40)
-		C.visible_message("<span class='danger'>\The [src] knocks down \the [C]!</span>", \
+		if(unstealth == FALSE && knockdown_people && .) //Guaranteed knockdown if we get the first hit while disguised. Typically, only players can do this since NPC mimics transform first before attacking.
+			unstealth = TRUE
+			restore()
+			C.Knockdown(40)
+			C.visible_message("<span class='danger'>\The [src] knocks down \the [C]!</span>", \
 				"<span class='userdanger'>\The [src] knocks you down!</span>")
-	else if(knockdown_people && . && prob(15) && iscarbon(target))
-		var/mob/living/carbon/C = target
-		C.Knockdown(40)
-		C.visible_message("<span class='danger'>\The [src] knocks down \the [C]!</span>", \
-				"<span class='userdanger'>\The [src] knocks you down!</span>")
+		else if(knockdown_people && . && prob(15))
+			C.Knockdown(40)
+			C.visible_message("<span class='danger'>\The [src] knocks down \the [C]!</span>", \
+					"<span class='userdanger'>\The [src] knocks you down!</span>")
+		if(C.nutrition >= 15)
+			C.nutrition -= (rand(7,15)) //They lose 7-15 nutrition
+			adjustBruteLoss(-3) //We heal 3 damage
+		C.adjustCloneLoss(rand(2,4)) //They also take a bit of cellular damage.
 
 /mob/living/simple_animal/hostile/hs13mimic/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	trigger()

--- a/hyperstation/code/mobs/mimic.dm
+++ b/hyperstation/code/mobs/mimic.dm
@@ -43,9 +43,10 @@
 	/obj/item/projectile,
 	/obj/item/radio/intercom))
 	var/warned
-	var/playstyle_string = "<span class='big bold'>You are a mimic,</span></b> a tricky creature that can take the form of \
+	var/playstyle_string = "<span class='boldannounce'>You are a mimic,</span></b> a tricky creature that can take the form of \
 							almost any items nearby by shift-clicking it. While morphed, you move slowly and do less damage. \
-							Finally, you can restore yourself to your original form while morphed by shift-clicking yourself.</b>"
+							Finally, you can restore yourself to your original form while morphed by shift-clicking yourself. \
+							Attacking carbon lifeforms will heal you at the cost of destructuring their DNA.</b>"
 
 /mob/living/simple_animal/hostile/hs13mimic/Initialize()
 	. = ..()
@@ -60,7 +61,7 @@
 /mob/living/simple_animal/hostile/hs13mimic/Life()
 	. = ..()
 	if(src.mind && !warned)
-		SEND_SOUND(src, sound('sound/magic/mutate.ogg'))
+		SEND_SOUND(src, sound('sound/ambience/antag/ling_aler.ogg'))
 		to_chat(src, src.playstyle_string)
 		warned = TRUE
 

--- a/hyperstation/code/mobs/mimic.dm
+++ b/hyperstation/code/mobs/mimic.dm
@@ -34,6 +34,7 @@
 	minbodytemp = 250 //weak to cold
 	maxbodytemp = 1500
 	pressure_resistance = 600
+	sight = SEE_MOBS
 	var/unstealth = FALSE
 	var/knockdown_people = 1
 	var/playerTransformCD = 50


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mimics are now able to heal a little bit by attacking carbon lifeforms that have nutrition, by draining it like slimes do. If the target has no nutrition, they will not heal anymore.

They also gain thermal vision, which is only really useful in the off chance that an admeme is memeing these or that someone gets sentience.

## Why It's Good For The Game

Mimic code go brr.

## Changelog
:cl:
add: Mimics can now heal slightly per attack on carbon lifeforms.
add: Sentient mimics have thermal vision
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
