### PR TITLE
Backgrounds and GIRTH, Preference Menu

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -140,7 +140,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		"cock_length" = 6,
 		"belly_size" = 1,
 		"butt_size" = 1,
-		"cock_girth_ratio" = COCK_GIRTH_RATIO_DEF,
+		"cock_girth_ratio" = 0.25,
 		"cock_color" = "fff",
 		"has_sheath" = FALSE,
 		"sheath_color" = "fff",
@@ -434,7 +434,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>Custom Species Name:</b><a style='display:block;width:100px' href='?_src_=prefs;preference=custom_species;task=input'>[custom_species ? custom_species : "None"]</a><BR>"
 			dat += "<a style='display:block;width:100px' href='?_src_=prefs;preference=all;task=random'>Random Body</A><BR>"
 			dat += "<b>Always Random Body:</b><a href='?_src_=prefs;preference=all'>[be_random_body ? "Yes" : "No"]</A><BR>"
-			//dat += "<br><b>Cycle background:</b><a style='display:block;width:100px' href='?_src_=prefs;preference=cycle_bg;task=input'>[bgstate]</a><BR>"
+			dat += "<br><b>Cycle background:</b><a style='display:block;width:100px' href='?_src_=prefs;preference=cycle_bg;task=input'>[bgstate]</a><BR>"
 
 			var/use_skintones = pref_species.use_skintones
 			if(use_skintones)
@@ -845,6 +845,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						dat += "<span style='border: 1px solid #161616; background-color: #[features["cock_color"]];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=cock_color;task=input'>Change</a><br>"
 					dat += "<b>Penis Shape:</b> <a style='display:block;width:120px' href='?_src_=prefs;preference=cock_shape;task=input'>[features["cock_shape"]]</a>"
 					dat += "<b>Penis Length:</b> <a style='display:block;width:120px' href='?_src_=prefs;preference=cock_length;task=input'>[features["cock_length"]] inch(es)</a>"
+					dat += "<b>Girth Ratio:</b> <a style='display:block;width:50px' href='?_src_=prefs;preference=cock_girth_ratio;task=input'>[features["cock_girth_ratio"]]</a>"
 					dat += "<b>Has Testicles:</b><a style='display:block;width:50px' href='?_src_=prefs;preference=has_balls'>[features["has_balls"] == TRUE ? "Yes" : "No"]</a>"
 					if(features["has_balls"])
 						if(pref_species.use_skintones && features["genitals_use_skintone"] == TRUE)
@@ -2252,6 +2253,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/new_length = input(user, "Penis length in inches:\n([COCK_SIZE_MIN]-[COCK_SIZE_MAX]) Your sprite size will affect your length examine text!\n(When 6in, 50%->3in, 200%->12in)", "Character Preference") as num|null
 					if(new_length)
 						features["cock_length"] = max(min( round(text2num(new_length)), COCK_SIZE_MAX),COCK_SIZE_MIN)
+
+				if("cock_girth_ratio")
+					var/new_girth = input(user, "Penis to girth ratio:\n([COCK_GIRTH_RATIO_MIN]-[COCK_GIRTH_RATIO_MAX]) This will affect your girth examine text in relation to length!\n(Whole numbers become fractions 25->.25, 30->.3)", "Character Preference") as num|null
+					if(new_girth)
+						features["cock_girth_ratio"] = (max(min( round(text2num(new_girth)), 42),15))/100
 
 				if("balls_size")
 					var/new_balls_size = input(user, "Testicle circumference in inches:\n([BALLS_SIZE_MIN]-[BALLS_SIZE_MAX])", "Character Preference") as num|null


### PR DESCRIPTION
## About The Pull Request

Ended up getting backgrounds back so you can see the character you have on more than just a black hexcode #000000 background (for some reason it was still in the code but noted out? // don't know if it was a typo or intended).

Also provided a new selection for the penis, along with length you have girth, default is .25 can change it from the thinnest .15 to .42 being EXTRA THICC (by typing in whole numbers then dividing by 100 to get that fraction, 25 goes to .25 for example.)

## Why It's Good For The Game

Gives more variety for horny because seeing numbers makes me and some others go :eyes: , and a different perspective with the background in character creation to make it easier looking at characters using darker shades of colors.

## Changelog
:cl:
add: Girth ratio choice to penis in preferences
code: Placed the background system back in play as it was // noted out or something
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
