### PR TITLE
Revert "Minor TEG Update" re-capping the TEG power gen to 2MW.

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -89,10 +89,7 @@
 				var/energy_transfer = delta_temperature*hot_air_heat_capacity*cold_air_heat_capacity/(hot_air_heat_capacity+cold_air_heat_capacity)
 
 				var/heat = energy_transfer*(1-efficiency)
-				if(delta_temperature < 16800) // second point where derivative of below function = 1
-					lastgen += LOGISTIC_FUNCTION(500000,0.0009,delta_temperature,10000)
-				else
-					lastgen += delta_temperature + 482102 // value of above function at 16800, or very nearly so
+				lastgen += LOGISTIC_FUNCTION(500000,0.0009,delta_temperature,10000)
 
 				hot_air.temperature = hot_air.temperature - energy_transfer/hot_air_heat_capacity
 				cold_air.temperature = cold_air.temperature + heat/cold_air_heat_capacity


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reverts quotefox/Hyper-Station-13#1157

## Why It's Good For The Game

I see now that uncapping the TEG was not the right approach. We've a variety of engines that have different risks and I'll look into a way to make the TEG's risk/reward properly balanced in a way that doesn't invalidate other departments' credit generation systems.

Even then, with 2MW you still get a decent amount of credits from the TEG, which is still a reliably safe engine. For more than that, you'll have to go a little further and learn other engines by ordering them from cargo. (Yay, department interaction)

Even better, this encourages cargo to have its own engine running if it wants a little extra alongside other things such as plantations/etc, as well as encouraging engineering to have different engines running at the same time / using waste output from said engines to maximize efficiency.

## Changelog
:cl:
balance: TEG capped to 2mw. For now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->



