### PR TITLE
kink mate venders get more portals

### DIFF
--- a/modular_citadel/code/game/machinery/vending.dm
+++ b/modular_citadel/code/game/machinery/vending.dm
@@ -68,7 +68,7 @@
 				/obj/item/electropack/vibrator/small = 2,
 				/obj/item/electropack/vibrator = 2,
 				/obj/item/fleshlight = 2,
-				/obj/item/storage/box/portallight = 1,
+				/obj/item/storage/box/portallight = 3,
 				)
 	contraband = list(
 				/obj/item/clothing/under/gear_harness = 3,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

makes each kink vender have 3 portal box kits instead of 1

## Why It's Good For The Game

most likely isnt, but stops fighting over theses things even with 10 venders on station

## Changelog
:cl:
balance: makes each vender have 3 portal box kits instead of 1
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
