### PR TITLE
Restores Synthsteak / Synthmeat Functionality

### DIFF
--- a/code/modules/food_and_drinks/food/snacks/meat.dm
+++ b/code/modules/food_and_drinks/food/snacks/meat.dm
@@ -191,7 +191,7 @@
 	desc = "A synthetic chunk of meat."
 	icon_state = "meatproduct" //growing meat will make it look like a lumpo
 	foodtype = RAW | MEAT //hurr durr chemicals we're harmed in the production of this meat thus its non-vegan.
-	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/meatproduct
+	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/plain/meatproduct
 
 /obj/item/reagent_containers/food/snacks/meat/slab/meatproduct
 	name = "meat product"
@@ -280,7 +280,7 @@
 	bitesize = 4
 	tastes = list("meat" = 1, "wheat" = 1)
 	foodtype = GRAIN
-	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/meatproduct
+	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/plain/meatproduct
 
 /obj/item/reagent_containers/food/snacks/meat/slab/gorilla
 	name = "gorilla meat"
@@ -340,7 +340,7 @@
 /obj/item/reagent_containers/food/snacks/meat/steak/plain
     foodtype = MEAT
 
-/obj/item/reagent_containers/food/snacks/meat/steak/meatproduct
+/obj/item/reagent_containers/food/snacks/meat/steak/plain/meatproduct
     foodtype = MEAT
     icon_state = "meatproduct_steak"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Originally an oversight from the food PR.

This makes it so you can use the steaks created by synthmeat/meatwheat with recipes that use steaks.

## Why It's Good For The Game

bugfix

![image](https://user-images.githubusercontent.com/53913550/123558058-b5b56000-d76a-11eb-80ce-b79929a409d0.png)

## Changelog
:cl:
fix: You can use synthmeat/meatwheat steaks with recipes that use steaks again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
