### PR TITLE
Map changes Layenia/Centcom

### DIFF
--- a/_maps/map_files/LayeniaStation/LayeniaStation.dmm
+++ b/_maps/map_files/LayeniaStation/LayeniaStation.dmm
@@ -3156,6 +3156,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -11887,6 +11891,10 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/range)
@@ -21080,6 +21088,10 @@
 /obj/item/stock_parts/micro_laser/high,
 /obj/item/stock_parts/micro_laser/high,
 /obj/item/stock_parts/micro_laser/high,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "egq" = (
@@ -23054,6 +23066,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8;
 	name = "air scrubber"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/open/floor/wood,
 /area/library/lounge)
@@ -25155,6 +25171,10 @@
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -31606,6 +31626,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "gUI" = (
@@ -32189,6 +32213,13 @@
 /obj/item/multitool,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
+"hdv" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/quartermaster/miningdock)
 "hdC" = (
 /turf/open/floor/plasteel/stairs/medium{
 	dir = 1
@@ -39141,6 +39172,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel{
 	dir = 1;
 	icon_state = "floor_plate"
@@ -41201,7 +41236,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "joa" = (
-/obj/machinery/rnd/production/circuit_imprinter,
 /obj/machinery/requests_console{
 	department = "Robotics";
 	departmentType = 2;
@@ -41213,6 +41247,7 @@
 	pixel_x = 8;
 	pixel_y = 6
 	},
+/obj/machinery/rnd/production/circuit_imprinter/department/science,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "jom" = (
@@ -41544,6 +41579,27 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
+"jwZ" = (
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8;
+	name = "air supply pipe"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4;
+	name = "scrubbers pipe"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "floor_plate"
+	},
+/area/crew_quarters/dorms)
 "jxh" = (
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -50346,6 +50402,10 @@
 /obj/item/healthanalyzer,
 /obj/item/healthanalyzer,
 /obj/item/healthanalyzer,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "mau" = (
@@ -50372,6 +50432,9 @@
 /area/security/main)
 "max" = (
 /obj/effect/turf_decal/bot,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/misc_lab)
 "maJ" = (
@@ -55718,6 +55781,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"nwo" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/science/misc_lab)
 "nwy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -60198,6 +60273,10 @@
 /obj/structure/table/wood,
 /obj/machinery/recharger,
 /obj/item/melee/chainofcommand,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "oEy" = (
@@ -62129,6 +62208,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	name = "air supply pipe"
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/open/floor/wood,
 /area/library)
 "pdc" = (
@@ -63013,6 +63096,10 @@
 /obj/effect/turf_decal/loading_area{
 	icon_state = "drain";
 	name = "drain"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 1
@@ -67853,6 +67940,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "qwz" = (
@@ -68759,9 +68847,6 @@
 	},
 /area/bridge)
 "qGB" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/effect/baseturf_helper/asteroid/layenia,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/loading_area{
@@ -71957,6 +72042,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -72170,6 +72258,9 @@
 "rwI" = (
 /obj/structure/dresser,
 /obj/item/card/id/captains_spare,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "rwL" = (
@@ -74096,6 +74187,10 @@
 /obj/item/book/lorebooks/engrams{
 	pixel_y = 5
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "rSj" = (
@@ -74603,6 +74698,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 8;
 	name = "scrubbers pipe"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel{
 	dir = 4;
@@ -75573,6 +75672,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "siU" = (
@@ -76135,6 +76238,23 @@
 /obj/structure/railing,
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
+"srv" = (
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/easel,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel{
+	dir = 1;
+	icon_state = "floor_plate"
+	},
+/area/artatrium)
 "srD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	name = "scrubbers pipe"
@@ -76412,6 +76532,16 @@
 	},
 /turf/open/floor/grass,
 /area/medical/sleeper)
+"suQ" = (
+/obj/structure/chair/sofa{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/carpet/black,
+/area/arcade)
 "suZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -76448,6 +76578,10 @@
 	dir = 4;
 	icon_state = "drain";
 	name = "drain"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel,
 /area/medical/morgue)
@@ -76779,6 +76913,22 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/medical/psych)
+"szD" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "floor_plate"
+	},
+/area/artatrium)
 "szF" = (
 /turf/open/floor/plasteel{
 	dir = 4;
@@ -81301,6 +81451,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"tKm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "floor_plate"
+	},
+/area/quartermaster/storage)
 "tKv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	name = "scrubbers pipe"
@@ -82696,6 +82859,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 8;
 	name = "air vent"
+	},
+/obj/machinery/airalarm{
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -88726,6 +88892,9 @@
 	dir = 4
 	},
 /obj/machinery/dna_scannernew,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vCo" = (
@@ -92545,6 +92714,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "wxg" = (
@@ -94610,6 +94783,14 @@
 "xaK" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"xaM" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/fitness)
 "xaU" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
@@ -95072,6 +95253,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -98634,6 +98818,7 @@
 	name = "Cargo Office";
 	req_access_txt = "50"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "ybT" = (
@@ -111340,7 +111525,7 @@ pBv
 pTg
 qhI
 qvh
-kpR
+xaM
 eco
 lCm
 gsw
@@ -116789,7 +116974,7 @@ gPq
 gPq
 ain
 lnM
-njX
+srv
 rLi
 gJK
 nSr
@@ -117055,7 +117240,7 @@ dna
 abm
 hgr
 lIM
-hgr
+szD
 pDj
 lnM
 wcK
@@ -120838,7 +121023,7 @@ ylw
 eAU
 ntl
 rEa
-pSk
+jwZ
 eAU
 uXl
 ecg
@@ -121398,7 +121583,7 @@ wrc
 kKo
 rWh
 upc
-rWh
+tKm
 rWh
 dTs
 jel
@@ -123445,7 +123630,7 @@ sLM
 lrp
 oVF
 xbv
-snb
+suQ
 fNF
 hSr
 sCL
@@ -127069,7 +127254,7 @@ obL
 rwy
 rtS
 aBS
-qoD
+hdv
 gwO
 kfq
 wpZ
@@ -143495,7 +143680,7 @@ mzw
 abT
 abT
 abT
-abT
+nwo
 abT
 jvS
 pzd

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -9260,15 +9260,12 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/control)
 "tQ" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp{
-	pixel_x = -17;
-	pixel_y = 3
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 14
 	},
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/centcom/ferry)
 "tR" = (
 /obj/machinery/status_display/ai,
@@ -10079,14 +10076,13 @@
 /turf/open/floor/plasteel,
 /area/syndicate_mothership)
 "vx" = (
-/obj/machinery/light/small{
-	pixel_y = -2
+/obj/machinery/light,
+/obj/structure/sign/poster/contraband/space_cube{
+	pixel_y = -32
 	},
-/obj/structure/dresser,
-/obj/item/toy/plush/mammal/chemlight{
-	pixel_y = 16
-	},
-/turf/open/floor/wood,
+/obj/structure/easel,
+/obj/item/canvas/twentythreeXtwentythree,
+/turf/open/floor/mineral/basaltstone_floor,
 /area/centcom/ferry)
 "vy" = (
 /obj/effect/turf_decal/tile/green{
@@ -11958,6 +11954,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"zl" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/centcom/ferry)
 "zm" = (
 /obj/machinery/computer/rdservercontrol{
 	dir = 1
@@ -12749,6 +12751,10 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
+"Ba" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/wood,
+/area/centcom/ferry)
 "Bb" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/crate/bin,
@@ -12793,6 +12799,42 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/xeno,
 /turf/open/floor/grass,
 /area/wizard_station)
+"Bj" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/rag/towel{
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/rag/towel{
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/rag/towel{
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/rag/towel{
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/rag/towel{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/rag/towel{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/rag/towel{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/rag/towel{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/rag/towel{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/turf/open/floor/wood,
+/area/centcom/ferry)
 "Bk" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 9;
@@ -12804,12 +12846,18 @@
 	icon_state = "steel_panel";
 	name = "steel pannel"
 	},
+/obj/machinery/vending/games{
+	free = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "Bl" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/plating,
 /area/syndicate_mothership)
+"Bn" = (
+/turf/open/floor/plasteel/stairs,
+/area/centcom/ferry)
 "Bo" = (
 /obj/machinery/vending/autodrobe{
 	req_access_txt = "0"
@@ -12821,6 +12869,33 @@
 /obj/structure/table/wood,
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"Bq" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/item/soap/deluxe,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/machinery/door/window/brigdoor/southleft{
+	dir = 4;
+	name = "Shower"
+	},
+/obj/structure/curtain{
+	alpha = 240;
+	color = "#454545";
+	icon_state = "closed";
+	open = 0
+	},
+/turf/open/floor/plasteel/freezer,
+/area/centcom/ferry)
 "Br" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -13310,6 +13385,13 @@
 	name = "sand"
 	},
 /area/centcom/control)
+"Cm" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/wood,
+/area/centcom/ferry)
 "Cn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
@@ -13786,7 +13868,6 @@
 /area/centcom/holding)
 "CW" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/wood,
 /area/centcom/ferry)
 "CX" = (
@@ -13889,6 +13970,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"Df" = (
+/obj/structure/chair/sofa{
+	dir = 8;
+	icon_state = "sofamiddle"
+	},
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
 "Dh" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -14040,6 +14128,35 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/indestructible/riveted,
 /area/centcom/supply)
+"DB" = (
+/obj/structure/table,
+/obj/item/storage/pill_bottle/mutarad{
+	pixel_x = -7
+	},
+/obj/item/razor{
+	pixel_y = 12
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/obj/item/storage/pill_bottle/psicodine{
+	pixel_x = 9;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/pill/psicodine{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/pill/psicodine,
+/obj/item/lipstick/black{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer,
+/area/centcom/ferry)
 "DC" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
@@ -14963,6 +15080,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
+"FA" = (
+/obj/effect/decal/cleanable/semendrip{
+	pixel_x = 10;
+	pixel_y = 6
+	},
+/obj/decal{
+	desc = "A drain built into the floor, perhaps for potential floods?.";
+	icon = 'icons/obj/machines/pool.dmi';
+	icon_state = "drain";
+	name = "drain";
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer,
+/area/centcom/ferry)
 "FB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -15137,6 +15269,35 @@
 "FX" = (
 /turf/open/floor/grass,
 /area/centcom/holding)
+"FY" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/machinery/door/window/brigdoor/westright{
+	dir = 4;
+	name = "Shower"
+	},
+/obj/structure/curtain{
+	alpha = 240;
+	color = "#454545";
+	icon_state = "closed";
+	open = 0
+	},
+/obj/effect/decal/cleanable/semendrip,
+/obj/effect/decal/cleanable/semendrip{
+	pixel_x = 10;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/semendrip{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/turf/open/floor/plasteel/freezer,
+/area/centcom/ferry)
 "FZ" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -15812,6 +15973,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"Hl" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/hatch{
+	name = "Sauna"
+	},
+/turf/open/floor/wood,
+/area/centcom/ferry)
 "Hm" = (
 /obj/machinery/vending/hydroseeds,
 /obj/effect/turf_decal/tile/green{
@@ -16130,6 +16298,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
+"HL" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/ferry)
 "HM" = (
 /obj/structure/chair,
 /obj/effect/landmark/thunderdome/observe,
@@ -17293,6 +17467,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"JW" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 9
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/centcom/ferry)
 "JX" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -17367,7 +17548,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/table,
+/obj/structure/closet/wardrobe/pjs,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "Kg" = (
@@ -17827,6 +18011,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/bedsheetbin,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "Le" = (
@@ -17859,6 +18046,16 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
+"Lj" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/snacks/benedict,
+/obj/item/reagent_containers/food/snacks/benedict,
+/obj/item/reagent_containers/food/snacks/benedict,
+/obj/item/reagent_containers/food/snacks/waffles,
+/obj/item/reagent_containers/food/snacks/waffles,
+/obj/item/reagent_containers/food/snacks/waffles,
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
 "Lk" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/secure_data/laptop{
@@ -18222,6 +18419,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/arena)
+"Mj" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
 "Mk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -18250,6 +18451,33 @@
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
+"Mn" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/semendrip{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/obj/decal{
+	desc = "A drain built into the floor, perhaps for potential floods?.";
+	icon = 'icons/obj/machines/pool.dmi';
+	icon_state = "drain";
+	name = "drain";
+	pixel_x = -1
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
+"Mo" = (
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock{
+	id_tag = "CCDormChemlight2";
+	name = "Kenshin Midori's Bunk"
+	},
+/turf/open/floor/wood,
+/area/centcom/ferry)
 "Mq" = (
 /obj/effect/turf_decal/loading_area{
 	icon_state = "drain";
@@ -18263,34 +18491,13 @@
 /turf/open/floor/grass/fairy/blue,
 /area/centcom/ferry)
 "Mr" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/greenplaidshirt,
-/obj/item/storage/backpack/satchel/leather,
-/obj/item/clothing/shoes/winterboots,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/neck/petcollar/choker,
-/obj/item/lipstick/black,
-/obj/item/toy/tennis/green,
-/obj/item/radio/headset/headset_cent,
-/obj/item/clothing/under/rank/centcom_officer,
-/obj/item/clothing/suit/hooded/wintercoat/centcom,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/pda/lieutenant{
-	hidden = 0
+/obj/structure/chair/sofa/left{
+	dir = 8
 	},
-/obj/item/melee/classic_baton/telescopic,
-/obj/item/storage/box/survival,
-/obj/item/crowbar/red,
-/obj/item/card/id/centcom{
-	assignment = "Off-Duty Intelligence Officer";
-	desc = "An ID straight from Central Command.";
-	name = "Kenshin Midori's ID Card (Off-Duty Intelligence Officer)";
-	registered_name = "Kenshin Midori"
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/item/encryptionkey/heads/captain,
-/obj/item/flashlight/seclite,
-/obj/item/gun/energy/e_gun/dragnet/snare,
-/turf/open/floor/wood,
+/turf/open/floor/mineral/basaltstone_floor,
 /area/centcom/ferry)
 "Ms" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -18406,6 +18613,18 @@
 	name = "Thunderdome Admin"
 	},
 /area/centcom/ferry)
+"ML" = (
+/obj/structure/table/wood,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 16
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/computer/security/wooden_tv,
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
 "MM" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
@@ -18456,9 +18675,53 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
+"MW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
+	dir = 8
+	},
+/turf/open/floor/grass/fakebasalt,
+/area/centcom/ferry)
+"MX" = (
+/obj/structure/table/wood,
+/obj/item/storage/pill_bottle/dice{
+	pixel_x = -3
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "drain";
+	name = "drain"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
 "MY" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/cafeteria,
+/area/centcom/ferry)
+"MZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/hacking_guide{
+	pixel_y = 32
+	},
+/obj/item/stack/sheet/micro_bricks/twenty,
+/obj/item/stack/sheet/micro_bricks/twenty,
+/obj/item/carpentry/glue,
+/turf/open/floor/pod/light,
+/area/centcom/ferry)
+"Na" = (
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4;
+	icon_state = "drain";
+	name = "drain"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
+"Nb" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/heater,
+/turf/open/floor/wood,
 /area/centcom/ferry)
 "Nc" = (
 /obj/effect/turf_decal/tile/brown{
@@ -18505,6 +18768,16 @@
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
+/area/centcom/ferry)
+"Nh" = (
+/obj/structure/mirror{
+	pixel_y = 33
+	},
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plasteel/freezer,
 /area/centcom/ferry)
 "Ni" = (
 /obj/structure/table/reinforced,
@@ -18614,6 +18887,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white,
 /area/centcom/ferry)
+"NC" = (
+/obj/machinery/computer/arcade/battle{
+	dir = 1
+	},
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
 "ND" = (
 /obj/structure/closet/secure_closet/freezer/meat{
 	locked = 0
@@ -18719,6 +18998,16 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
+"NQ" = (
+/obj/structure/chair/sofa{
+	dir = 8;
+	icon_state = "sofamiddle"
+	},
+/obj/structure/sign/painting/library_secure{
+	pixel_x = 25
+	},
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
 "NR" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -18782,6 +19071,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/syndicate_mothership)
+"NW" = (
+/obj/structure/sign/poster/official/foam_force_ad{
+	pixel_y = 32
+	},
+/obj/structure/chair/sofa/corner,
+/obj/item/instrument/piano_synth{
+	pixel_x = 4
+	},
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
 "NX" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -18833,14 +19132,10 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/syndicate_mothership)
 "Of" = (
-/obj/structure/closet/wardrobe/pjs,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -18903,6 +19198,18 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
+/area/centcom/ferry)
+"Oo" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "drain";
+	name = "drain"
+	},
+/turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
 "Op" = (
 /obj/structure/table,
@@ -18989,6 +19296,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"OK" = (
+/obj/machinery/door/airlock{
+	dir = 4;
+	name = "Storage"
+	},
+/turf/open/floor/pod/light,
+/area/centcom/ferry)
 "OL" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -19101,6 +19415,31 @@
 	},
 /turf/open/floor/plating/asteroid/layenia/garden,
 /area/centcom/ferry)
+"Pc" = (
+/obj/item/toy/beach_ball/holoball,
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "drain";
+	name = "drain"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
+"Pd" = (
+/obj/structure/dresser,
+/obj/item/toy/plush/mammal/chemlight{
+	pixel_y = 16
+	},
+/obj/item/card/id/centcom{
+	assignment = "Off-Duty Intelligence Officer";
+	desc = "An ID straight from Central Command.";
+	name = "Kenshin Midori's ID Card (Off-Duty Intelligence Officer)";
+	registered_name = "Kenshin Midori"
+	},
+/obj/structure/sign/painting/library{
+	pixel_y = -24
+	},
+/turf/open/floor/carpet/monochrome,
+/area/centcom/ferry)
 "Pf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -19126,6 +19465,25 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
+"Pk" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp{
+	pixel_x = -17;
+	pixel_y = 3
+	},
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/item/modular_computer/laptop/preset/civillian{
+	name = "laptop"
+	},
+/turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
 "Pl" = (
 /obj/structure/toilet{
@@ -19170,6 +19528,28 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"Pt" = (
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck/cas{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/toy/cards/deck/cas/black{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4;
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "drain";
+	name = "drain"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
 "Pu" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -19229,6 +19609,14 @@
 	smooth = 1
 	},
 /area/centcom/holding)
+"PB" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "drain";
+	name = "drain"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
 "PC" = (
 /obj/structure/closet/secure_closet/personal/cabinet{
 	name = "Winfre Ryyn-Kinar's closet"
@@ -19269,6 +19657,15 @@
 /obj/item/camera,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod)
+"PH" = (
+/obj/machinery/space_heater,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 14
+	},
+/turf/open/floor/wood,
+/area/centcom/ferry)
 "PI" = (
 /obj/machinery/light{
 	dir = 8
@@ -19284,6 +19681,17 @@
 "PL" = (
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"PM" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/paper_bin/construction{
+	pixel_x = 11
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
 "PN" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/green{
@@ -19390,6 +19798,33 @@
 	},
 /turf/open/floor/mineral/basaltstone_floor,
 /area/centcom/ferry)
+"Qg" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/loading_area{
+	dir = 4;
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/item/pen/blue,
+/obj/item/pen/fourcolor{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/pen/red{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
+"Qj" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "drain";
+	name = "drain";
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
 "Qk" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
@@ -19398,9 +19833,38 @@
 /obj/singularity/wizard/mapped,
 /turf/open/indestructible/binary,
 /area/fabric_of_reality)
+"Qn" = (
+/obj/structure/rack/shelf,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/integrated_circuit_printer/upgraded,
+/obj/item/stock_parts/cell/high/empty,
+/obj/item/stock_parts/cell/high/empty,
+/obj/item/stock_parts/cell/high/empty,
+/obj/item/stock_parts/cell/high/empty,
+/obj/item/stock_parts/cell/high,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/modular_computer/tablet/preset/advanced,
+/obj/item/computer_hardware/network_card/advanced,
+/obj/item/computer_hardware/network_card/advanced,
+/obj/item/multitool,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/storage/belt/utility/full,
+/turf/open/floor/pod/light,
+/area/centcom/ferry)
 "Qo" = (
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/evac)
+"Qp" = (
+/obj/machinery/computer/arcade/minesweeper{
+	dir = 4
+	},
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
 "Qq" = (
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership)
@@ -19454,6 +19918,35 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
+/area/centcom/ferry)
+"Qx" = (
+/obj/machinery/door/window/westleft{
+	dir = 1;
+	name = "Bedroom"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "drain";
+	name = "drain"
+	},
+/turf/open/floor/carpet/monochrome,
+/area/centcom/ferry)
+"Qy" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/decal{
+	desc = "A drain built into the floor, perhaps for potential floods?.";
+	icon = 'icons/obj/machines/pool.dmi';
+	icon_state = "drain";
+	name = "drain";
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/semendrip{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/turf/open/floor/carpet/monochrome,
 /area/centcom/ferry)
 "Qz" = (
 /obj/effect/turf_decal/loading_area{
@@ -19604,14 +20097,20 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/plasteel/cafeteria,
 /area/syndicate_mothership)
+"QS" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Sauna"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/wood,
+/area/centcom/ferry)
 "QT" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/centcom/holding)
 "QU" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/structure/sauna_oven,
+/obj/machinery/atmospherics/components/unary/passive_vent,
 /turf/open/floor/wood,
 /area/centcom/ferry)
 "QV" = (
@@ -19647,6 +20146,12 @@
 	},
 /turf/open/floor/plating,
 /area/syndicate_mothership)
+"Rc" = (
+/obj/structure/sign/poster/contraband/shamblers_juice{
+	pixel_y = -32
+	},
+/turf/open/floor/carpet/monochrome,
+/area/centcom/ferry)
 "Rd" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "lmrestroom"
@@ -19720,11 +20225,29 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Rp" = (
+/obj/structure/table/wood,
+/obj/machinery/cell_charger,
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
 "Rq" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/apron/chef,
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/plasteel/cafeteria,
+/area/centcom/ferry)
+"Rr" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/centcom/ferry)
+"Rs" = (
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
+	},
+/turf/open/floor/mineral/basaltstone_floor,
 /area/centcom/ferry)
 "Rw" = (
 /obj/structure/table/reinforced,
@@ -19732,6 +20255,25 @@
 /obj/item/storage/bag/tray,
 /obj/item/kitchen/fork,
 /turf/open/floor/plasteel/cafeteria,
+/area/centcom/ferry)
+"Rx" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "drain";
+	name = "drain"
+	},
+/turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
 "Rz" = (
 /obj/effect/turf_decal/loading_area,
@@ -19756,11 +20298,29 @@
 	},
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/basketball)
+"RH" = (
+/obj/structure/medkit_cabinet{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "drain";
+	name = "drain"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/centcom/ferry)
 "RI" = (
 /obj/structure/medkit_cabinet{
 	pixel_x = -27
 	},
 /turf/open/floor/plasteel/white,
+/area/centcom/ferry)
+"RJ" = (
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
+	},
+/turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
 "RK" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -19844,6 +20404,12 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/ferry)
+"RV" = (
+/obj/machinery/atmospherics/miner/water_vapor{
+	desc = "A gas miner which appears to be getting water vapor from nowhere."
+	},
+/turf/open/floor/grass/fakebasalt,
+/area/centcom/ferry)
 "RY" = (
 /turf/open/floor/carpet/black,
 /area/centcom/control)
@@ -19857,6 +20423,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/syndicate_mothership)
+"Sa" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 16
+	},
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/three_course_meal,
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
 "Sb" = (
 /obj/structure/table/wood,
 /obj/item/toy/prize/mauler{
@@ -19886,6 +20461,14 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Se" = (
+/obj/structure/fans/tiny/invisible,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/engine/co2,
+/area/centcom/ferry)
 "Sf" = (
 /obj/structure/chair{
 	dir = 4;
@@ -19911,6 +20494,14 @@
 /obj/item/toy/nuke,
 /turf/open/floor/wood,
 /area/syndicate_mothership)
+"Sj" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "drain";
+	name = "drain"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/centcom/ferry)
 "Sk" = (
 /obj/structure/lattice/catwalk,
 /turf/closed/indestructible/riveted,
@@ -19921,6 +20512,14 @@
 	name = "drain"
 	},
 /turf/open/floor/carpet/black,
+/area/centcom/ferry)
+"Sm" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/turf/open/floor/mineral/basaltstone_floor,
 /area/centcom/ferry)
 "So" = (
 /obj/structure/chair/wood/wings{
@@ -19976,6 +20575,14 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Sx" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 16
+	},
+/obj/structure/chair/sofa,
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
 "Sy" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -19985,6 +20592,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
+"Sz" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/centcom/ferry)
 "SB" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -20088,6 +20701,15 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"SO" = (
+/obj/item/storage/secure/safe{
+	code = "0000";
+	desc = "A wall safe repurposed into a makeshift mailbox, the numbers 0000 seems to be written on the cover.";
+	name = "secure mailbox";
+	pixel_x = 6
+	},
+/turf/closed/indestructible/riveted,
+/area/centcom/ferry)
 "SP" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/flora/ausbushes/grassybush,
@@ -20099,6 +20721,12 @@
 "SR" = (
 /obj/machinery/vending/boozeomat/all_access,
 /turf/open/floor/wood,
+/area/centcom/ferry)
+"SS" = (
+/obj/machinery/computer/arcade/orion_trail{
+	dir = 1
+	},
+/turf/open/floor/mineral/basaltstone_floor,
 /area/centcom/ferry)
 "ST" = (
 /obj/structure/filingcabinet/security,
@@ -20141,6 +20769,12 @@
 	},
 /turf/open/floor/grass,
 /area/centcom/holding)
+"SZ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/centcom/ferry)
 "Ta" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/junglebush/large{
@@ -20156,6 +20790,10 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/centcom/holding)
+"Td" = (
+/obj/structure/chair/sofa,
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
 "Tf" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8;
@@ -20206,6 +20844,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"Tm" = (
+/obj/structure/chair/bench/right,
+/turf/open/floor/wood,
+/area/centcom/ferry)
 "Tn" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -20282,6 +20924,12 @@
 /obj/machinery/computer/arcade,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Tx" = (
+/obj/structure/chair/bench/right{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/ferry)
 "Tz" = (
 /obj/effect/light_emitter,
 /turf/open/floor/plating/asteroid/snow/airless,
@@ -20384,15 +21032,8 @@
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership)
 "TQ" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/mutarad{
-	pixel_x = -7
-	},
-/obj/item/razor{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/white,
+/obj/structure/chair/bench/left,
+/turf/open/floor/wood,
 /area/centcom/ferry)
 "TR" = (
 /obj/structure/chair/comfy{
@@ -20481,6 +21122,9 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Ui" = (
+/turf/open/floor/plasteel/freezer,
+/area/centcom/ferry)
 "Uj" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Restroom";
@@ -20488,6 +21132,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/syndicate_mothership)
+"Uk" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/decal{
+	desc = "A drain built into the floor, perhaps for potential floods?.";
+	icon = 'icons/obj/machines/pool.dmi';
+	icon_state = "drain";
+	name = "drain";
+	pixel_x = -1
+	},
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
 "Ul" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -20656,6 +21313,21 @@
 /obj/effect/light_emitter,
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
+"UH" = (
+/obj/structure/rack/shelf,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/wood,
+/area/centcom/ferry)
 "UI" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1;
@@ -20663,6 +21335,13 @@
 	name = "drain"
 	},
 /turf/open/floor/grass/fairy/blue,
+/area/centcom/ferry)
+"UJ" = (
+/obj/structure/chair/comfy/black,
+/obj/structure/sign/poster/official/pda_ad{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/basaltstone_floor,
 /area/centcom/ferry)
 "UL" = (
 /obj/effect/turf_decal/tile/brown,
@@ -20730,17 +21409,11 @@
 /turf/open/floor/wood,
 /area/centcom/holding)
 "UU" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 6
+	},
 /obj/structure/table/wood,
-/obj/item/clipboard{
-	pixel_x = -14
-	},
-/obj/item/pen/red{
-	pixel_x = -14
-	},
-/obj/item/folder/yellow{
-	pixel_x = -5
-	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/centcom/ferry)
 "UV" = (
 /mob/living/simple_animal/bot/medbot{
@@ -20824,6 +21497,9 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/evac)
+"Vg" = (
+/turf/open/floor/pod/light,
+/area/centcom/ferry)
 "Vh" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8;
@@ -20870,6 +21546,62 @@
 	dir = 2
 	},
 /area/syndicate_mothership)
+"Vk" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/greenplaidshirt,
+/obj/item/storage/backpack/satchel/leather,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/neck/petcollar/choker,
+/obj/item/toy/tennis/green,
+/obj/item/radio/headset/headset_cent,
+/obj/item/clothing/under/rank/centcom_officer,
+/obj/item/clothing/suit/hooded/wintercoat/centcom,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/pda/lieutenant{
+	hidden = 0
+	},
+/obj/item/melee/classic_baton/telescopic,
+/obj/item/storage/box/survival,
+/obj/item/crowbar/red,
+/obj/item/encryptionkey/heads/captain,
+/obj/item/flashlight/seclite,
+/obj/item/gun/energy/e_gun/dragnet/snare,
+/obj/item/clothing/shoes/jackboots/toeless,
+/obj/item/clothing/shoes/footwraps{
+	color = "#5c8ebc"
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/item/clothing/under/gear_harness,
+/obj/item/clothing/neck/cloak/polychromic/half,
+/obj/item/clothing/neck/cloak/polychromic,
+/obj/item/clothing/under/polychromic/bulge,
+/obj/item/toy/crayon/spraycan,
+/obj/item/clothing/under/pants/classicjeans,
+/obj/item/clothing/shoes/footwraps{
+	color = "#ffde7d"
+	},
+/obj/item/clothing/suit/jacket/miljacket,
+/obj/item/clothing/under/blacktango,
+/turf/open/floor/carpet/monochrome,
+/area/centcom/ferry)
+"Vl" = (
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
 "Vm" = (
 /obj/effect/landmark/holding_facility,
 /turf/open/floor/wood,
@@ -21000,6 +21732,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/one)
+"VC" = (
+/obj/machinery/button/door{
+	id = "CCDormChemlight2";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -8;
+	pixel_y = 28;
+	specialfunctions = 4
+	},
+/obj/structure/holohoop{
+	layer = 3.9
+	},
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
 "VD" = (
 /obj/structure/flora/crystal/medium/growth{
 	icon_state = "crystalgrowth3";
@@ -21058,12 +21804,9 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "VK" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 14
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
 	},
-/obj/structure/chair/comfy/black,
 /turf/open/floor/wood,
 /area/centcom/ferry)
 "VL" = (
@@ -21183,6 +21926,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"Wg" = (
+/obj/machinery/door/airlock{
+	dir = 4;
+	id_tag = null;
+	name = "Bathroom"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/centcom/ferry)
 "Wh" = (
 /obj/machinery/button/door{
 	id = "CCDormChemlight";
@@ -21191,7 +21942,16 @@
 	pixel_x = 25;
 	specialfunctions = 4
 	},
-/turf/open/floor/wood,
+/obj/structure/table/wood,
+/obj/item/gun/ballistic/automatic/c20r/toy/unrestricted,
+/obj/item/ammo_box/magazine/toy/smgm45,
+/obj/item/ammo_box/magazine/toy/smgm45,
+/obj/item/gun/ballistic/automatic/c20r/toy/unrestricted,
+/obj/item/ammo_box/magazine/toy/smgm45,
+/obj/item/ammo_box/magazine/toy/smgm45,
+/obj/item/ammo_box/foambox,
+/obj/item/ammo_box/foambox,
+/turf/open/floor/mineral/basaltstone_floor,
 /area/centcom/ferry)
 "Wi" = (
 /obj/effect/turf_decal/tile/brown,
@@ -21219,6 +21979,43 @@
 	name = "plating"
 	},
 /area/centcom/control)
+"Wl" = (
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "drain";
+	name = "drain";
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
+"Wm" = (
+/obj/structure/table/wood,
+/obj/item/clipboard{
+	pixel_x = -14
+	},
+/obj/item/pen/red{
+	pixel_x = -14
+	},
+/obj/item/folder/yellow{
+	pixel_x = -5
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/item{
+	desc = "A set of blueprints depicting a wide variety of designs, ranging from general items, weapons, equipment, and room plans. It seems so much of a mess that you can't tell what's scrapped or currently in the works.";
+	icon_state = "blueprints";
+	name = "blueprints"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
 "Wn" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 6;
@@ -21259,6 +22056,51 @@
 "Wr" = (
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"Ws" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/turf/open/floor/carpet/monochrome,
+/area/centcom/ferry)
+"Wt" = (
+/obj/structure/closet/crate/secure{
+	anchored = 1;
+	name = "secure gear crate";
+	req_access_txt = "101"
+	},
+/obj/item/clothing/suit/space/officer,
+/obj/item/clothing/head/helmet/space/beret,
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/clothing/gloves/combat,
+/obj/item/implanter/cqc,
+/obj/item/gun/energy/e_gun/stun{
+	selfcharge = 1
+	},
+/obj/item/radio/headset/headset_cent/commander,
+/obj/item/clothing/glasses/thermal,
+/obj/item/clothing/under/syndicate{
+	armor = list("melee" = 30, "bullet" =30, "laser" = 30, "energy" = 30, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 75, "acid" = 60);
+	has_sensor = 1
+	},
+/obj/item/card/id/centcom{
+	assignment = "Intelligence Officer";
+	desc = "An ID straight from Central Command.";
+	name = "Kenshin Midori's ID Card (Intelligence Officer)";
+	registered_name = "Kenshin Midori"
+	},
+/obj/item/book{
+	damtype = "stamina";
+	desc = "An old and dusty book, the pages look faded from time while looking at the pages alone makes you tired.";
+	force = 80;
+	hitsound = "punch";
+	name = "very heavy book";
+	throwforce = 160
+	},
+/obj/item/storage/box/zipties,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/storage/secure/briefcase/zao/standard,
+/turf/open/floor/pod/light,
+/area/centcom/ferry)
 "Wu" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -21294,6 +22136,39 @@
 	},
 /obj/structure/window,
 /turf/open/floor/carpet/royalblack,
+/area/centcom/ferry)
+"WA" = (
+/obj/machinery/atmospherics/pipe/manifold/general/hidden,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/rag/towel{
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/rag/towel{
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel{
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/rag/towel{
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/rag/towel{
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/rag/towel{
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/rag/towel{
+	pixel_y = 3
+	},
+/turf/open/floor/wood,
 /area/centcom/ferry)
 "WC" = (
 /obj/structure/table/reinforced,
@@ -21441,6 +22316,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"WV" = (
+/obj/structure/chair/sofa/right,
+/obj/structure/sign/painting/library{
+	pixel_y = 28
+	},
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
 "WW" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
@@ -21529,9 +22411,9 @@
 /area/centcom/ferry)
 "Xi" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/wood,
+/obj/item/camera,
+/obj/item/camera_film,
+/turf/open/floor/mineral/basaltstone_floor,
 /area/centcom/ferry)
 "Xk" = (
 /obj/structure/chair/wood/wings{
@@ -21824,6 +22706,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
+"XQ" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4;
+	icon_state = "drain";
+	name = "drain"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
 "XR" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -21857,6 +22747,55 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/evac)
+"XV" = (
+/obj/structure/closet/crate/medical,
+/obj/item/slimepotion/genderchange,
+/obj/item/slimepotion/genderchange,
+/obj/item/slimepotion/genderchange,
+/obj/item/slimepotion/genderchange,
+/obj/item/slimepotion/genderchange,
+/obj/item/slimepotion/genderchange,
+/obj/item/slimepotion/genderchange,
+/obj/item/storage/pill_bottle/penis_enlargement,
+/obj/item/storage/pill_bottle/penis_enlargement,
+/obj/item/storage/pill_bottle/penis_enlargement,
+/obj/item/storage/pill_bottle/breast_enlargement,
+/obj/item/storage/pill_bottle/breast_enlargement,
+/obj/item/storage/pill_bottle/breast_enlargement,
+/obj/item/storage/pill_bottle/breast_enlargement,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 14
+	},
+/obj/item/storage/hypospraykit/enlarge,
+/obj/item/storage/hypospraykit/enlarge,
+/obj/item/storage/hypospraykit/enlarge,
+/obj/item/storage/pill_bottle/breast_enlargement,
+/obj/item/storage/pill_bottle/breast_enlargement,
+/obj/item/storage/pill_bottle/breast_enlargement,
+/obj/item/storage/pill_bottle/breast_enlargement,
+/obj/item/storage/pill_bottle/penis_enlargement,
+/obj/item/storage/pill_bottle/penis_enlargement,
+/obj/item/storage/pill_bottle/penis_enlargement,
+/obj/item/storage/pill_bottle/penis_enlargement,
+/turf/open/floor/pod/light,
+/area/centcom/ferry)
+"XW" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-10"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer,
+/area/centcom/ferry)
 "XX" = (
 /obj/machinery/light{
 	dir = 4
@@ -22112,6 +23051,16 @@
 /obj/structure/janitorialcart,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
+"YF" = (
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Sauna"
+	},
+/turf/open/floor/wood,
+/area/centcom/ferry)
 "YG" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 10;
@@ -22123,6 +23072,10 @@
 	free = 1
 	},
 /turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
+"YH" = (
+/obj/structure/chair/bench,
+/turf/open/floor/wood,
 /area/centcom/ferry)
 "YI" = (
 /obj/structure/flora/ausbushes/reedbush,
@@ -22163,6 +23116,54 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"YM" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/obj/structure/closet,
+/obj/item/condom{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/condom,
+/obj/item/condom,
+/obj/item/condom,
+/obj/item/condom{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/condom{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/condom{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/condom{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/condom{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/condom,
+/obj/item/condom{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/sounding,
+/obj/item/fleshlight,
+/obj/item/dildo/custom,
+/obj/item/milking_machine/penis,
+/obj/item/milking_machine,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/plasteel/freezer,
+/area/centcom/ferry)
 "YN" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/carpet/black,
@@ -22191,6 +23192,19 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"YS" = (
+/obj/decal{
+	desc = "A drain built into the floor, perhaps for potential floods?.";
+	icon = 'icons/obj/machines/pool.dmi';
+	icon_state = "drain";
+	name = "drain";
+	pixel_x = -1
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
 "YT" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/neutral{
@@ -22219,6 +23233,51 @@
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"YW" = (
+/obj/structure/chair/bench/left{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/ferry)
+"YX" = (
+/obj/structure/closet/crate/wooden,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXnineteen,
+/obj/item/canvas/twentythreeXnineteen,
+/obj/item/canvas/twentythreeXnineteen,
+/obj/item/canvas/twentythreeXnineteen,
+/obj/item/canvas/twentythreeXnineteen,
+/obj/item/canvas/nineteenXnineteen,
+/obj/item/canvas/nineteenXnineteen,
+/obj/item/canvas/nineteenXnineteen,
+/obj/item/canvas/nineteenXnineteen,
+/obj/item/canvas/nineteenXnineteen,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
+"YY" = (
+/obj/structure/rack/shelf,
+/obj/item/mop/advanced{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -5;
+	pixel_y = 17
+	},
+/obj/item/storage/bag/trash,
+/obj/item/lightreplacer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/light,
+/area/centcom/ferry)
 "YZ" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck,
@@ -22242,6 +23301,11 @@
 "Zc" = (
 /turf/open/indestructible/binary,
 /area/space)
+"Zd" = (
+/obj/structure/bed/pod,
+/obj/item/bedsheet/black,
+/turf/open/floor/carpet/monochrome,
+/area/centcom/ferry)
 "Zf" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel,
@@ -22342,6 +23406,13 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Zu" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 7
+	},
+/turf/open/floor/grass/fakebasalt,
+/area/centcom/ferry)
 "Zv" = (
 /obj/structure/window{
 	dir = 4
@@ -22369,43 +23440,10 @@
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "Zy" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 14
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
 	},
-/obj/structure/closet/crate/secure{
-	anchored = 1;
-	name = "secure gear crate";
-	req_access_txt = "101"
-	},
-/obj/item/clothing/suit/space/officer,
-/obj/item/clothing/head/helmet/space/beret,
-/obj/item/clothing/shoes/combat/swat,
-/obj/item/clothing/gloves/combat,
-/obj/item/implanter/cqc,
-/obj/item/gun/energy/e_gun/stun,
-/obj/item/radio/headset/headset_cent/commander,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/under/syndicate{
-	has_sensor = 1
-	},
-/obj/item/card/id/centcom{
-	assignment = "Intelligence Officer";
-	desc = "An ID straight from Central Command.";
-	name = "Kenshin Midori's ID Card (Intelligence Officer)";
-	registered_name = "Kenshin Midori"
-	},
-/obj/item/book{
-	damtype = "stamina";
-	desc = "An old and dusty book, the pages look faded from time while looking at the pages alone makes you tired.";
-	force = 80;
-	hitsound = "punch";
-	name = "very heavy book";
-	throwforce = 160
-	},
-/obj/item/storage/box/zipties,
-/obj/item/clothing/mask/gas/sechailer,
+/obj/machinery/meter,
 /turf/open/floor/wood,
 /area/centcom/ferry)
 "Zz" = (
@@ -22436,6 +23474,16 @@
 	dir = 8
 	},
 /area/centcom/ferry)
+"ZD" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave{
+	pixel_y = 4
+	},
+/obj/structure/sign/poster/contraband/sun_kist{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/basaltstone_floor,
+/area/centcom/ferry)
 "ZE" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
@@ -22447,6 +23495,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
+"ZG" = (
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
 "ZH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -22486,6 +23542,9 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership)
+"ZM" = (
+/turf/open/floor/carpet/monochrome,
+/area/centcom/ferry)
 "ZO" = (
 /obj/structure/flora/junglebush/large{
 	pixel_x = -17;
@@ -22505,6 +23564,12 @@
 "ZQ" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/two)
+"ZR" = (
+/obj/structure/chair/bench{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/ferry)
 "ZT" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom";
@@ -22544,6 +23609,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
+"ZY" = (
+/obj/structure/table/wood/poker,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/toy/cards/deck,
+/obj/item/coin/uranium{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/monochrome,
+/area/centcom/ferry)
 
 (1,1,1) = {"
 aa
@@ -50226,14 +51304,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+mD
+mD
+mD
+mD
+mD
+mD
+mD
+mD
 aa
 aa
 aa
@@ -50483,14 +51561,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+mD
+Qn
+YY
+mD
+Bq
+FY
+XW
+mD
 aa
 aa
 aa
@@ -50740,13 +51818,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+mD
+MZ
+Vg
+mD
+RH
+Sj
+Ui
 mD
 mD
 mD
@@ -50997,13 +52075,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+mD
+XV
+Vg
+mD
+Nh
+FA
+zl
 mD
 XJ
 Up
@@ -51254,13 +52332,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+mD
+Wt
+Vg
+mD
+DB
+Ui
+YM
 mD
 Tv
 Yj
@@ -51511,13 +52589,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+mD
+mD
+OK
+mD
+mD
+Wg
+mD
 mD
 Pb
 On
@@ -51767,14 +52845,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+mD
+mD
+oB
+oB
+Bn
+Sm
+we
+Vk
 mD
 mD
 WP
@@ -52023,16 +53101,16 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+mD
+mD
+mD
+ML
+Rx
+Oo
+Vl
+Rs
+Qx
+Pd
 mD
 we
 XC
@@ -52280,16 +53358,16 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+mD
+Ba
+mD
+UJ
+Wm
+pg
+RJ
+we
+Ws
+ZY
 mD
 NZ
 OD
@@ -52536,17 +53614,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
 mD
 mD
+PH
 mD
-mD
-mD
+Uk
+Pk
+pg
+RJ
+we
+Ws
+Rc
 mD
 we
 SC
@@ -52793,17 +53871,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
 mD
-Oi
-RI
-Uz
-TQ
+Bj
+oB
+Mo
+we
+PB
+pg
+RJ
+we
+Ws
+Zd
 mD
 Xc
 PT
@@ -53049,18 +54127,18 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 mD
-Xz
-TS
-TS
-wn
+mD
+UP
+oB
+mD
+VC
+PB
+pg
+RJ
+Mj
+Qy
+ZM
 mD
 AF
 Yp
@@ -53306,17 +54384,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 mD
+tQ
+oB
+oB
 mD
+Sa
+Pc
+pg
+RJ
+Rp
 mD
-Pp
 mD
 mD
 mD
@@ -53562,19 +54640,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 mD
-CW
+mD
+Hl
+mD
+mD
+mD
+ZD
+PB
+pg
+RJ
 Xi
-oB
-qd
+Qp
+Mn
 mD
 YD
 CP
@@ -53819,19 +54897,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 mD
-VK
-UU
+TQ
+oB
+SZ
+Tx
+mD
+Lj
+PB
 pg
-TY
+pg
+Qj
+Wl
+YX
 mD
 Qf
 Yn
@@ -54076,19 +55154,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 mD
-QU
-tQ
+YH
+CW
+CW
+ZR
+mD
+WV
+PB
 pg
-Ue
+pg
+pg
+ZG
+NC
 mD
 Ml
 UI
@@ -54333,19 +55411,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 mD
-oB
+YH
+QU
+Rr
+ZR
+mD
+Td
+MX
+PM
 pg
 pg
-oB
+ZG
+SS
 mD
 Zo
 UI
@@ -54590,18 +55668,18 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 mD
-Zy
-pg
-pg
+YH
+UU
+JW
+ZR
+mD
+Sx
+Pt
+Qg
+XQ
+XQ
+Na
 vx
 mD
 wi
@@ -54847,19 +55925,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 mD
+Tm
+VK
+HL
+YW
+mD
+NW
+Df
+NQ
 Mr
 Wh
-oB
-qd
+we
+YS
 mD
 Qr
 Tp
@@ -55104,19 +56182,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 mD
-oe
 mD
-oe
+YF
+mD
+mD
+mD
+mD
 mD
 mD
 mD
 mD
 ux
-mD
+SO
 mD
 mD
 mD
@@ -55361,10 +56439,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-oe
+mD
+UH
+Zy
+mD
 WR
 Kf
 XD
@@ -55618,10 +56696,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 mD
+Cm
+Sz
+QS
 Of
 ZW
 NO
@@ -55875,10 +56953,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-oe
+mD
+Nb
+WA
+mD
 Ol
 Ld
 Ch
@@ -56132,9 +57210,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+mD
+mD
+Se
 mD
 oe
 mD
@@ -56390,8 +57468,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+mD
+MW
 mD
 Ng
 Lq
@@ -56647,8 +57725,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+mD
+RV
 mD
 yi
 Sv
@@ -56904,8 +57982,8 @@ xb
 aa
 aa
 aa
-aa
-aa
+mD
+Zu
 mD
 YI
 vp


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alrighty, this little PR is more for quality along the lines of adding more fire alarms and air alarms to some rooms that were missing or otherwise needed them, comparing it from our old map box station for example.

Additionally robotics circuit imprinter is no longer an omni printer, instead it's now just like science, being all that what they need in science.

Finally Centcom got a sauna, oh and the dog ended up remodeling their room.

## Why It's Good For The Game

Going from the first to last points, some rooms really needed air alarms such as chemistry (of course when there's a fire or explosion) and as well as robotics, for that matter it's more of a need than a reason to it, while adding some fire alarms in different areas around station, much like cargo, some parts of engineering, the captains room and bridge, near the holodeck, and dorms. While I may not have gotten everything, we'll see about fine tuning some things as time goes by.

For robotics circuit imprinter going from omni to science, this was a much needed change as many scientist powergame as it is, building their own medbay, or making advance security camera by the use of unlocking illegal technology (I don't know if science can make these on their normal printer but the omni still proves to be a go to location in science).

Finally centcom got a bit more added things to flavor, however I will need to explain how an intern got a bigger room. 🤔 More on that later.

## Changelog
:cl:
add: Several air alarms and fire alarms to Layenia
add: Added more onto Centcom
balance: rebalanced robotics circuit inprinter from omni to science
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
