### PR TITLE
Zweihander 1.1.2

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -187,7 +187,7 @@
 		stunpwr *= round(stuncharge/hitcost, 0.1)
 
 
-	L.Knockdown(stunpwr)
+	L.Knockdown(80) //Max knockdown without having objects fall out of hands
 	L.adjustStaminaLoss(stunpwr*0.1, affected_zone = (istype(user) ? user.zone_selected : BODY_ZONE_CHEST))//CIT CHANGE - makes stunbatons deal extra staminaloss. Todo: make this also deal pain when pain gets implemented.
 	L.apply_effect(EFFECT_STUTTER, stunforce)
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)

--- a/hyperstation/code/obj/ZaoCorp/hat.dm
+++ b/hyperstation/code/obj/ZaoCorp/hat.dm
@@ -6,6 +6,7 @@
 	item_state = "helmet"
 	item_color = "zaohat"
 	alternate_worn_icon = 'hyperstation/icons/mobs/head.dmi'
+	dynamic_hair_suffix = null
 	armor = list("melee" = 40, "bullet" = 40, "laser" = 10,"energy" = 20, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = 60)
 	cold_protection = HEAD
 	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT


### PR DESCRIPTION
## About The Pull Request

This is another update to the Zweisword to buff it, along with some other things included such as

Zao Sword:
Buffed blocking
Adds a stun to the grab intent attack
increases the zap to 100% on a active pick up of the sword

Tweaking stun batons, making them no longer drop held objects when hit with the maximum knockdown value before this occurs.

Made it so the zao hat doesn't remove the top of the hair for some objects.



## Why It's Good For The Game

For the sword and hat, a balancing and small fixes for existing issues.

For the stun baton, batons have been overwhelmingly powerful as out code base hasn't changed them since their introduction, while other communities have already done some things to better balance them.

## Changelog
:cl:
tweak: Some things with the stun batons and Zao Sword
balance: I think(?)
fix: the top of the hair being removed with the zao hat
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
