### PR TITLE
BS Anomaly nerf

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -190,11 +190,11 @@
 /obj/effect/anomaly/bluespace/anomalyEffect()
 	..()
 	for(var/mob/living/M in range(1,src))
-		do_teleport(M, locate(M.x, M.y, M.z), 4, channel = TELEPORT_CHANNEL_BLUESPACE)
+		do_teleport(M, locate(M.x, M.y, M.z), 2, channel = TELEPORT_CHANNEL_BLUESPACE) // distance lowered from 4 to 2
 
 /obj/effect/anomaly/bluespace/Bumped(atom/movable/AM)
 	if(isliving(AM))
-		do_teleport(AM, locate(AM.x, AM.y, AM.z), 8, channel = TELEPORT_CHANNEL_BLUESPACE)
+		do_teleport(AM, locate(AM.x, AM.y, AM.z), 2, channel = TELEPORT_CHANNEL_BLUESPACE) // distance lowered from 8 to 2
 
 /obj/effect/anomaly/bluespace/detonate()
 	var/turf/T = pick(get_area_turfs(impact_area))
@@ -227,6 +227,9 @@
 			for (var/atom/movable/A in urange(12, FROM )) // iterate thru list of mobs in the area
 				if(istype(A, /obj/item/beacon))
 					continue // don't teleport beacons because that's just insanely stupid
+				if(isliving(A))
+					do_teleport(A, locate(A.x, A.y, A.z), 2, channel = TELEPORT_CHANNEL_BLUESPACE)
+					continue // layenia is too dangerous for teleports but having absolutely nothing happen is anticlimactic
 				if(A.anchored)
 					continue
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adjusted bluespace anomalies to be much MUCH less dangerous and, imo, a lot more fun. I really enjoyed testing this.


## Why It's Good For The Game

Layenia is too dangerous for standard bluespace anomalies, but hiding everything under impossibly high chaos vote requirements is effectively deleting them. These changes use the absolute bare minimum teleport distance to maintain a "what just happened?" feeling (distance 1 causes you to walk, distance 2 is a teleport), and keeps the "where'd all my stuff go?" consequence from failing to neutralize the anomaly in time.


## Changelog
:cl:
balance: bluespace anomalies have greatly reduced teleport distance on bump and at proximity
balance: bluespace anomaly detonation teleport distance greatly reduced for living things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
