### PR TITLE
Fixes "medkit cabinent" typo

### DIFF
--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_medical_and_dinnerware.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_medical_and_dinnerware.dm
@@ -93,7 +93,7 @@
 
 
 /datum/design/medkit
-	name = "Medkit Cabinent"
+	name = "Medkit Cabinet"
 	id = "medkit_cabinet"
 	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(MAT_METAL = 4000)


### PR DESCRIPTION
## About The Pull Request

Fixes a typo.

## Why It's Good For The Game

No one likes typos.

## Changelog
:cl:
Corrects "Medicine Cabinent" to "Medicine Cabinet"
/:cl:


