### PR TITLE
Adminbus Crystalline Asteroid Update - Aka - No brakes on this train

### DIFF
--- a/hyperstation/code/game/objects/railings.dm
+++ b/hyperstation/code/game/objects/railings.dm
@@ -39,7 +39,8 @@
 		/obj/effect/collapse,
 		/obj/effect/particle_effect/ion_trails,
 		/obj/effect/dummy/phased_mob,
-		/obj/effect/immovablerod
+		/obj/effect/immovablerod,
+		/obj/effect/crystalline_reentry
 		)) //Gotta make sure certain things can phase through it otherwise the railings also block them.
 
 /obj/structure/railing/CanPass(atom/movable/mover, turf/target)

--- a/hyperstation/code/modules/events/crystalline_reentry.dm
+++ b/hyperstation/code/modules/events/crystalline_reentry.dm
@@ -131,11 +131,8 @@
 	return ..()
 
 /obj/effect/crystalline_reentry/proc/complete_trajectory()
-	//We hit what we wanted to hit, time to go
-	special_target = null
-	destination = get_edge_target_turf(src, dir)
-	walk(src,0)
-	walk_towards(src, destination, 1)
+	//We hit what we wanted to hit, time to go boom!
+	collision_effect()
 
 /obj/effect/crystalline_reentry/ex_act(severity, target)
 	return 0
@@ -147,8 +144,9 @@
 	return
 
 /obj/effect/crystalline_reentry/Bump(atom/clong)
-	asteroidhealth = asteroidhealth - rand(7,14)
-	
+	if(!special_target)//If it has a special target, THERE ARE NO BRAKES ON THE ADMINBUS, BABY
+		asteroidhealth = asteroidhealth - rand(7,14)
+	if(clong = istype())
 	if(prob(10))
 		playsound(src, 'sound/effects/bang.ogg', 50, 1)
 		audible_message("<span class='danger'>You hear a BONK!</span>")
@@ -177,19 +175,6 @@
 		qdel(other)
 	if(asteroidhealth <= 0)
 		collision_effect()
-		atmos_spawn_air("water_vapor=1000;TEMP=0") //brr
-		switch(rand(1,100))
-			if(1 to 20)
-				var/obj/structure/spawner/crystalline/M = new(src.loc)
-				visible_message("<span class='danger'>A [M] emerges from the asteroid's rubble!</span>")
-				if(prob(50) && tendrilnotify)
-					priority_announce("Unknown organic entities have been detected in the vincinity of [station_name()]. General caution is advised.", "General Alert")
-			if(21 to 99)
-				visible_message("The asteroid collapses into nothing...")
-			if(100)
-				var/mob/living/simple_animal/bot/hugbot/M = new(src.loc)
-				visible_message("<span class='danger'>A [M] emerges from the asteroid's rubble! Wait... What?</span>")
-		qdel(src)
 	else
 		atmos_spawn_air("water_vapor=75;TEMP=0") //brr
 
@@ -198,6 +183,8 @@
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
 		H.adjustBruteLoss(160)
+	if(special_target && loc == get_turf(special_target))
+		complete_trajectory()
 
 /obj/effect/crystalline_reentry/proc/make_debris()
 	for(var/throws = dropamt, throws > 0, throws--)
@@ -218,6 +205,19 @@
 		var/dist = get_dist(M.loc, src.loc)
 		shake_camera(M, dist > 20 ? 2 : 4, dist > 20 ? 1 : 3)
 		M.playsound_local(src.loc, null, 50, 1, random_frequency, 10, S = meteor_sound)
+	atmos_spawn_air("water_vapor=1250;TEMP=0") //brr
+	switch(rand(1,100))
+		if(1 to 20)
+			var/obj/structure/spawner/crystalline/M = new(src.loc)
+			visible_message("<span class='danger'>A [M] emerges from the asteroid's rubble!</span>")
+			if(prob(50) && tendrilnotify)
+				priority_announce("Unknown organic entities have been detected in the vincinity of [station_name()]. General caution is advised.", "General Alert")
+		if(21 to 99)
+			visible_message("The asteroid collapses into nothing...")
+		if(100)
+			var/mob/living/simple_animal/bot/hugbot/M = new(src.loc)
+			visible_message("<span class='danger'>A [M] emerges from the asteroid's rubble! Wait... What?</span>")
+	qdel(src)
 
 /obj/effect/crystalline_reentry/notendrilalert
 	tendrilnotify = FALSE

--- a/hyperstation/code/modules/events/crystalline_reentry.dm
+++ b/hyperstation/code/modules/events/crystalline_reentry.dm
@@ -146,7 +146,7 @@
 /obj/effect/crystalline_reentry/Bump(atom/clong)
 	if(!special_target)//If it has a special target, THERE ARE NO BRAKES ON THE ADMINBUS, BABY
 		asteroidhealth = asteroidhealth - rand(7,14)
-	if(clong = istype())
+
 	if(prob(10))
 		playsound(src, 'sound/effects/bang.ogg', 50, 1)
 		audible_message("<span class='danger'>You hear a BONK!</span>")
@@ -183,7 +183,7 @@
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
 		H.adjustBruteLoss(160)
-	if(special_target && loc == get_turf(special_target))
+	if(special_target && loc == get_turf(special_target)) // just in case. Otherwise the asteroid can stop if it penetrates someone that is standing exactly on that spot and that is bad
 		complete_trajectory()
 
 /obj/effect/crystalline_reentry/proc/make_debris()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so crystalline asteroids with a special target (aka, adminbus) don't stop until they reach the target turf.

## Why It's Good For The Game

it isn't, but it's adminbus anyway so...

## Changelog
:cl:
tweak: adminbus crystalline asteroid behavior
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
