### PR TITLE
makes advanced xeno arch mining scanners only show item depth

### DIFF
--- a/code/modules/research/xenoarch/strange_rock.dm
+++ b/code/modules/research/xenoarch/strange_rock.dm
@@ -96,8 +96,6 @@
 			to_chat(user,"You must stand still to scan.")
 			return
 		playsound(loc, HM.usesound, 50, 1, -1)
-		to_chat(user,"Base Depth: [itembasedepth] centimeters.")
-		to_chat(user,"Safe Depth: [itemsafedepth] centimeters.")
 		to_chat(user,"Item Depth: [itemactualdepth] centimeters.")
 	if(istype(W,/obj/item/xenoarch/help/measuring))
 		var/obj/item/xenoarch/help/measuring/HM = W


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

makes xeno arch scanners tell only item depth and nothing else

## Why It's Good For The Game

if you know the item depth you dont need to know safe and deepest, making the scanner clog chat less

## Changelog
:cl:
del: safe and base depth from advanced xeno arch scanners to lessen chat spam
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
