### PR TITLE
Experimental cloning fix

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -186,16 +186,21 @@
 	H.Unconscious(80)
 
 	//only transfer consciousness if the clone isn't experimental
-	if(!experimental)
+	if(experimental)
+		var/list/candidates = pollCandidatesForMob("Do you want to play as [clonename]'s defective clone?", null, null, null, 100, H)
+		if(LAZYLEN(candidates))
+			var/mob/dead/observer/C = pick(candidates)
+			H.key = C.key
+	else
 		clonemind.transfer_to(H)
 
-		if(grab_ghost_when == CLONER_FRESH_CLONE)
-			H.grab_ghost()
-			to_chat(H, "<span class='notice'><b>Consciousness slowly creeps over you as your body regenerates.</b><br><i>So this is what cloning feels like?</i></span>")
+	if(grab_ghost_when == CLONER_FRESH_CLONE)
+		H.grab_ghost()
+		to_chat(H, "<span class='notice'><b>Consciousness slowly creeps over you as your body regenerates.</b><br><i>So this is what cloning feels like?</i></span>")
 
-		if(grab_ghost_when == CLONER_MATURE_CLONE)
-			H.ghostize(TRUE)	//Only does anything if they were still in their old body and not already a ghost
-			to_chat(H.get_ghost(TRUE), "<span class='notice'>Your body is beginning to regenerate in a cloning pod. You will become conscious when it is complete.</span>")
+	if(grab_ghost_when == CLONER_MATURE_CLONE)
+		H.ghostize(TRUE)	//Only does anything if they were still in their old body and not already a ghost
+		to_chat(H.get_ghost(TRUE), "<span class='notice'>Your body is beginning to regenerate in a cloning pod. You will become conscious when it is complete.</span>")
 
 	if(H)
 		H.faction |= factions

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -134,9 +134,12 @@
 	if(mess || attempting)
 		return FALSE
 
-	//only check for clone's mind if it's not experimental cloning
-	if(!experimental)
+	//runtime error protection
+	if(mindref)
 		clonemind = locate(mindref) in SSticker.minds
+
+	//only exit out of cloning with no mind if cloning is not experimental.
+	if(!experimental)
 		if(!istype(clonemind))	//not a mind
 			return FALSE
 		if(!QDELETED(clonemind.current))
@@ -216,12 +219,10 @@
 	attempting = FALSE
 
 	//sizecode stuff, check size of scanned individual to then pass in later. someone should turn size into a dna trait tbh
-	if(mindref)
-		clonemind = locate(mindref) in SSticker.minds
-		if(istype(clonemind))
-			var/mob/living/current = clonemind.current //gets body of current mind
-			if(!isnull(current))
-				size = current.size_multiplier * 100
+	if(istype(clonemind))
+		var/mob/living/current = clonemind.current //gets body of current mind
+		if(!isnull(current))
+			size = current.size_multiplier * 100
 
 	return TRUE
 

--- a/code/game/machinery/exp_cloner.dm
+++ b/code/game/machinery/exp_cloner.dm
@@ -9,6 +9,7 @@
 	internal_radio = FALSE
 
 //Start growing a human clone in the pod!
+/*
 /obj/machinery/clonepod/experimental/growclone(ckey, clonename, ui, se, datum/species/mrace, list/features, factions)
 	if(panel_open)
 		return FALSE
@@ -71,7 +72,7 @@
 		H.suiciding = FALSE
 	attempting = FALSE
 	return TRUE
-
+*/
 
 //Prototype cloning console, much more rudimental and lacks modern functions such as saving records, autocloning, or safety checks.
 /obj/machinery/computer/prototype_cloning
@@ -293,7 +294,29 @@
 		temp = "<font class='bad'>Cloning cycle already in progress.</font>"
 		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 	else
-		pod.growclone(null, mob_occupant.real_name, dna.uni_identity, dna.mutation_index, clone_species, dna.features, mob_occupant.faction)
+
+		//disabled vars from how cloning.dm does it
+		//var/ckey = mob_occupant.ckey
+		var/name = mob_occupant.real_name
+		//var/id = copytext_char(md5(mob_occupant.real_name), 2, 6)
+		//var/UE = dna.unique_enzymes
+		var/mind = null
+		var/UI = dna.uni_identity
+		var/SE = dna.mutation_index
+		var/features = dna.features
+		var/factions = mob_occupant.faction
+		var/list/quirks = list()
+
+		if (!isnull(mob_occupant.mind)) //Save that mind so traitors can continue traitoring after cloning.
+			mind = "[REF(mob_occupant.mind)]"
+
+		for(var/V in mob_occupant.roundstart_quirks)
+			var/datum/quirk/T = V
+			quirks[T.type] = T.clone_data()
+
+		//grows the clone, format;
+		// ckey, clonename, ui, mutation_index, mindref, datum/species/mrace, list/features, factions, list/quirks, experimental = FALSE
+		pod.growclone(null, name, UI, SE, mind, clone_species, features, factions, quirks, TRUE)
 		temp = "[mob_occupant.real_name] => <font class='good'>Cloning data sent to pod.</font>"
 		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 

--- a/code/game/machinery/exp_cloner.dm
+++ b/code/game/machinery/exp_cloner.dm
@@ -8,7 +8,7 @@
 	circuit = /obj/item/circuitboard/machine/clonepod/experimental
 	internal_radio = FALSE
 
-//Start growing a human clone in the pod!
+//Start growing a human clone in the pod! Depreciated and replaced with parent object's growclone method.
 /*
 /obj/machinery/clonepod/experimental/growclone(ckey, clonename, ui, se, datum/species/mrace, list/features, factions)
 	if(panel_open)

--- a/code/game/machinery/exp_cloner.dm
+++ b/code/game/machinery/exp_cloner.dm
@@ -295,11 +295,8 @@
 		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 	else
 
-		//disabled vars from how cloning.dm does it
-		//var/ckey = mob_occupant.ckey
+		//put here for ease of use / ability to change, rather than in the method call to growclone
 		var/name = mob_occupant.real_name
-		//var/id = copytext_char(md5(mob_occupant.real_name), 2, 6)
-		//var/UE = dna.unique_enzymes
 		var/mind = null
 		var/UI = dna.uni_identity
 		var/SE = dna.mutation_index


### PR DESCRIPTION
## About The Pull Request
Authored by haha26 and 777joshua777

Changes experimental cloning to use parent method rather than its own growclone method for code reusability and ease of change. In so doing fixes syncing genitals and quirks to cloned body.
Updated cloning.dm to support this by adding boolean flag to method, and if checks on said flag to adjust functionality accordingly.
Fixed experimental cloning not being able to properly reflect sizecode, size now ported to cloned bodies.

## Why It's Good For The Game

Fixes genitalia, quirks, and size not being properly carried over to cloned bodies. Reduces stratification / spaghettification of code by reducing the number of methods similar machines use; changes in one reflect changes in other.

## Changelog
:cl: haha26 and 777joshua777
del: Removed old growclone method from exp_cloner.dm, commented out for future reference and depreciated
fix: Genitals are copied to experimentally cloned body.
fix: Size is copied to experimentally cloned body.
fix: Quirks are copied to experimentally cloned body.
refactor: exp_cloner.dm now uses parent object's growclone method so changes in how clones are made and what mobs have are reflected in experimental cloning
/:cl:
