### PR TITLE
Allows vending machines to throw items at people when they are broken/hacked/infected

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -568,10 +568,8 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 		speak(slogan)
 		last_slogan = world.time
 
-	/* no freebies
 	if(shoot_inventory && prob(shoot_inventory_chance))
 		throw_item()
-	*/
 
 /obj/machinery/vending/proc/speak(message)
 	if(stat & (BROKEN|NOPOWER))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

## Why It's Good For The Game

Not quite sure why/when this was removed in the first place, but having a vending machine toss things has its... Uses... Every now and then.

## Changelog
:cl:
add: Vending machines may randomly throw items at people when they are broken/hacked/infected again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
