### PR TITLE
[s] Rod depletion easter egg.

### DIFF
--- a/hyperstation/code/modules/power/reactor/fuel_rods.dm
+++ b/hyperstation/code/modules/power/reactor/fuel_rods.dm
@@ -40,6 +40,12 @@
 				if("plutonium")
 					R = new /obj/item/twohanded/required/fuel_rod/plutonium(loc)
 					R.depletion = depletion
+					if(prob(10))
+						R.name = "Plush-239 Fuel Rod"
+						R.desc = "Kinaris would like to remind you that it is not liable for any permanent radioactive damage done to its employees."
+						R.icon = 'hyperstation/icons/obj/plushes.dmi'
+						R.icon_state = "chemlight"
+						R.fuel_power = 0.25 //Funny easter egg, slightly more powerful too.
 				if("depleted")
 					if(fuel_power < 10)
 						fuel_power = 0

--- a/hyperstation/code/modules/power/reactor/fuel_rods.dm
+++ b/hyperstation/code/modules/power/reactor/fuel_rods.dm
@@ -40,7 +40,7 @@
 				if("plutonium")
 					R = new /obj/item/twohanded/required/fuel_rod/plutonium(loc)
 					R.depletion = depletion
-					if(prob(10))
+					if(prob(1))
 						R.name = "Plush-239 Fuel Rod"
 						R.desc = "Kinaris would like to remind you that it is not liable for any permanent radioactive damage done to its employees."
 						R.icon = 'hyperstation/icons/obj/plushes.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

10% chance on depletion for a uranium fuel rod to deplete into a 'Plush-239 Fuel Rod', which is slightly more powerful and volatile than a regular plutonium fuel rod.

(Should I decrease it to something like 5%?)

## Why It's Good For The Game

Easter egg gud.


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
