### PR TITLE
Disables UO45 from the gateway rotation

### DIFF
--- a/config/awaymissionconfig.txt
+++ b/config/awaymissionconfig.txt
@@ -16,7 +16,7 @@ _maps/RandomZLevels/blackmarketpackers.dmm
 _maps/RandomZLevels/away_mission/jungleresort.dmm
 #_maps/RandomZLevels/centcomAway.dmm
 _maps/RandomZLevels/moonoutpost19.dmm
-_maps/RandomZLevels/undergroundoutpost45.dmm
+#_maps/RandomZLevels/undergroundoutpost45.dmm
 _maps/RandomZLevels/caves.dmm
 _maps/RandomZLevels/snowdin.dmm
 _maps/RandomZLevels/research.dmm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title.
![image](https://user-images.githubusercontent.com/53913550/121972522-b05f1b00-cd51-11eb-8331-e7e0fd53739c.png)
**Requires a config file modification.**
Refer to the changes to config/awaymissionconfig.txt and replicate them in the server files.

## Why It's Good For The Game

The UO45 map was abandoned in 2015, with the original developer never finishing the intended product that was that map. Up until this day in TGstation and other stations as far as I've researched it remains empty and... Boring.

Unless someone decides to take it up and turn it into something decent, this PR simply disables the rotation, but needs a host to change the config file for it, just like I changed it in the changed files.

## Changelog
:cl:
del: UO45 gateway disabled, but not removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
