### PR TITLE
Removes Some Xenobio Effects

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -710,8 +710,8 @@ datum/status_effect/stabilized/blue/on_remove()
 /datum/status_effect/stabilized/cerulean
 	id = "stabilizedcerulean"
 	colour = "cerulean"
-	var/mob/living/clone
-
+	//var/mob/living/clone
+/*
 /datum/status_effect/stabilized/cerulean/on_apply()
 	var/typepath = owner.type
 	clone = new typepath(owner.loc)
@@ -743,7 +743,7 @@ datum/status_effect/stabilized/blue/on_remove()
 		clone.visible_message("<span class='warning'>[clone] dissolves into a puddle of goo!</span>")
 		clone.unequip_everything()
 		qdel(clone)
-
+*/
 /datum/status_effect/stabilized/pyrite
 	id = "stabilizedpyrite"
 	colour = "pyrite"
@@ -869,12 +869,12 @@ datum/status_effect/stabilized/blue/on_remove()
 	id = "stabilizedoil"
 	colour = "oil"
 	examine_text = "<span class='warning'>SUBJECTPRONOUN smells of sulfer and oil!</span>"
-
+/*
 /datum/status_effect/stabilized/oil/tick()
 	if(owner.stat == DEAD)
 		explosion(get_turf(owner),1,2,4,flame_range = 5)
 	return ..()
-
+*/
 /datum/status_effect/stabilized/black
 	id = "stabilizedblack"
 	colour = "black"

--- a/code/modules/research/xenobiology/crossbreeding/burning.dm
+++ b/code/modules/research/xenobiology/crossbreeding/burning.dm
@@ -239,7 +239,7 @@ Burning extracts:
 
 /obj/item/slimecross/burning/oil
 	colour = "oil"
-
+/*
 /obj/item/slimecross/burning/oil/do_effect(mob/user)
 	user.visible_message("<span class='danger'>[src] begins to shake with rapidly increasing force!</span>")
 	addtimer(CALLBACK(src, .proc/boom), 50)
@@ -247,7 +247,7 @@ Burning extracts:
 /obj/item/slimecross/burning/oil/proc/boom()
 	explosion(get_turf(src), 2, 4, 4) //Same area as normal oils, but increased high-impact values by one each, then decreased light by 2.
 	qdel(src)
-
+*/
 /obj/item/slimecross/burning/black
 	colour = "black"
 

--- a/code/modules/research/xenobiology/crossbreeding/charged.dm
+++ b/code/modules/research/xenobiology/crossbreeding/charged.dm
@@ -199,7 +199,7 @@ Charged extracts:
 
 /obj/item/slimecross/charged/oil
 	colour = "oil"
-
+/*
 /obj/item/slimecross/charged/oil/do_effect(mob/user)
 	user.visible_message("<span class='danger'>[src] begins to shake with rapidly increasing force!</span>")
 	addtimer(CALLBACK(src, .proc/boom), 50)
@@ -207,7 +207,7 @@ Charged extracts:
 /obj/item/slimecross/charged/oil/proc/boom()
 	explosion(get_turf(src), 3, 2, 1) //Much smaller effect than normal oils, but devastatingly strong where it does hit.
 	qdel(src)
-
+*/
 /obj/item/slimecross/charged/black
 	colour = "black"
 

--- a/code/modules/research/xenobiology/crossbreeding/chilling.dm
+++ b/code/modules/research/xenobiology/crossbreeding/chilling.dm
@@ -132,9 +132,9 @@ Chilling extracts:
 
 /obj/item/slimecross/chilling/bluespace
 	colour = "bluespace"
-	var/list/allies = list()
-	var/active = FALSE
-
+	//var/list/allies = list()
+	//var/active = FALSE
+/*
 /obj/item/slimecross/chilling/bluespace/afterattack(atom/target, mob/user, proximity)
 	if(!proximity || !isliving(target) || active)
 		return
@@ -168,7 +168,7 @@ Chilling extracts:
 				S.interrupted = TRUE
 				M.remove_status_effect(S)
 	..()
-
+*/
 /obj/item/slimecross/chilling/sepia
 	colour = "sepia"
 	var/list/allies = list()
@@ -262,7 +262,7 @@ Chilling extracts:
 
 /obj/item/slimecross/chilling/oil
 	colour = "oil"
-
+/*
 /obj/item/slimecross/chilling/oil/do_effect(mob/user)
 	user.visible_message("<span class='danger'>[src] begins to shake with muted intensity!</span>")
 	addtimer(CALLBACK(src, .proc/boom), 50)
@@ -270,7 +270,7 @@ Chilling extracts:
 /obj/item/slimecross/chilling/oil/proc/boom()
 	explosion(get_turf(src), -1, -1, 10, 0) //Large radius, but mostly light damage, and no flash.
 	qdel(src)
-
+*/
 /obj/item/slimecross/chilling/black
 	colour = "black"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Disables some lines of code which are to do with xenobio extracts. While they are neat on paper, I don't imagine why players may wanna toss bombs around or teleport everyone on-station to them; let alone a scientist on a furry ERP server. I was considering the same for stabilized light pink and stabilized red, but they do have a good use for scientists who may want to get to anomalies fast. These however, just serve no purpose for the job they line under. We're not a traditional SS13 server.
Xenobio as a whole is very, very dated and is due a replacement in some time. We'll get around to that soon.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less griefy, banbait mechanics that players may accidentally stumble across
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: a bunch of extract effects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
