### PR TITLE
the cybertongue fuckin sucks dude

### DIFF
--- a/code/modules/mob/living/taste.dm
+++ b/code/modules/mob/living/taste.dm
@@ -46,10 +46,6 @@
 	if ((from.pH > 12.5) || (from.pH < 1.5))
 		to_chat(src, "<span class='warning'>You taste chemical burns!</span>")
 		T.applyOrganDamage(5)
-	if(istype(T, /obj/item/organ/tongue/cybernetic) && T.owner?.stat != DEAD)
-		to_chat(src, "<span class='notice'>Your tongue moves on it's own in response to the liquid.</span>")
-		say("The pH is appropriately [round(from.pH, 1)].")
-		return
 	if (!HAS_TRAIT(src, TRAIT_AGEUSIA)) //I'll let you get away with not having 1 damage.
 		if(last_ph_taste_time + 50 < world.time)
 			var/ph_taste_number

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -43,7 +43,7 @@
 		return
 	if(organ_flags & ORGAN_SYNTHETIC)
 		var/errormessage = list("Runtime in tongue.dm, line 39: Undefined operation \"zapzap ow my tongue\"", "afhsjifksahgjkaslfhashfjsak", "-1.#IND", "Graham's number", "inside you all along", "awaiting at least 1 approving review before merging this taste request")
-		owner.say("The pH is appropriately [pick(errormessage)].")
+		owner.say("The pH is approximately [pick(errormessage)].")
 
 /obj/item/organ/tongue/applyOrganDamage(var/d, var/maximum = maxHealth)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
gets rid of the shitty "The pH is appropriately <num>" message from the cybernetic tongue whenever you drink anything
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
it's fucking annoying and made the cybertongue basically unusable because of it. it will be gone now. monkeys everywhere rejoice.
## Changelog
:cl:
del: Removes cybertongue pH readout.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
