### PR TITLE
Bluespace Anomaly Changes

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1130,6 +1130,27 @@ B --><-- A
 		if (target)
 			return target
 
+/proc/get_safe_random_station_turf_nochasm() //same method as above but with chasm detection
+	for (var/i in 1 to 5)
+		var/list/L = get_area_turfs(pick(GLOB.the_station_areas))
+		var/turf/target
+		while (L.len && !target)
+			var/I = rand(1, L.len)
+			var/turf/T = L[I]
+			if(!T.density)
+				var/clear = TRUE
+				for(var/obj/O in T)
+					if(O.density)
+						clear = FALSE
+						break
+				if(ischasm(T)) //stop right there criminal scum
+					clear = FALSE
+				if(clear)
+					target = T
+			if (!target)
+				L.Cut(I,I+1)
+		if (target)
+			return target
 
 /proc/get_closest_atom(type, list, source)
 	var/closest_atom

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
@@ -297,7 +297,7 @@
 	repeatable = TRUE
 	//property_weights = list("extended" = 1)
 	occurances_max = 2
-	chaos_min = 3.0
+	chaos_min = 1.2
 
 /datum/dynamic_ruleset/event/anomaly_flux
 	name = "Anomaly: Hyper-Energetic Flux"

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -227,6 +227,10 @@
 			for (var/atom/movable/A in urange(12, FROM )) // iterate thru list of mobs in the area
 				if(istype(A, /obj/item/beacon))
 					continue // don't teleport beacons because that's just insanely stupid
+				if(isliving(A))
+					var/turf/L = get_safe_random_station_turf_nochasm() //Safe and cuddly.
+					do_teleport(A, L, forceMove = TRUE, channel = TELEPORT_CHANNEL_BLUESPACE)
+					continue
 				if(A.anchored)
 					continue
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so bluespace anomaly explosions will not cloud people. Ever.

Also pulls their chaos level back down to 1.2 instead of 1 (Should we do 1?)

## Why It's Good For The Game

Better changes I guess?

## Changelog
:cl:
balance: Restored bluespace anomaly chaos level, made them unable to cloud people through the explosion but still be funny.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
