### PR TITLE
Fixes mice spawning and dying in layenia

### DIFF
--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -8,7 +8,7 @@ SUBSYSTEM_DEF(minor_mapping)
 	return ..()
 
 /datum/controller/subsystem/minor_mapping/proc/trigger_migration(num_mice=10)
-	var/list/exposed_wires = find_exposed_wires()
+	var/list/exposed_wires = find_exposed_wires_safetemp()
 
 	var/mob/living/simple_animal/mouse/M
 	var/turf/proposed_turf
@@ -31,6 +31,22 @@ SUBSYSTEM_DEF(minor_mapping)
 		all_turfs += block(locate(1,1,z), locate(world.maxx,world.maxy,z))
 	for(var/turf/open/floor/plating/T in all_turfs)
 		if(is_blocked_turf(T))
+			continue
+		if(locate(/obj/structure/cable) in T)
+			exposed_wires += T
+
+	return shuffle(exposed_wires)
+
+/proc/find_exposed_wires_safetemp()
+	var/list/exposed_wires = list()
+	exposed_wires.Cut()
+	var/list/all_turfs
+	for (var/z in SSmapping.levels_by_trait(ZTRAIT_STATION))
+		all_turfs += block(locate(1,1,z), locate(world.maxx,world.maxy,z))
+	for(var/turf/open/floor/plating/T in all_turfs)
+		if(is_blocked_turf(T))
+			continue
+		if(T.air?.temperature <= T0C) //Don't spawn them in an area where they'll immediately die, pretty please.
 			continue
 		if(locate(/obj/structure/cable) in T)
 			exposed_wires += T


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Creates an alternate function to find exposed wires under safe temperatures and uses that to spawn the roundstart mice and infestation mice.

## Why It's Good For The Game

It's kinda bad to have them 90% of the time spawning outside the station and instantly dying. This fixes the issue reliably without compromising functionality from find_exposed_wires()

## Changelog
:cl:
fix: mice spawning and dying outside the gas station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
