### PR TITLE
Mini display case fix

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -90,6 +90,7 @@
 
 /obj/structure/displaycase/obj_break(damage_flag)
 	. = ..()
+	dump()
 	if(!broken && !(flags_1 & NODECONSTRUCT_1))
 		density = FALSE
 		broken = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so the item properly dumps upon being broken.

## Why It's Good For The Game

Bugfix. Without this the captain's laser weapon case for example would not dump the gun upon being broken.

## Changelog
:cl:
fix: display cases not dropping items upon being broken
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
