### PR TITLE
Wardens -do- count as security. And other dynamic changes.

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -1,6 +1,7 @@
 #define DYNAMIC_DEFAULT_CHAOS       1.0 //The default chaos value for low pop low vote rounds
-#define DYNAMIC_VOTE_NORMALIZATION  7   //If there are fewer than this many votes, the average will be skewed towards the default
+#define DYNAMIC_VOTE_NORMALIZATION  8   //If there are fewer than this many votes, the average will be skewed towards the default
 #define DYNAMIC_NONVOTER_FACTOR 0.5 // 1 means they count for a full vote
+#define DYNAMIC_NONVOTER_VALUE 1.5 // The chaos value that non-voters should account for.
 
 SUBSYSTEM_DEF(vote)
 	name = "Vote"
@@ -154,10 +155,10 @@ SUBSYSTEM_DEF(vote)
 				while (v < DYNAMIC_VOTE_NORMALIZATION) //For low low pop, low vote rounds.
 					numbers += DYNAMIC_DEFAULT_CHAOS //stops the one person voting from setting the chaos to five and flooding the station with anomalies
 					v += 1
-			else if (voted.len < GLOB.clients.len)	//Have non-voters "vote" 2, if we're not lowpop
+			else if (voted.len < GLOB.clients.len)	//Have non-voters "vote" if we're not lowpop
 				for(var/I in 1 to (GLOB.clients.len - voted.len))
 					v += DYNAMIC_NONVOTER_FACTOR //Instead of a fixed value, this will now factor how much non-voter votes are 'worth' in the system.
-					numbers += 2
+					numbers += DYNAMIC_NONVOTER_VALUE
 				v = round(v) //This rounds the value to the nearest multiple, to make sure no calculations go fucky wucky.
 			var/total = 0
 			for (var/i in numbers)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -408,7 +408,7 @@
 	name = "Malfunctioning AI"
 	antag_datum = /datum/antagonist/traitor
 	antag_flag = ROLE_MALF
-	enemy_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Scientist", "Research Director", "Chief Engineer", "Engineer", "Shaft Miner")
+	enemy_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	exclusive_roles = list("AI")
 	required_enemies = list(4,4,4,4,4,4,2,2,2,0)
 	required_candidates = 1

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -847,7 +847,7 @@ datum/dynamic_ruleset/midround/bloodcult/trim_candidates()
   restricted_roles = list("AI", "Cyborg")
   protected_roles = list("Rookie", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")
   required_candidates = 1
-  enemy_roles = list("Security Officer", "Head of Security", "Captain", "AI", "Cyborg", "Chaplain", "Curator", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")
+  enemy_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Chaplain", "Curator")
   required_enemies = list(3,2,2,2,2,2,2,2,2,2)
   weight = 3
   cost = 10

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -847,7 +847,7 @@ datum/dynamic_ruleset/midround/bloodcult/trim_candidates()
   restricted_roles = list("AI", "Cyborg")
   protected_roles = list("Rookie", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")
   required_candidates = 1
-  enemy_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Chaplain", "Curator")
+  enemy_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Chaplain")
   required_enemies = list(3,2,2,2,2,2,2,2,2,2)
   weight = 3
   cost = 10

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -408,7 +408,7 @@
 	name = "Malfunctioning AI"
 	antag_datum = /datum/antagonist/traitor
 	antag_flag = ROLE_MALF
-	enemy_roles = list("Security Officer", "Warden","Detective","Head of Security", "Captain", "Scientist", "Research Director", "Chief Engineer", "Engineer", "Shaft Miner")
+	enemy_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Scientist", "Research Director", "Chief Engineer", "Engineer", "Shaft Miner")
 	exclusive_roles = list("AI")
 	required_enemies = list(4,4,4,4,4,4,2,2,2,0)
 	required_candidates = 1
@@ -461,7 +461,7 @@
 	name = "Wizard"
 	antag_datum = /datum/antagonist/wizard
 	antag_flag = ROLE_WIZARD
-	enemy_roles = list("Security Officer","Detective","Head of Security", "Captain")
+	enemy_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	required_enemies = list(2,2,1,1,1,1,1,1,1,0)
 	required_candidates = 1
 	weight = 1
@@ -495,7 +495,7 @@
 	name = "Nuclear Assault"
 	antag_flag = ROLE_OPERATIVE
 	antag_datum = /datum/antagonist/nukeop
-	enemy_roles = list("AI", "Cyborg", "Security Officer", "Warden","Detective","Head of Security", "Captain")
+	enemy_roles = list("AI", "Cyborg", "Security Officer", "Warden", "Detective","Head of Security", "Captain")
 	required_enemies = list(3,3,3,3,3,2,2,2,2,1)
 	required_candidates = 5
 	weight = 5
@@ -539,7 +539,7 @@
 	name = "Blob"
 	antag_datum = /datum/antagonist/blob
 	antag_flag = ROLE_BLOB
-	enemy_roles = list("Security Officer", "Detective", "Head of Security", "Captain", "Station Engineer")
+	enemy_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Station Engineer")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
 	weight = 3
@@ -629,7 +629,7 @@ datum/dynamic_ruleset/midround/bloodcult/trim_candidates()
 	name = "Alien Infestation"
 	antag_datum = /datum/antagonist/xeno
 	antag_flag = ROLE_ALIEN
-	enemy_roles = list("Security Officer", "Detective", "Head of Security", "Captain")
+	enemy_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
 	weight = 3
@@ -680,7 +680,7 @@ datum/dynamic_ruleset/midround/bloodcult/trim_candidates()
 	controller = /datum/round_event_control/nightmare
 	antag_flag = "Nightmare"
 	antag_flag_override = ROLE_ALIEN
-	enemy_roles = list("Security Officer", "Detective", "Head of Security", "Captain")
+	enemy_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
 	weight = 4
@@ -728,7 +728,7 @@ datum/dynamic_ruleset/midround/bloodcult/trim_candidates()
 	//config_tag = "abductors"
 	antag_flag = ROLE_ABDUCTOR
 	// Has two antagonist flags, in fact
-	enemy_roles = list("AI", "Cyborg", "Security Officer", "Warden","Detective","Head of Security", "Captain")
+	enemy_roles = list("AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	required_enemies = list(3,3,2,2,2,2,2,2,2,0)
 	required_candidates = 2
 	weight = 3
@@ -770,7 +770,7 @@ datum/dynamic_ruleset/midround/bloodcult/trim_candidates()
 	name = "Space Ninja"
 	//config_tag = "ninja"
 	antag_flag = ROLE_NINJA
-	enemy_roles = list("Security Officer","Head of Security","Captain")
+	enemy_roles = list("Security Officer", "Warden", "Head of Security", "Captain")
 	required_enemies = list(3,3,2,2,2,2,1,1,1,0)
 	required_candidates = 1
 	weight = 4

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -210,7 +210,7 @@
 	restricted_roles = list("AI", "Cyborg", "Positronic Brain")
 	protected_roles = list("Rookie", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")
 	required_candidates = 1
-	enemy_roles = list("Rookie", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")
+	enemy_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	weight = 4
 	cost = 10

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -210,7 +210,7 @@
 	restricted_roles = list("AI", "Cyborg", "Positronic Brain")
 	protected_roles = list("Rookie", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")
 	required_candidates = 1
-	enemy_roles = list("Security Officer", "Detective", "Head of Security", "Captain")
+	enemy_roles = list("Rookie", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	weight = 4
 	cost = 10
@@ -847,7 +847,7 @@ datum/dynamic_ruleset/midround/bloodcult/trim_candidates()
   restricted_roles = list("AI", "Cyborg")
   protected_roles = list("Rookie", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")
   required_candidates = 1
-  enemy_roles = list("Security Officer","Head of Security","Captain","AI","Cyborg","Chaplain","Curator")
+  enemy_roles = list("Security Officer", "Head of Security", "Captain", "AI", "Cyborg", "Chaplain", "Curator", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")
   required_enemies = list(3,2,2,2,2,2,2,2,2,2)
   weight = 3
   cost = 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Vote stuff: Default votes count as a 1.5 instead of a 2. We're higher in pop now, so this needs to be probably taken into account.

For whatever reason, most of the midround rulesets were not taking a warden's existence into account.

## Why It's Good For The Game

I think we could use a bit more spice during midrounds. Turns out a lot of midrounds were not taking things such as wardens and heads into account.

Sidenote, should we lower the chaos requirement for bloodsuckers to 3.5?

## Changelog
:cl:
tweak: some dynamic midround values
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
