### PR TITLE
Triples stock of portal boxes

### DIFF
--- a/modular_citadel/code/game/machinery/vending.dm
+++ b/modular_citadel/code/game/machinery/vending.dm
@@ -68,7 +68,7 @@
 				/obj/item/electropack/vibrator/small = 2,
 				/obj/item/electropack/vibrator = 2,
 				/obj/item/fleshlight = 2,
-				/obj/item/storage/box/portallight = 1,
+				/obj/item/storage/box/portallight = 3,
 				)
 	contraband = list(
 				/obj/item/clothing/under/gear_harness = 3,


### PR DESCRIPTION
With the recent update that allows multiple to be worn, people are beginning to hoard them. This makes it a bit more accessible to the public, rather than having to order multiple restock kits that  really are only being used for one item.


:cl:
add: Tripled stock of portal boxes.
/:cl:

