### PR TITLE
Carpentry VS paperwork

### DIFF
--- a/code/modules/cargo/exports/manifest.dm
+++ b/code/modules/cargo/exports/manifest.dm
@@ -80,7 +80,7 @@
 // Paper work done correctly
 
 /datum/export/paperwork_correct
-	cost = 120 // finicky number 20 x 120 = 2400 per crate
+	cost = 50 // finicky number 20 x 50 = 1000 per crate, nerfed from 120 to 50 gaining 2400 versus 1000 (CC is running out of space to put all this paper somewhere)
 	k_elasticity = 0
 	unit_name = "correct paperwork"
 	export_types = list(/obj/item/folder/paperwork_correct)

--- a/code/modules/cargo/packs/misc.dm
+++ b/code/modules/cargo/packs/misc.dm
@@ -223,7 +223,7 @@
 /datum/supply_pack/misc/paper_work
 	name = "Freelance Paper work"
 	desc = "The Kinaris Primary Bureaucratic Database Intelligence (PDBI) reports that the station has not completed its funding and grant paperwork this solar cycle. In order to gain further funding, your station is required to fill out (20) ten of these forms or no additional capital will be disbursed. We have sent you ten copies of the following form and we expect every one to be up to Kinaris Standards." // Disbursement. It's not a typo, look it up.
-	cost = 700 // Net of 0 credits but makes (120 x 20 = 2400)
+	cost = 700 // Net of 0 credits but makes (50 x 20 = 1000, used to be (120 x 20 = 2400))
 	contains = list(/obj/item/folder/paperwork,
 					/obj/item/folder/paperwork,
 					/obj/item/folder/paperwork,

--- a/hyperstation/code/modules/cargo/exports/sweatshop.dm
+++ b/hyperstation/code/modules/cargo/exports/sweatshop.dm
@@ -1,24 +1,26 @@
 /datum/export/sweatshop/stool
-	cost = 850
+	cost = 2550 //buffed temporarily due to paper being pricier than actual wood, was 850
 	unit_name = "custom stool"
 	export_types = list(/obj/item/processed/wood/stool)
 
 /datum/export/sweatshop/cushion
-	cost = 300
+	cost = 450 //buffed temporarily due to paper being pricier than actual cotton, was 300
 	unit_name = "cloth cushion"
 	export_types = list(/obj/item/cushion)
 
 /datum/export/sweatshop/cushionsilk
-	cost = 500
+	cost = 750 //buffed temporarily due to paper being pricier than actual silk, was 500
 	unit_name = "silk cushion"
 	export_types = list(/obj/item/cushion)
 
 /datum/export/sweatshop/stool/cushioncloth
-	cost = 1800
+	cost = 5400 //buffed temporarily due to paper being pricier than actual wood, was 1800
 	unit_name = "cushioned stool (cloth)"
 	export_types = list(/obj/item/processed/wood/stoolcloth)
 
 /datum/export/sweatshop/stool/cushionsilk
-	cost = 2400
+	cost = 7200 //buffed temporarily due to paper being pricier than actual wood, was 2400
 	unit_name = "cushioned stool (cloth)"
 	export_types = list(/obj/item/processed/wood/stoolsilk)
+
+// Prices above are temporary buffs until more carpentry is added


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Due to a large influx of paperwork stacking up in the cubicles of centcom with approved and denied paperwork, there has been a sudden drop in demand for filling out freelance paperwork (credits gained from 120 per paperwork to 50, from 2400 per crate to 1000)! However with the extra work required to organize, carpentry is now in demand for more comforting working spaces, making all hand crafted goods much more valuable.

## Why It's Good For The Game

The reason for this change to cargo's freelance paperwork price is due to the fact I see nothing but cargo techs and QM's doing nothing but paperwork, spamming the crafting button and hitting that 100 input limit constantly on the server, which I can imagine would create a bit of lag over time, it's low effort for a lot of reward in the investment of time.

I want to see cargo more engaging with their bounties, or even more interactive with how they export goods, going as far as making a factory in cargo that makes Omega weed from the help of botany and a circuit farm bot from science in order to really get profitable gains, furthermore I would like to see carpentry be more worth while until more objects/craftables get added in, as I'd love cargo to be homedepot. These changes are more so in place to slowly get rid of paperwork all together, until we can replace it with some thing more interactive, or remove it all together as it slowly get's removed over time compared to a finger snap.

## Changelog
:cl:
tweak: export prices for paper and stools
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
