### PR TITLE
Animal blacklist update for random sentience

### DIFF
--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -1,13 +1,14 @@
 /var/list/blacklisted_sentient_animals = typecacheof(list(
-	/mob/living/simple_animal/slime,
-	/mob/living/simple_animal/hostile/megafauna,
-	/mob/living/simple_animal/hostile/blob,
-	/mob/living/simple_animal/jacq,
-	/mob/living/simple_animal/holodeck_monkey,
 	/mob/living/simple_animal/astral,
+	/mob/living/simple_animal/bot/mulebot,
 	/mob/living/simple_animal/butterfly,
+	/mob/living/simple_animal/holodeck_monkey,
+	/mob/living/simple_animal/hostile/blob,
 	/mob/living/simple_animal/hostile/boss/paper_wizard,
-	/mob/living/simple_animal/hostile/poison/bees))
+	/mob/living/simple_animal/hostile/megafauna,
+	/mob/living/simple_animal/hostile/poison/bees,
+	/mob/living/simple_animal/jacq,
+	/mob/living/simple_animal/slime))
 
 /datum/round_event_control/sentience
 	name = "Random Human-level Intelligence"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Blacklists mulebots, butterflies, paper wizards and bees from random animal sentience. Also organizes the list alphabetically.

## Why It's Good For The Game

Butterflies will always be stuck, bees can also just be a permastuck sentience, mulebots cannot do their functions anymore, and paper wizards are boss mobs. Let's push these out, shall we?

## Changelog
:cl:
tweak: More additions to the random animal sentience type blacklist.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
