### PR TITLE
No more 2D Girth

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -25,7 +25,7 @@
 	to_chat(C, "[info_text]")
 	C.skin_tone = "albino"
 	C.update_body(0)
-	var/obj/effect/proc_holder/spell/targeted/shapeshift/bat/B = new
+	var/obj/effect/proc_holder/spell/targeted/shapeshift/bat/vampire/B = new
 	C.AddSpell(B)
 
 /datum/species/vampire/on_species_loss(mob/living/carbon/C)
@@ -33,7 +33,7 @@
 	if(C.mind)
 		for(var/S in C.mind.spell_list)
 			var/obj/effect/proc_holder/spell/S2 = S
-			if(S2.type == /obj/effect/proc_holder/spell/targeted/shapeshift/bat)
+			if(S2.type == /obj/effect/proc_holder/spell/targeted/shapeshift/bat/vampire)
 				C.mind.spell_list.Remove(S2)
 				qdel(S2)
 
@@ -135,6 +135,9 @@
 	var/ventcrawl_nude_only = TRUE
 	var/transfer_name = TRUE
 
+/obj/effect/proc_holder/spell/targeted/shapeshift/bat/vampire
+	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat/vampire
+
 /obj/effect/proc_holder/spell/targeted/shapeshift/bat/Shapeshift(mob/living/caster)			//cit change
 	var/obj/shapeshift_holder/H = locate() in caster
 	if(H)
@@ -147,6 +150,20 @@
 		var/mob/living/simple_animal/SA = H
 		if(ventcrawl_nude_only && length(caster.get_equipped_items(include_pockets = TRUE)))
 			SA.ventcrawler = FALSE
+	if(transfer_name)
+		H.name = caster.name
+
+	clothes_req = 0
+	human_req = 0
+
+/obj/effect/proc_holder/spell/targeted/shapeshift/bat/vampire/Shapeshift(mob/living/caster)			//cit change
+	var/obj/shapeshift_holder/H = locate() in caster
+	if(H)
+		to_chat(caster, "<span class='warning'>You're already shapeshifted!</span>")
+		return
+
+	var/mob/living/shape = new shapeshift_type(caster.loc)
+	H = new(shape,src,caster)
 	if(transfer_name)
 		H.name = caster.name
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -49,3 +49,6 @@
 	emote_see = list("is ready to law down the law.", "flaps about with an air of authority.")
 	response_help = "respects the authority of"
 	gold_core_spawnable = FRIENDLY_SPAWN
+
+/mob/living/simple_animal/hostile/retaliate/bat/vampire //Too many people use this to vent into places they shouldn't, *cough cough* armory
+	ventcrawler = VENTCRAWLER_NONE

--- a/modular_citadel/code/modules/arousal/organs/penis.dm
+++ b/modular_citadel/code/modules/arousal/organs/penis.dm
@@ -33,6 +33,9 @@
 		var/obj/item/organ/genital/penis/P = o.getorganslot("penis")
 		to_chat(o, "<span class='warning'>You feel your tallywacker shrinking away from your body as your groin flattens out!</b></span>")
 		P.Remove(o)
+	if(girth_ratio == null)
+		girth_ratio = COCK_GIRTH_RATIO_DEF
+		o.update_genitals()
 	switch(round(cached_length))
 		if(0 to 4) //If modest size
 			length = cached_length


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so that way if someone has a null variable in the dick code, it sets it to the default  girth, because 2D penis is hard to look at.

Also gave vampire a new bat datum, no ventcrawling into the armory folks.

## Why It's Good For The Game

Qaulity of life

## Changelog
:cl:
add: A new bat that can't ventcrawl for vampires
add: A spell that ties in with the new bat
fix: Girth (I think)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
