### PR TITLE
Prevents mapping helpers and baseturf helpers from being clouded

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -21,10 +21,13 @@
 		/obj/effect/particle_effect,
 		/obj/effect/light_emitter/tendril,
 		/obj/effect/collapse,
+		/obj/effect/cloud_collapse,
 		/obj/effect/particle_effect/ion_trails,
 		/obj/effect/dummy/phased_mob,
 		/obj/effect/immovablerod,
-		/obj/effect/crystalline_reentry
+		/obj/effect/crystalline_reentry,
+		/obj/effect/mapping_helpers,
+		/obj/effect/baseturf_helper
 		))
 
 /datum/component/chasm/Initialize(turf/target)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Should probably make sure that the clouds don't eat those, alongside another effect

## Why It's Good For The Game

This is due to a rare scenario where a chasm could swallow the baseturf and mapping helpers, thus breaking the game if it's an important mapping helper, such as docking airlock helpers.

## Changelog
:cl:
add: some more atoms to the chasm blacklist
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
