### PR TITLE
Fixes turf browser (statbrowser) icons

### DIFF
--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -292,6 +292,8 @@ var imageRetryDelay = 50;
 var imageRetryLimit = 50;
 var menu = document.querySelector('#menu');
 var under_menu = document.querySelector('#under_menu');
+var statcontentdiv = document.getElementById('statcontent');
+var storedimages = [];
 
 function createStatusTab(name) {
 	if(document.getElementById(name) || name.trim() == "")
@@ -796,15 +798,26 @@ function iconError(E) {
 }
 
 function draw_listedturf() {
-	var statcontentdiv = document.getElementById("statcontent");
 	statcontentdiv[textContentKey] = "";
 	var table = document.createElement("table");
 	for(var i = 0; i < turfcontents.length; i++) {
 		var part = turfcontents[i];
-		if(part[2]) {
+		if(storedimages[part[1]] == null && part[2]) {
 			var img = document.createElement("img");
 			img.src = part[2];
-			img[addEventListenerKey]("onerror", iconError());
+			img.id = part[1];
+			storedimages[part[1]] = part[2];
+			img.onerror = function() {
+				iconError();
+			};
+			table.appendChild(img);
+		} else {
+			var img = document.createElement("img");
+			img.onerror = function() {
+				iconError();
+			};
+			img.src = storedimages[part[1]];
+			img.id = part[1];
 			table.appendChild(img);
 		}
 		var b = document.createElement("div");


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A small something for @quotefox as they're incredibly busy atm.

Caches alt click turf icons and turns them into a neat little list. They should no longer fail to display now.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/53913550/123533786-a09aeb80-d6ee-11eb-960a-8fe75b5c4b94.png)

## Changelog
:cl:
fix: statbrowser turf icons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
