### PR TITLE
Seemingly fixes some planetary atmos issues

### DIFF
--- a/_maps/map_files/LayeniaStation/LayeniaStation.dmm
+++ b/_maps/map_files/LayeniaStation/LayeniaStation.dmm
@@ -1609,25 +1609,16 @@
 /turf/open/floor/engine/layenia,
 /area/layenia)
 "acn" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/engine/layenia,
-/area/layenia)
-"aco" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/engine/layenia,
-/area/layenia)
-"acp" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 8
 	},
-/turf/open/floor/engine/layenia,
+/turf/open/floor/plating/asteroid/layenia,
+/area/layenia)
+"acp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/layenia,
 /area/layenia)
 "acq" = (
 /obj/effect/turf_decal/stripes/line{
@@ -3340,26 +3331,27 @@
 /turf/open/floor/plating/layenia,
 /area/layenia)
 "afb" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/layenia,
+/obj/structure/closet/crate/engineering,
+/turf/open/floor/plating/asteroid/layenia,
 /area/layenia)
 "afc" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light{
-	pixel_y = -1
-	},
-/turf/open/floor/plating/layenia,
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
 /area/layenia)
 "afd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/structure/fence{
+	dir = 4
 	},
 /turf/open/floor/plating/layenia,
 /area/layenia)
 "afe" = (
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/fence{
 	dir = 4
 	},
@@ -3389,16 +3381,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "afg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/floor/plating/layenia,
-/area/layenia)
-"afh" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
@@ -3407,6 +3389,15 @@
 	},
 /turf/open/floor/plating/layenia,
 /area/layenia)
+"afh" = (
+/obj/structure/lattice,
+/obj/structure/transit_tube/horizontal,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 16
+	},
+/turf/open/chasm/cloud,
+/area/layenia/cloudlayer)
 "afi" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
@@ -42721,13 +42712,6 @@
 	icon_state = "floor_plate"
 	},
 /area/quartermaster/office)
-"jOA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/closet/crate/engineering,
-/turf/open/floor/plating/asteroid/layenia,
-/area/layenia)
 "jOH" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -49223,15 +49207,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/fore/secondary)
-"lJM" = (
-/obj/structure/lattice,
-/obj/structure/transit_tube/horizontal,
-/obj/machinery/light{
-	dir = 1;
-	pixel_y = 16
-	},
-/turf/open/chasm/cloud,
-/area/layenia/cloudlayer)
 "lJV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -67644,15 +67619,6 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"qur" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "MiniSat Walkway 1";
-	network = list("minisat");
-	start_active = 1
-	},
-/turf/open/chasm/cloud,
-/area/layenia/cloudlayer)
 "quu" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -84932,10 +84898,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"uEp" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
