### PR TITLE
Correctly categorizes two traits

### DIFF
--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -4,7 +4,7 @@
 	var/name = "Test Quirk"
 	var/desc = "This is a test quirk."
 	var/value = 0
-	var/category = "Uncategorized"	//Hyper change: Sort quirks into categories
+	var/category = CATEGORY_UNCATEGORIZED	//Hyper change: Sort quirks into categories
 	var/human_only = TRUE
 	var/gain_text
 	var/lose_text

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -159,6 +159,7 @@
 	name = "Colorist"
 	desc = "You like carrying around a hair dye spray to quickly apply color patterns to your hair."
 	value = 0
+	category = CATEGORY_ITEMS
 	medical_record_text = "Patient enjoys dyeing their hair with pretty colors."
 
 /datum/quirk/colorist/on_spawn()
@@ -176,6 +177,7 @@
 	name = "Trashcan"
 	desc = "You are able to consume and digest trash."
 	value = 0
+	category = CATEGORY_FOOD
 	gain_text = "<span class='notice'>You feel like munching on a can of soda.</span>"
 	lose_text = "<span class='notice'>You no longer feel like you should be eating trash.</span>"
 	mob_trait = TRAIT_TRASHCAN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Just a quick patch, these two were missing from the categorized view (default) and only visible in the normal trait view

## Why It's Good For The Game

Patch.

## Changelog
:cl:
fix: two traits missing from the categorized trait view
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
