### PR TITLE
Adds Flour and Soymilk to the biogen. Removes Cream from the Biogen.

### DIFF
--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -58,7 +58,7 @@
 	id = "smeat"
 	build_type = BIOGENERATOR
 	materials = list(MAT_BIOMASS = 175)
-	build_path = /obj/item/reagent_containers/food/snacks/meat/slab/meatproduct
+	build_path = /obj/item/reagent_containers/food/snacks/meat/slab/synthmeat
 	category = list("initial", "Food")
 
 /datum/design/ez_nut

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -5,6 +5,14 @@
 //Please be wary to not add inorganic items to the results such as generic glass bottles and metal.
 //as they kind of defeat the design of this feature.
 
+/datum/design/soymilk
+	name = "10u Soymilk"
+	id = "soymilk"
+	build_type = BIOGENERATOR
+	materials = list(MAT_BIOMASS = 20)
+	make_reagents = list(/datum/reagent/consumable/soymilk = 10)
+	category = list("initial","Food")
+
 /datum/design/milk
 	name = "10u Milk"
 	id = "milk"
@@ -13,12 +21,12 @@
 	make_reagents = list(/datum/reagent/consumable/milk = 10)
 	category = list("initial","Food")
 
-/datum/design/cream
-	name = "10u Cream"
-	id = "cream"
+/datum/design/flour
+	name = "10u Flour"
+	id = "flour"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 30)
-	make_reagents = list(/datum/reagent/consumable/cream = 10)
+	materials = list(MAT_BIOMASS = 20)
+	make_reagents = list(/datum/reagent/consumable/flour = 10)
 	category = list("initial","Food")
 
 /datum/design/black_pepper
@@ -50,7 +58,7 @@
 	id = "smeat"
 	build_type = BIOGENERATOR
 	materials = list(MAT_BIOMASS = 175)
-	build_path = /obj/item/reagent_containers/food/snacks/meat/slab/synthmeat
+	build_path = /obj/item/reagent_containers/food/snacks/meat/slab/meatproduct
 	category = list("initial", "Food")
 
 /datum/design/ez_nut


### PR DESCRIPTION
## About The Pull Request

Adds Flour and Soymilk to the biogen. Removes Cream. (It has seemingly no use in botany, and the soda machine in the bar can make it.)

## Why It's Good For The Game

Trays don't currently work with the grinder, and because chefs shouldn't need to bust their ass for the bare minimum to do their job if there's no botanist. They still need plenty more tertiary ingredients for anything fun, this just covers the basics.

The basics being:
Dough
Pastry / Cake Bases (They need sugar from the bar, but that's a non-issue.)
Cheese
Tofu

Any chef can -easily- fill up a biogen themselves with a few harvests, and this helps reduce the micromanagement needed in the kitchen.

## Changelog
:cl:
add: Soymilk and Flour are in the Biogen
del: Removed Cream from Biogen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
