### PR TITLE
Energy Harvester Nerf

### DIFF
--- a/yogstation/code/modules/power/energyharvester.dm
+++ b/yogstation/code/modules/power/energyharvester.dm
@@ -14,7 +14,7 @@ GLOBAL_LIST_EMPTY(energy_harvesters)
 	throw_speed = 1
 	throw_range = 1
 	materials = list(MAT_METAL=750)
-	var/drain_rate = 100000000
+	var/drain_rate = 10000000
 	var/power_drained = 0
 	var/obj/structure/cable/attached
 	var/datum/looping_sound/generator/soundloop

--- a/yogstation/code/modules/power/energyharvester.dm
+++ b/yogstation/code/modules/power/energyharvester.dm
@@ -1,7 +1,7 @@
 GLOBAL_LIST_EMPTY(energy_harvesters)
 
 /obj/item/energy_harvester
-	desc = "A Device which upon connection to a node, will harvest the energy and send it to engineerless stations in return for credits, derived from a syndicate powersink model. The instructions say to never use more than 4 harvesters at a time."
+	desc = "A Device which upon connection to a node, will harvest the energy and send it to engineerless stations in return for credits, derived from a syndicate powersink model. The instructions say to never use more than 2 harvesters at a time."
 	name = "Energy Harvesting Module"
 	icon_state = "powersink0"
 	icon = 'icons/obj/device.dmi'
@@ -101,7 +101,7 @@ GLOBAL_LIST_EMPTY(energy_harvesters)
 	gpstag = "Energy Harvester"
 
 /obj/item/energy_harvester/proc/overloadCheck()
-	if(LAZYLEN(GLOB.energy_harvesters) > 4)
+	if(LAZYLEN(GLOB.energy_harvesters) > 2)
 		switch(overloadprog)
 			if(0 to 25)
 				if(prob(7))

--- a/yogstation/code/modules/power/energyharvester.dm
+++ b/yogstation/code/modules/power/energyharvester.dm
@@ -14,7 +14,7 @@ GLOBAL_LIST_EMPTY(energy_harvesters)
 	throw_speed = 1
 	throw_range = 1
 	materials = list(MAT_METAL=750)
-	var/drain_rate = 10000000
+	var/drain_rate = 5000000
 	var/power_drained = 0
 	var/obj/structure/cable/attached
 	var/datum/looping_sound/generator/soundloop


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Dumps energy harvester credit gen max to 3k credits per minute, limits them to two, encouraging cargo and other departments to do more things to get credits.

## Why It's Good For The Game

We had a big discussion about this with @Dahlular and in development chat. This is what I'll do for now, until we can make things a little bit more dynamic through persistency.

## Changelog
:cl:
balance: energy harvesters soft limited to 2 and 3k credit/m max
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
