### PR TITLE
CE Glove item_state fix

### DIFF
--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -14,7 +14,7 @@
 	desc = "Special Insulated gloves with pricy thermal shielding normally only found in combat gloves."
 	name = "Chief Engineer Insulated Gloves"
 	icon_state = "ce_insuls"
-	item_state = "combat"
+	item_state = "ygloves"
 	siemens_coefficient = 0
 	permeability_coefficient = 0.05
 	strip_delay = 80


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Super simple babby's first placeholder PR. Changes the worn state for the CE gloves which current show as invisible to something which is not invisible.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

- Invisible clothing man bad
- Visible clothing man good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

fix: fixes CE insuls by changing item_state from the unused 'combat' to ygloves, making them show as worn insuls.

:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
