### PR TITLE
CC Gateway Authorization

### DIFF
--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -7,12 +7,14 @@ GLOBAL_DATUM(the_gateway, /obj/machinery/gateway/centerstation)
 	icon_state = "off"
 	density = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	req_access = list(ACCESS_CENT_GENERAL) //Place holder for ID access for allowing it to be turned on.
 	var/active = 0
 	var/checkparts = TRUE
 	var/list/obj/effect/landmark/randomspawns = list()
 	var/calibrated = TRUE
 	var/list/linked = list()
 	var/can_link = FALSE	//Is this the centerpiece?
+	var/authorization = FALSE //Temporary place holder for admins to enable or disable gateway, and to be the stepping stone for a exploration department, small steps!
 
 /obj/machinery/gateway/Initialize()
 	randomspawns = GLOB.awaydestinations
@@ -123,6 +125,9 @@ GLOBAL_DATUM(the_gateway, /obj/machinery/gateway/centerstation)
 	if(!awaygate)
 		to_chat(user, "<span class='notice'>Error: No destination found.</span>")
 		return
+	if(!authorization)
+		to_chat(user, "<span class='notice'>Error: Authorization is required to activate the gateway, please contact Central Command for assistance.</span>")
+		return
 	if(world.time < wait)
 		to_chat(user, "<span class='notice'>Error: Warpspace triangulation in progress. Estimated time to completion: [DisplayTimeText(wait - world.time)].</span>")
 		return
@@ -166,6 +171,17 @@ GLOBAL_DATUM(the_gateway, /obj/machinery/gateway/centerstation)
 		else
 			to_chat(user, "<span class='boldnotice'>Recalibration successful!</span>: \black This gate's systems have been fine tuned.  Travel to this gate will now be on target.")
 			calibrated = TRUE
+			return
+
+/obj/machinery/gateway/centerstation/attackby(obj/item/W, mob/user, params)
+	if(istype(W,/obj/item/card/id))
+		W.GetID()
+		if(allowed(user))
+			authorization = !authorization
+			to_chat(user, "<span class='notice'>You [authorization ? "authorize" : "forbid"] activation for the gateway!</span>")
+			return
+		else
+			to_chat(user, "<span class='danger'>Access denied.</span>")
 			return
 
 /////////////////////////////////////Away////////////////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Due to a large influx of unauthorized access and security breaches in the gateway, central command has now restricted it's access to that of an official's level or higher, permission for activation will be required by an official from CC to permit it on site.

## Why It's Good For The Game

A lot of the time, many people such as civilians, miners, and assistance go into the gateway for action and most importantly looting, the gateway is more ment for exiling and undergoing operations (such as events). This teaches players that sometimes potentially dangerous zones are better not peaked in than come back to see what's on the other size (and risk not being able to come back).

## Changelog
:cl:
add: A new variable that requires a TRUE value to turn on the gateway.
tweak: The gateway just a bit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
