### PR TITLE
Fixed 'Hidden by clothes'.

### DIFF
--- a/modular_citadel/code/modules/arousal/organs/genitals.dm
+++ b/modular_citadel/code/modules/arousal/organs/genitals.dm
@@ -83,7 +83,7 @@
 				owner.exposed_genitals += src
 		if("Hidden by clothes")
 			through_clothes = FALSE
-			hidden = TRUE
+			hidden = FALSE
 			mode = "clothes"
 			if(src in owner.exposed_genitals)
 				owner.exposed_genitals -= src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As the title suggest, this little fix handles the assets so they are hidden by clothing, instead of being always hidden like they were before.

## Why It's Good For The Game

Weirdly enough, this was something of an issue when hyper first got made after the citadel port two years later it still remains broken, until now!

## Changelog
:cl:
fix: Genitals to be hidden by clothes when selecting it in the arousal menu
code: Made a single TRUE value into FALSE
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
