### PR TITLE
Fixing 2 typos I found

### DIFF
--- a/code/game/objects/items/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/grenades/spawnergrenade.dm
@@ -43,7 +43,7 @@
 	deliveryamt = 10
 
 /obj/item/grenade/spawnergrenade/clustaur
-	desc = "A very strange grenade often found in maintanance. Use of this may constitute a war crime in your area, consult your local captain."
+	desc = "A very strange grenade often found in maintenance. Use of this may constitute a war crime in your area, consult your local captain."
 	name = "clustaur grenade"
 	icon_state = "clustaur"
 	item_state = "clustaur"

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -61,7 +61,7 @@
 
 /datum/supply_pack/security/russianclothing
 	name = "Russian Surplus Clothing"
-	desc = "An old russian crate full of surplus armor that they used to use! Has two sets of bulletproff armor, a few union suits and some warm hats!"
+	desc = "An old russian crate full of surplus armor that they used to use! Has two sets of bulletproof armor, a few union suits and some warm hats!"
 	contraband = TRUE
 	cost = 5750 // Its basicly sec suits, good boots/gloves
 	contains = list(/obj/item/clothing/suit/security/officer/russian,


### PR DESCRIPTION
## About The Pull Request

Fixes exactly 2 typos I found

## Why It's Good For The Game

Grammar :)

## Changelog
:cl:
spellcheck: fixed 2 typos, one in the clustaur grenade's description, and one in the description of a crate that will probably never be ordered anyways.
/:cl:
