### PR TITLE
The PR nobody asked for - Coconut Cannons

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1921,6 +1921,20 @@ datum/uplink_item/stealthy_weapons/taeclowndo_shoes
 	item = /obj/item/gun/energy/emitter
 	restricted_roles = list("Chief Engineer", "Station Engineer", "Atmospheric Technician")
 
+/datum/uplink_item/role_restricted/coconut_cannon
+	name = "Coconut Cannon"
+	desc = "A coconut cannon for botanists. Doesn't need gas and can hold up to 50 coconuts."
+	cost = 5
+	item = /obj/item/pneumatic_cannon/coconut
+	restricted_roles = list("Botanist")
+
+/datum/uplink_item/role_restricted/scharge_coconut_cannon
+	name = "Self-Charging Coconut Cannon"
+	desc = "A special coconut cannon for botanists, this one can hold up to 20 coconuts and automatically fabricates one every two seconds!"
+	cost = 10
+	item = /obj/item/pneumatic_cannon/coconut/selfcharge
+	restricted_roles = list("Botanist")
+
 // Pointless
 /datum/uplink_item/badass
 	category = "(Pointless) Badassery"

--- a/hyperstation/code/game/objects/items/coconutcannon.dm
+++ b/hyperstation/code/game/objects/items/coconutcannon.dm
@@ -1,0 +1,31 @@
+/obj/item/reagent_containers/food/snacks/grown/coconut/hardened //Exclusively used by the selfcharging version
+	name = "hardened coconut"
+	desc = "just like a regular coconut, except this one was probably sitting in a freezer too."
+	force = 5
+	throwforce = 8
+
+/obj/item/pneumatic_cannon/coconut //Basically almost a complete mirror of the pie cannon.
+	name = "coconut cannon"
+	desc = "Co co nut."
+	force = 10
+	gasPerThrow = 0
+	pressureSetting = 2 //bonk
+	checktank = FALSE
+	range_multiplier = 3
+	fire_mode = PCANNON_FIFO
+	throw_amount = 1
+	maxWeightClass = 180	//60 coconuts.
+	clumsyCheck = FALSE
+	var/static/list/coconut_typecache = typecacheof(/obj/item/reagent_containers/food/snacks/grown/coconut)
+
+/obj/item/pneumatic_cannon/coconut/Initialize()
+	. = ..()
+	allowed_typecache = coconut_typecache
+
+/obj/item/pneumatic_cannon/coconut/selfcharge
+	desc = "Co co nut. This one seems to have an integrated bluespace coconut self-charging device."
+	automatic = TRUE
+	selfcharge = TRUE
+	pressureSetting = 2	//bonk
+	charge_type = /obj/item/reagent_containers/food/snacks/grown/coconut/hardened
+	maxWeightClass = 60	//20 coconuts.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3092,6 +3092,7 @@
 #include "hyperstation\code\datums\weather\oxygen_rain.dm"
 #include "hyperstation\code\game\machinery\lore_terminal.dm"
 #include "hyperstation\code\game\objects\railings.dm"
+#include "hyperstation\code\game\objects\items\coconutcannon.dm"
 #include "hyperstation\code\game\objects\items\cosmetics.dm"
 #include "hyperstation\code\game\objects\items\storage\big_bag.dm"
 #include "hyperstation\code\game\objects\structures\bench.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Basically mirrors of the clown's pie cannon and self charging pie cannon, it comes in two different variants for the botanist's traitor uplink. One which can hold up to 60 varied different types of coconuts (much like the regular piecannon can hold pies) and another one which self charges with a default coconut that deals a little more damage upon a successful bonk.

![image](https://user-images.githubusercontent.com/53913550/139141966-cfd1525b-4414-49c5-b00e-e49a5afae32b.png)

## Why It's Good For The Game

There's an actually surprising amount of code involving coconuts in this codebase, you can even turn them into reagent bombs or straight out improvised pipebombs. I think botanists would get a kick out of this.

## Changelog
:cl:
add: coconut cannon variants
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
