### PR TITLE
Fixes a runtime with hallucinations and a thing about mindbreaker

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -138,7 +138,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 	Show()
 
 /obj/effect/hallucination/simple/Destroy()
-	if(target.client)
+	if(target && target.client)
 		target.client.images.Remove(current_image)
 	active = FALSE
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -200,7 +200,8 @@
 	pH = 11
 
 /datum/reagent/toxin/mindbreaker/on_mob_life(mob/living/carbon/M)
-	M.hallucination += 5
+	if(!M.has_quirk(/datum/quirk/insanity))
+		M.hallucination += 5
 	return ..()
 
 /datum/reagent/toxin/plantbgone


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so mindbreaker toxin will no longer give hallucinations to people that have the insanity trait. Mindbreaker is meant to help them, after all.

(Not a change that's in the upstream)

Also fixes a runtime that is caused by things that have been destroyed trying to trigger hallucinations.

## Why It's Good For The Game

fix good

## Changelog
:cl:
tweak: mindbreaker toxin behavior for people with the insanity trait
fix: a hallucination runtime
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
