### PR TITLE
Two engineering alt job titles

### DIFF
--- a/code/modules/jobs/job_types/job_alt_titles.dm
+++ b/code/modules/jobs/job_types/job_alt_titles.dm
@@ -2,10 +2,10 @@
 
 //Engineering
 /datum/job/chief_engineer
-	alt_titles = list("Head Engineer", "Construction Coordinator", "Project Manager")
+	alt_titles = list("Head Engineer", "Construction Coordinator", "Project Manager", "Power Plant Director")
 
 /datum/job/engineer
-	alt_titles = list("Maintenance Technician", "Engine Technician", "Electrician", "Structural Engineer", "Mechanic",  "Station Architect")
+	alt_titles = list("Maintenance Technician", "Engine Technician", "Electrician", "Structural Engineer", "Mechanic",  "Station Architect", "Nuclear Plant Operator")
 
 /datum/job/atmos
 	alt_titles = list("Firefighter", "Life Support Specialist", "Disposals Technician")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives chief engineers the Power Plant Director alt title and engineers the Nuclear Plant Operator alt title.

## Why It's Good For The Game

Variety!

## Changelog
:cl:
add: Two engineering alt job titles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