-/area/layenia)
 "uEq" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/soda_cans/shamblers{
@@ -142403,7 +142365,7 @@ adz
 adz
 aeI
 aeV
-afb
+tBc
 xJU
 tOA
 sWn
@@ -142660,7 +142622,7 @@ fkk
 aet
 aeJ
 aeV
-afb
+tBc
 xJU
 vXm
 aai
@@ -142917,13 +142879,13 @@ aej
 aev
 aeK
 aeV
-afc
+rhG
 xJU
 vXm
 oRR
 vXm
 xJU
-qqi
+afh
 gJF
 gPq
 foH
@@ -143174,13 +143136,13 @@ aek
 aew
 aeK
 aeV
-afb
+tBc
 xJU
 qrB
 wlS
 ijQ
 xJU
-lJM
+qqi
 gJF
 gPq
 foH
@@ -143431,7 +143393,7 @@ adz
 aey
 aeK
 aeV
-afb
+tBc
 xJU
 pjc
 iym
@@ -143688,11 +143650,11 @@ lcY
 aez
 aeK
 aeV
-afb
-acm
-acm
+tBc
+tBc
+tBc
 acp
-acm
+tBc
 eAA
 qqi
 gJF
@@ -143945,11 +143907,11 @@ ael
 aeA
 aeL
 aeW
-afd
-acm
-acm
-acm
-acm
+tBc
+tBc
+tBc
+acp
+tBc
 eAA
 qqi
 gJF
@@ -144202,12 +144164,12 @@ tBc
 rot
 huR
 huR
-lty
-acn
-aco
-aco
-aco
-eAA
+tBc
+tBc
+tBc
+acp
+tBc
+afc
 qqi
 gJF
 gPq
@@ -144459,13 +144421,13 @@ tBc
 rot
 huR
 huR
-ram
-cec
-cec
-cec
-jOA
-uEp
-qqi
+tBc
+tBc
+tBc
+acp
+tBc
+eAA
+afh
 gJF
 gPq
 foH
@@ -144719,10 +144681,10 @@ huR
 tBc
 tBc
 tBc
+acp
 tBc
 xiz
-eAA
-lJM
+qqi
 gJF
 gPq
 foH
@@ -144976,9 +144938,9 @@ huR
 tBc
 tBc
 tBc
+acp
 tBc
-afe
-gPq
+afd
 qqi
 gJF
 gPq
@@ -145233,9 +145195,9 @@ huR
 tBc
 tBc
 tBc
+acp
 tBc
-afg
-gPq
+afe
 qqi
 gJF
 gPq
@@ -145490,9 +145452,9 @@ aeX
 tBc
 tBc
 tBc
+acp
 tBc
-afh
-gPq
+afg
 qqi
 gJF
 gPq
@@ -145747,9 +145709,9 @@ aeZ
 tBc
 tBc
 tBc
+acp
 tBc
 xiz
-gPq
 qqi
 gJF
 gPq
@@ -146004,9 +145966,9 @@ aeZ
 tBc
 tBc
 tBc
+acp
 tBc
-afe
-gPq
+afd
 qqi
 gJF
 gPq
@@ -146261,9 +146223,9 @@ afa
 tBc
 tBc
 tBc
+acn
 tBc
-afg
-gPq
+afe
 qqi
 gJF
 gPq
@@ -146519,8 +146481,8 @@ tBc
 tBc
 tBc
 tBc
-afh
-gPq
+tBc
+afg
 qqi
 gJF
 gPq
@@ -146775,9 +146737,9 @@ aed
 xiz
 aeb
 aec
+aec
 aed
 xiz
-qur
 qqi
 gJF
 gPq

--- a/code/game/turfs/simulated/floor/plasteel_floor.dm
+++ b/code/game/turfs/simulated/floor/plasteel_floor.dm
@@ -19,17 +19,12 @@
 	initial_gas_mix = AIRLESS_ATMOS
 /turf/open/floor/plasteel/telecomms
 	initial_gas_mix = TCOMMS_ATMOS
-/turf/open/floor/plasteel/layenia
-	initial_gas_mix = FROZEN_ATMOS
-
 /turf/open/floor/plasteel/dark
 	icon_state = "darkfull"
 /turf/open/floor/plasteel/dark/airless
 	initial_gas_mix = AIRLESS_ATMOS
 /turf/open/floor/plasteel/dark/telecomms
 	initial_gas_mix = TCOMMS_ATMOS
-/turf/open/floor/plasteel/dark/layenia
-	initial_gas_mix = FROZEN_ATMOS
 /turf/open/floor/plasteel/airless/dark
 	icon_state = "darkfull"
 /turf/open/floor/plasteel/dark/side
@@ -146,3 +141,11 @@
 
 /turf/open/floor/plasteel/sepia
 	icon_state = "sepia"
+
+//Layenia Tiles - Hyper
+/turf/open/floor/plasteel/layenia
+	initial_gas_mix = FROZEN_ATMOS
+	planetary_atmos = TRUE
+/turf/open/floor/plasteel/dark/layenia
+	initial_gas_mix = FROZEN_ATMOS
+	planetary_atmos = TRUE

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -379,6 +379,7 @@
 	slowdown = 1
 	environment_type = "layenia"
 	flags_1 = NONE
+	heat_capacity = INFINITY //Makes it so no matter the heat, it will not burn out.
 	planetary_atmos = TRUE
 	burnt_states = null
 	bullet_sizzle = TRUE

--- a/code/game/turfs/simulated/floor/plating/misc_plating.dm
+++ b/code/game/turfs/simulated/floor/plating/misc_plating.dm
@@ -3,10 +3,6 @@
 	icon_state = "plating"
 	initial_gas_mix = AIRLESS_ATMOS
 
-/turf/open/floor/plating/layenia
-	icon_state = "plating"
-	initial_gas_mix = FROZEN_ATMOS
-
 /turf/open/floor/plating/abductor
 	name = "alien floor"
 	icon_state = "alienpod1"
@@ -244,3 +240,9 @@
 
 /turf/open/floor/plating/snowed/temperatre
 	temperature = 255.37
+
+//Layenia Tiles - Hyper
+/turf/open/floor/plating/layenia
+	icon_state = "plating"
+	initial_gas_mix = FROZEN_ATMOS
+	planetary_atmos = TRUE

--- a/code/game/turfs/simulated/floor/reinf_floor.dm
+++ b/code/game/turfs/simulated/floor/reinf_floor.dm
@@ -167,6 +167,8 @@
 	name = "vacuum floor"
 	initial_gas_mix = AIRLESS_ATMOS
 
+//Layenia Tiles - Hyper
 /turf/open/floor/engine/layenia
 	name = "reinforced floor"
 	initial_gas_mix = FROZEN_ATMOS
+	planetary_atmos = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

By remaking the TEG exhaust slightly, making it so crimson rock -cannot burn at all- and giving the other external layenia tiles planetary atmos so they properly eat up the bad gases.

## Why It's Good For The Game

engineering 100000000k bad

## Changelog
:cl:
tweak: teg exhaust
add: planetary atmos property to external layenia tiles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
