### PR TITLE
Prevent Portallights from being deepfried?

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -46,7 +46,8 @@ God bless America.
 		/obj/item/reagent_containers/syringe,
 		/obj/item/reagent_containers/food/condiment,
 		/obj/item/storage/part_replacer,
-		/obj/item/his_grace))
+		/obj/item/his_grace,
+		/obj/item/portallight))
 	var/datum/looping_sound/deep_fryer/fry_loop
 
 /obj/machinery/deepfryer/Initialize()

--- a/hyperstation/code/obj/fleshlight.dm
+++ b/hyperstation/code/obj/fleshlight.dm
@@ -164,6 +164,13 @@
 			C.adjustArousalLoss(20)
 			M.adjustArousalLoss(20)
 			M.do_jitter_animation() //make your partner shake too!
+
+			if (M.getArousalLoss() >= 100 && ishuman(M) && prob(5))//Why not have a probability to cum when someone's getting nailed with max arousal?~
+				if(V.is_exposed())	//Oh yea, if vagina is not exposed, the climax will not cause a spill
+					M.mob_climax_outside(V, spillage = TRUE) 
+				else
+					M.mob_climax_outside(V, spillage = FALSE)
+
 			if (C.getArousalLoss() >= 100 && ishuman(C) && C.has_dna())
 				var/mob/living/carbon/human/O = C
 

--- a/modular_citadel/code/modules/arousal/arousal.dm
+++ b/modular_citadel/code/modules/arousal/arousal.dm
@@ -284,7 +284,7 @@
 			setArousalLoss(min_arousal)
 
 
-/mob/living/carbon/human/proc/mob_climax_outside(obj/item/organ/genital/G, mb_time = 30) //This is used for forced orgasms and other hands-free climaxes
+/mob/living/carbon/human/proc/mob_climax_outside(obj/item/organ/genital/G, mb_time = 30, spillage = TRUE) //This is used for forced orgasms and other hands-free climaxes
 	var/total_fluids = 0
 	var/datum/reagents/fluid_source = null
 	var/unable_to_come = FALSE
@@ -310,12 +310,18 @@
 								"<span class='userlove'>You feel yourself about to orgasm.</span>", \
 								"<span class='userlove'>You feel yourself about to orgasm.</span>")
 		if(do_after(src, mb_time, target = src))
-			if(total_fluids > 5)
-				fluid_source.reaction(src.loc, TOUCH, 1, 0)
-			fluid_source.clear_reagents()
-			src.visible_message("<span class='love'>[src] orgasms[istype(src.loc, /turf/open/floor) ? ", spilling onto [src.loc]" : ""], using [p_their()] [G.name]!</span>", \
-								"<span class='userlove'>You climax[istype(src.loc, /turf/open/floor) ? ", spilling onto [src.loc]" : ""] with your [G.name].</span>", \
-								"<span class='userlove'>You climax using your [G.name].</span>")
+			if(spillage)
+				if(total_fluids > 5)
+					fluid_source.reaction(src.loc, TOUCH, 1, 0)
+				fluid_source.clear_reagents()
+				src.visible_message("<span class='love'>[src] orgasms[istype(src.loc, /turf/open/floor) ? ", spilling onto [src.loc]" : ""], with [p_their()] [G.name]!</span>", \
+									"<span class='userlove'>You climax[istype(src.loc, /turf/open/floor) ? ", spilling onto [src.loc]" : ""] with your [G.name].</span>", \
+									"<span class='userlove'>You climax using your [G.name].</span>")
+			else //Else from spillage check, also note subtle text change
+				src.visible_message("<span class='love'>[src] orgasms with [p_their()] [G.name]!</span>", \
+									"<span class='userlove'>You climax with your [G.name].</span>", \
+									"<span class='userlove'>You climax using your [G.name].</span>")
+								
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "orgasm", /datum/mood_event/orgasm)
 			if(G.can_climax)
 				setArousalLoss(min_arousal)
@@ -420,7 +426,7 @@
 					src.visible_message("<span class='love'>[src] climaxes with someone, using [p_their()] [G.name]!</span>", \
 									"<span class='userlove'>You ejaculate with someone, using your [G.name].</span>", \
 									"<span class='userlove'>You have climaxed inside someone, using your [G.name].</span>")
-					to_chat(L, "<span class='userlove'>You feel someone ejeculate inside you.</span>")
+					to_chat(L, "<span class='userlove'>You feel someone ejaculate inside you.</span>")
 
 				SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "orgasm", /datum/mood_event/orgasm)
 				SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "orgasm", /datum/mood_event/orgasm)


### PR DESCRIPTION
Tested and confirmed working. This edit will prevent portallights from being deepfried.

I will leave the decision to either merge or reject this PR to the admin looking into this. This literally took me like five minutes so don't feel bad if you need to kick this if its not aligning to the vision of the server.
(I don't know how to commit so if this doubleposts I apologize)

Edit:
I don't know how the hell to have my commits as separate PRs like the cool kids. 
So what does the portallight and arousal files do?
-If at 100 arousal the used partner will have a 5% chance to orgasm per use
-If the genital used (Vagina in this case) is exposed, orgasm will result in fluids spilled, if NOT, no spillage
-mob_climax_outside now has three arguments, this doesn't seem to affect the rest of the game, the new argument is: spillage = TRUE, it should be self explanatory 
-src.visible_message adjusted to react appropriately. I have a feeling my implementation is FAR from optimal, see "if(spillage)" and onwards in mob_climax_outside in arousal.dm
-minor spelling fix

Seriously if this double barreled PR is not appropriate, tell me, delete it and I will see if I can figure out how to fix it.
