### PR TITLE
Micro Reimplementation

### DIFF
--- a/code/__DEFINES/citadel_defines.dm
+++ b/code/__DEFINES/citadel_defines.dm
@@ -72,7 +72,7 @@
 #define BREASTS_SIZE_IMPOSSIBLE		30
 
 //Bodysize Limits
-#define MIN_BODYSIZE		50
+#define MIN_BODYSIZE		25
 #define MAX_BODYSIZE		200
 
 #define BREASTS_SIZE_MIN 	BREASTS_SIZE_A


### PR DESCRIPTION
## About The Pull Request

Micros are now once again creatable.
What this does is simply return the original minimum size to 25%, rather than 50%.
As is, it's a foot and some at minimum with this change, rather than about three feet prior. Of course, the downsides of reduced height are pretty heavy, and still apply. Even more so than it did at 50%.

## Why It's Good For The Game

Having character creations / potential characters locked behind a game mechanic (_especially one not available until later into the round_) is a yikes. It stifles creativity, prevents players from creating characters they'd wish and is ultimately just not good for RP overall.
If such were possible without an instant denial, I'd go a step further and rework size entirely, permitting the creation of proper micros. This will have to do in absence of such, however.

## Changelog
:cl:
tweak: Once more permits the creation of very, very small characters.
/:cl: