### PR TITLE
Client/Login loss prevention - Cool down, buddy.

### DIFF
--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -77,7 +77,9 @@
 	var/datum/action/innate/imaginary_hide/hide
 
 /mob/camera/imaginary_friend/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	greet()
 	Show()
 

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -138,7 +138,9 @@
 	..()
 
 /mob/living/split_personality/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	to_chat(src, "<span class='notice'>As a split personality, you cannot do anything but observe. However, you will eventually gain control of your body, switching places with the current personality.</span>")
 	to_chat(src, "<span class='warning'><b>Do not commit suicide or put the body in a deadly position. Behave like you care about it as much as the owner.</b></span>")
 
@@ -214,7 +216,9 @@
 	var/codeword
 
 /mob/living/split_personality/traitor/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	to_chat(src, "<span class='notice'>As a brainwashed personality, you cannot do anything yet but observe. However, you may gain control of your body if you hear the special codeword, switching places with the current personality.</span>")
 	to_chat(src, "<span class='notice'>Your activation codeword is: <b>[codeword]</b></span>")
 	if(objective)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -68,6 +68,8 @@
 
 	var/list/learned_recipes //List of learned recipe TYPES.
 
+	var/reEnterCooldown = 0 //This was created to prevent players from deleting their own bodies when the server can't keep up with them and they're trying to re-enter/exit their corpse too quickly.
+
 /datum/mind/New(var/key)
 	src.key = key
 	soulOwner = src

--- a/code/modules/antagonists/blob/blob/overmind.dm
+++ b/code/modules/antagonists/blob/blob/overmind.dm
@@ -163,7 +163,9 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	return ..()
 
 /mob/camera/blob/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	to_chat(src, "<span class='notice'>You are the overmind!</span>")
 	blob_help()
 	update_health_hud()

--- a/code/modules/antagonists/clockcult/clock_mobs.dm
+++ b/code/modules/antagonists/clockcult/clock_mobs.dm
@@ -28,7 +28,9 @@
 	update_values()
 
 /mob/living/simple_animal/hostile/clockwork/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	add_servant_of_ratvar(src, TRUE)
 	to_chat(src, playstyle_string)
 	if(GLOB.ratvar_approaches)

--- a/code/modules/antagonists/clockcult/clock_mobs/_eminence.dm
+++ b/code/modules/antagonists/clockcult/clock_mobs/_eminence.dm
@@ -53,7 +53,9 @@
 	return TRUE
 
 /mob/camera/eminence/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	add_servant_of_ratvar(src, TRUE)
 	var/datum/antagonist/clockcult/C = mind.has_antag_datum(/datum/antagonist/clockcult,TRUE)
 	if(C && C.clock_team)

--- a/code/modules/antagonists/devil/true_devil/_true_devil.dm
+++ b/code/modules/antagonists/devil/true_devil/_true_devil.dm
@@ -51,7 +51,9 @@
 	real_name = name
 
 /mob/living/carbon/true_devil/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	var/datum/antagonist/devil/devilinfo = mind.has_antag_datum(/datum/antagonist/devil)
 	devilinfo.greet()
 	mind.announce_objectives()

--- a/code/modules/antagonists/disease/disease_mob.dm
+++ b/code/modules/antagonists/disease/disease_mob.dm
@@ -78,7 +78,9 @@ the new instance inside the host to be updated to the template's stats.
 			S.overmind = null
 
 /mob/camera/disease/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	if(freemove)
 		to_chat(src, "<span class='warning'>You have [DisplayTimeText(freemove_end - world.time)] to select your first host. Click on a human to select your host.</span>")
 

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -86,7 +86,9 @@
 	name = built_name
 
 /mob/living/simple_animal/revenant/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	to_chat(src, "<span class='deadsay'><span class='big bold'>You are a revenant.</span></span>")
 	to_chat(src, "<b>Your formerly mundane spirit has been infused with alien energies and empowered into a revenant.</b>")
 	to_chat(src, "<b>You are not dead, not alive, but somewhere in between. You are capable of limited interaction with both worlds.</b>")

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -116,6 +116,8 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 
 /mob/dead/Login()
 	. = ..()
+	if(!. || !client)
+		return FALSE
 	var/turf/T = get_turf(src)
 	if (isturf(T))
 		update_z(T.z)

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -1,4 +1,6 @@
 /mob/dead/new_player/Login()
+	if(!client)
+		return
 	if(CONFIG_GET(flag/use_exp_tracking))
 		client.set_exp_from_db()
 		client.set_db_player_flags()
@@ -7,7 +9,9 @@
 		mind.active = 1
 		mind.current = src
 
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 
 	var/motd = global.config.motd
 	if(motd)

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -1,5 +1,7 @@
 /mob/dead/observer/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 
 	ghost_accs = client.prefs.ghost_accs
 	ghost_others = client.prefs.ghost_others

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -360,6 +360,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(mind.current.key && mind.current.key[1] != "@")	//makes sure we don't accidentally kick any clients
 		to_chat(usr, "<span class='warning'>Another consciousness is in your body...It is resisting you.</span>")
 		return
+	if(mind.reEnterCooldown > world.time - 20) //cooldown to avoid body deletion. The server can be slower than players clicking this too fast.
+		to_chat(src, "<span class='warning'>You are doing this too fast. Stay still and try this again in a few seconds.</span>")
+		return
+	mind.reEnterCooldown = world.time
 	client.change_view(CONFIG_GET(string/default_view))
 	SStgui.on_transfer(src, mind.current) // Transfer NanoUIs.
 	mind.current.key = key

--- a/code/modules/mob/living/carbon/alien/login.dm
+++ b/code/modules/mob/living/carbon/alien/login.dm
@@ -1,4 +1,6 @@
 /mob/living/carbon/alien/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	AddInfectionImages()
 	return

