### PR TITLE
Grow a pair! (testicle fix)

### DIFF
--- a/modular_citadel/code/modules/arousal/organs/testicles.dm
+++ b/modular_citadel/code/modules/arousal/organs/testicles.dm
@@ -7,7 +7,7 @@
 	slot 					= "testicles"
 	size 					= BALLS_SIZE_MIN
 	var/size_name			= "average"
-	shape					= "single"
+	shape					= "Single" //Shape name has to be capital to work
 	var/sack_size			= BALLS_SACK_SIZE_DEF
 	var/cached_size			= 6
 	//fluid_mult				= 0.133 // Set to a lower value due to production scaling with size (I.E. 6 inches the "normal" amount)

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/enlargement.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/enlargement.dm
@@ -240,8 +240,30 @@
 /datum/reagent/fermi/penis_enlarger/on_mob_life(mob/living/carbon/M) //Increases penis size, 5u = +1 inch.
 	if(!ishuman(M))
 		return
+	var/obj/item/organ/genital/testicles/T = M.getorganslot("testicles") //Hyper Change, testicles come first so the dick isn't hidden behind the testicles layer
 	var/obj/item/organ/genital/penis/P = M.getorganslot("penis")
-	var/obj/item/organ/genital/testicles/T = M.getorganslot("testicles") //Hyper Change
+	if(!T)//Hyper change// Adds testicles if there are none.
+
+		//If they have Acute hepatic pharmacokinesis, then route processing though liver.
+		if(HAS_TRAIT(M, TRAIT_PHARMA))
+			var/obj/item/organ/liver/L = M.getorganslot("liver")
+			if(L)
+				L.swelling+= 0.05
+				return..()
+			else
+				M.adjustToxLoss(1)
+				return..()
+
+		//otherwise proceed as normal
+		var/obj/item/organ/genital/testicles/nT = new
+		nT.Insert(M)
+		if(nT)
+			nT.size = BALLS_SIZE_MIN
+			to_chat(M, "<span class='warning'>Your groin feels warm, as you feel two sensitive orbs taking shape below.</b></span>")
+			nT.cached_size = 1
+			nT.sack_size = BALLS_SACK_SIZE_DEF
+			T = nT
+
 	if(!P)//They do have a preponderance for escapism, or so I've heard.
 
 		//If they have Acute hepatic pharmacokinesis, then route processing though liver.
@@ -264,28 +286,6 @@
 			nP.prev_length = 1
 			M.reagents.remove_reagent(type, 5)
 			P = nP
-
-	if(!T)//Hyper change// Adds testicles if there are none.
-
-		//If they have Acute hepatic pharmacokinesis, then route processing though liver.
-		if(HAS_TRAIT(M, TRAIT_PHARMA))
-			var/obj/item/organ/liver/L = M.getorganslot("liver")
-			if(L)
-				L.swelling+= 0.05
-				return..()
-			else
-				M.adjustToxLoss(1)
-				return..()
-
-		//otherwise proceed as normal
-		var/obj/item/organ/genital/testicles/nT = new
-		nT.Insert(M)
-		if(nT)
-			nT.size = BALLS_SIZE_MIN
-			to_chat(M, "<span class='warning'>Your groin feels warm, as you feel two sensitive orbs taking shape below.</b></span>")
-			nT.cached_size = 1
-			nT.sack_size = BALLS_SACK_SIZE_DEF
-			T = nT
 
 	P.cached_length = P.cached_length + 0.1
 	//Hyper change// Increase ball size too


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR is a simple fix to make testicles appear on using penis enlargment and prioritizing the testicles to appear on the body first before the dick 

## Why It's Good For The Game

Originally when having the no dick or testicles, when taking penis enlargement pills, the balls would add onto the body yet their sprite would not appear, making it look like a fancy switchblade, additionally when they do appear, the sprite layer goes penis than balls, making it disappear at odd angles when a character sprite looks south or west/east, by having the balls get added first, this fixes the sprite issue, and potentially makes the autosurgeon for testicles work.

## Changelog
:cl:
spellcheck: Capitalized a single letter S to make a sprite appear.
code: Rearranged one organ coming first before another when adding onto a character
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
