### PR TITLE
Luxury Pod Density Fix

### DIFF
--- a/_maps/templates/new_pod_luxury.dmm
+++ b/_maps/templates/new_pod_luxury.dmm
@@ -31,18 +31,21 @@
 /area/survivalpod)
 "f" = (
 /obj/machinery/chem_dispenser/drinks/beer{
+	density = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/carpet/black,
 /area/survivalpod)
 "g" = (
 /obj/machinery/chem_dispenser/drinks{
+	density = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/carpet/black,
 /area/survivalpod)
 "h" = (
 /obj/machinery/vending/boozeomat/all_access{
+	density = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/black,


### PR DESCRIPTION
## About The Pull Request
Changes the luxury pod's bar objects to be non-dense.
Previously, you couldn't step behind the counter. This permits such.
See the image below for space it frees up.
![image](https://user-images.githubusercontent.com/25065997/162418059-ca4ed5ea-6c83-4a51-b3fe-06df84482d87.png)

## Why It's Good For The Game

If someone were wanting to RP bartending or anything of the sort within the pod, it would be impossible without admin intervention. This corrects such, freeing up the area as stated above.

## Changelog
:cl:
fix: Luxury Pod density corrections.
/:cl: