### PR TITLE
Pumpkin Head Dullahan Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -35,7 +35,7 @@
 		if(pumpkin)//Pumpkinhead!
 			head.animal_origin = 100
 			head.icon = 'icons/obj/clothing/hats.dmi'
-			head.icon_state = "hardhat1_pumpkin_j"
+			head.icon_state = "hardhat1_pumpkin"
 			head.custom_head = TRUE
 		head.drop_limb()
 		if(!QDELETED(head)) //drop_limb() deletes the limb if it's no drop location and dummy humans used for rendering icons are located in nullspace. Do the math.


### PR DESCRIPTION

## About The Pull Request

For a good while the Pumpkin Head Dullahan species was missing its proper head sprite, instead showing a random hat.

![image](https://user-images.githubusercontent.com/46802162/136819295-3c556a47-9039-4185-9d39-545c86ea806b.png)
![image](https://user-images.githubusercontent.com/46802162/136819320-0cd1dbc2-fdea-4b47-877f-d1c3ea76c8de.png)

Now the species works as intended.

## Why It's Good For The Game

Halloween race and Pumpkin smashing good.

## Changelog
:cl:
Fix: Pumpkin Head Dullahan sprite fixed.
/:cl:

