### PR TITLE
how to fix aquatic legs in one easy step

### DIFF
--- a/modular_citadel/code/modules/mob/living/carbon/human/species_types/furrypeople.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/species_types/furrypeople.dm
@@ -102,7 +102,7 @@
 	icon_limbs = DEFAULT_BODYPART_ICON_CITADEL
 	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,HAIR,WINGCOLOR)
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	mutant_bodyparts = list("mam_tail", "mam_ears","mam_body_markings", "taur", "mam_snouts", "deco_wings")
+	mutant_bodyparts = list("mam_tail", "mam_ears","mam_body_markings", "taur", "mam_snouts", "deco_wings", "legs")
 	default_features = list("mcolor" = "FFF","mcolor2" = "FFF","mcolor3" = "FFF", "mam_tail" = "Shark", "mam_ears" = "None", "mam_body_markings" = "Shark", "mam_snouts" = "Round", "taur" = "None", "legs" = "Normal Legs", "deco_wings" = "None")
 	attack_verb = "bite"
 	attack_sound = 'sound/weapons/bite.ogg'


### PR DESCRIPTION
1. add eight letters

## About The Pull Request

apparently digitgrade legs were broken for aquatics. using my awesome sleuth skills i figured out the issue. so now in the character setup panel you can change your character's species to "aquatic" and legs to "digitigrade legs" and it will work

## Why It's Good For The Game

people begged for it

## Changelog
:cl:
fix: aquatics now properly support "digitigrade" leg type
/:cl: