### PR TITLE
A few Dynamic mode balance changes

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -1,6 +1,6 @@
 #define DYNAMIC_DEFAULT_CHAOS       1.0 //The default chaos value for low pop low vote rounds
-#define DYNAMIC_VOTE_NORMALIZATION  5   //If there are fewer than this many votes, the average will be skewed towards the default
-#define DYNAMIC_NONVOTER_FACTOR 0.75 // 1 means they count for a full vote
+#define DYNAMIC_VOTE_NORMALIZATION  7   //If there are fewer than this many votes, the average will be skewed towards the default
+#define DYNAMIC_NONVOTER_FACTOR 0.5 // 1 means they count for a full vote
 
 SUBSYSTEM_DEF(vote)
 	name = "Vote"

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
@@ -452,6 +452,7 @@
 	typepath = /datum/round_event/processor_overload
 	cost = 4
 	weight = 2
+	earliest_start = 30 MINUTES
 	repeatable_weight_decrease = 3
 	enemy_roles = list("Chief Engineer","Station Engineer")
 	required_enemies = list(2,2,2,2,1,1,1,1,1,1)
@@ -552,7 +553,7 @@
 	earliest_start = 40 MINUTES
 	//property_weights = list("teamwork" = 1,"chaos" = 1, "extended" = -1)
 	occurances_max = 1
-	chaos_min = 1.3
+	chaos_min = 1.5
 
 
 /datum/dynamic_ruleset/event/wormholes
@@ -594,13 +595,14 @@
 	enemy_roles = list("Virologist","Chief Medical Officer","Captain","Chemist")
 	required_enemies = list(2,1,1,1,1,1,1,0,0,0)
 	required_candidates = 1
-	weight = 4
-	cost = -5
+	weight = 2
+	cost = 4
+	earliest_start = 30 MINUTES
 	requirements = list(101,101,20,20,15,10,10,10,10,5) // yes, it can even happen in "extended"!
 	//property_weights = list("story_potential" = 1, "extended" = 1, "valid" = -2)
 	high_population_requirement = 5
 	occurances_max = 1
-	chaos_min = 1.5
+	chaos_min = 1.75
 
 /datum/dynamic_ruleset/event/revenant
 	name = "Revenant"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Some events were happening too soon in the round. This PR effectively gives players a bit more time in the round until disruptive things like a processor overload (may force engineering to re-do tcomms) happens, alongside some much needed changes like SD actually taking a bit of cost from the round's threat and having its weight lowered so that it's not guaranteed **Every single round.** Also raises its required chaos from 1.5 to 1.75.
It's supposed to be a more special thing, after all.

Also brings portal storms' chaos level from 1.3 to 1.5.

Vote changes:

Nonvoter factor brought down from 0.75 to 0.5, HOWEVER, this increases the threshold for DYNAMIC_VOTE_NORMALIZATION, requiring 7 or more votes before Dynamic's brakes are set loose and players have total control over the result of the votes instead of the current 5.

## Changelog
:cl:
tweak: Some dynamic tweaks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