--- a/code/modules/mob/living/carbon/human/login.dm
+++ b/code/modules/mob/living/carbon/human/login.dm
@@ -1,5 +1,7 @@
 /mob/living/carbon/human/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	if(src.martial_art == default_martial_art && mind.stored_martial_art) //If the mind has a martial art stored and the body has the default one.
 		src.mind.stored_martial_art.teach(src) //Running teach so that it deals with help verbs.
 	else if(src.martial_art != default_martial_art && src.martial_art != mind.stored_martial_art) //If the body has a martial art which is not the default one and is not stored in the mind.

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -1,5 +1,7 @@
 /mob/living/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	//Mind updates
 	sync_mind()
 	mind.show_memory(src, 0)

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -1,5 +1,7 @@
 /mob/living/silicon/ai/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	if(stat != DEAD)
 		for(var/each in GLOB.ai_status_displays) //change status
 			var/obj/machinery/status_display/ai/O = each

--- a/code/modules/mob/living/silicon/login.dm
+++ b/code/modules/mob/living/silicon/login.dm
@@ -7,4 +7,4 @@
 		var/datum/antagonist/bloodsucker/V = mind.has_antag_datum(/datum/antagonist/bloodsucker)
 		if(V)
 			mind.remove_antag_datum(V)
-	..()
+	return ..()

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -163,14 +163,15 @@
 	return TRUE
 
 /mob/living/silicon/pai/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	usr << browse_rsc('html/paigrid.png')			// Go ahead and cache the interface resources as early as possible
-	if(client)
-		client.perspective = EYE_PERSPECTIVE
-		if(holoform)
-			client.eye = src
-		else
-			client.eye = card
+	client.perspective = EYE_PERSPECTIVE
+	if(holoform)
+		client.eye = src
+	else
+		client.eye = card
 
 /mob/living/silicon/pai/get_status_tab_items()
 	. += ..()

--- a/code/modules/mob/living/silicon/robot/login.dm
+++ b/code/modules/mob/living/silicon/robot/login.dm
@@ -1,5 +1,7 @@
 
 /mob/living/silicon/robot/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	regenerate_icons()
 	show_laws(0)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -957,6 +957,8 @@ Pass a positive integer as an argument to override a bot's default speed.
 
 /mob/living/simple_animal/bot/Login()
 	. = ..()
+	if(!. || !client)
+		return FALSE
 	access_card.access += player_access
 	diag_hud_set_botmode()
 

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -64,7 +64,9 @@
 		CR.button.moved = "6:[pos],4:-2"
 
 /mob/living/simple_animal/hostile/construct/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	to_chat(src, playstyle_string)
 
 /mob/living/simple_animal/hostile/construct/examine(mob/user)

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -130,7 +130,9 @@
 	return ..()
 
 /mob/living/simple_animal/drone/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	check_laws()
 
 	if(flavortext)

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -37,7 +37,9 @@
 	hidden_uplink.telecrystals = 10
 
 /mob/living/simple_animal/drone/syndrone/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	to_chat(src, "<span class='notice'>You can kill and eat other drones to increase your health!</span>" )
 
 /mob/living/simple_animal/drone/syndrone/badass
@@ -149,7 +151,9 @@
 	verbs -= /mob/living/simple_animal/drone/verb/drone_ping
 
 /mob/living/simple_animal/drone/cogscarab/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	add_servant_of_ratvar(src, TRUE, GLOB.servants_active)
 	to_chat(src,"<b>You yourself are one of these servants, and will be able to utilize almost anything they can[GLOB.ratvar_awakens ? "":", <i>excluding a clockwork slab</i>"].</b>") // this can't go with flavortext because i'm assuming it requires them to be ratvar'd
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -70,7 +70,9 @@
 			humanize_spider(ghost)
 
 /mob/living/simple_animal/hostile/poison/giant_spider/Login()
-	..()
+	. = ..()
+	if(!. || !client)
+		return FALSE
 	if(directive)
 		to_chat(src, "<span class='notice'>Your mother left you a directive! Follow it at all costs.</span>")
 		to_chat(src, "<span class='spider'><b>[directive]</b></span>")
@@ -490,6 +492,8 @@
 
 /mob/living/simple_animal/hostile/poison/giant_spider/Login()
 	. = ..()
+	if(!. || !client)
+		return FALSE
 	GLOB.spidermobs[src] = TRUE
 
 /mob/living/simple_animal/hostile/poison/giant_spider/Destroy()

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -1,4 +1,6 @@
 /mob/Login()
+	if(!client)
+		return FALSE
 	GLOB.player_list |= src
 	lastKnownIP	= client.address
 	computer_id	= client.computer_id
@@ -16,6 +18,9 @@
 	next_move = 1
 
 	..()
+
+	if(!client)
+		return FALSE
 
 	reset_perspective(loc)
 
@@ -56,3 +61,4 @@
 	log_message("Client [key_name(src)] has taken ownership of mob [src]([src.type])", LOG_OWNERSHIP)
 	SEND_SIGNAL(src, COMSIG_MOB_CLIENT_LOGIN, client)
 
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

An issue that's been with us for quite some time is client loss during the login proc. To circumvent this and greatly diminish its occurrence, I've changed the way login works slightly and also added a cooldown for re-entering one's body while being a ghost, which was a guaranteed desync if the client was moving.

TL;DR
Pulls https://github.com/tgstation/tgstation/pull/50073 but slightly modified.

I haven't fully tested this on every possible occasion but with what I have tried so far, it works.

## Why It's Good For The Game

lobby boot bad

## Changelog
:cl:
tweak: login related procs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
