### PR TITLE
Brokeback Rigging 'Borgs

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -150,7 +150,7 @@
 	desc = "A diamond drill replacement for the mining module's standard drill."
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
-	module_type = /obj/item/robot_module/miner
+	module_type = list(/obj/item/robot_module/miner, /obj/item/robot_module/orepup)
 
 /obj/item/borg/upgrade/ddrill/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
@@ -182,7 +182,7 @@
 	desc = "A satchel of holding replacement for mining cyborg's ore satchel module."
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
-	module_type = /obj/item/robot_module/miner
+	module_type = list(/obj/item/robot_module/miner, /obj/item/robot_module/orepup)
 
 /obj/item/borg/upgrade/soh/action(mob/living/silicon/robot/R)
 	. = ..()
@@ -285,7 +285,7 @@
 	icon_state = "ash_plating"
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	require_module = 1
-	module_type = /obj/item/robot_module/miner
+	module_type = list(/obj/item/robot_module/miner, /obj/item/robot_module/orepup)
 
 /obj/item/borg/upgrade/lavaproof/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
@@ -417,7 +417,7 @@
 	module_type = list(
 		/obj/item/robot_module/medical,
 		/obj/item/robot_module/medihound)
-	
+
 	var/list/additional_reagents = list()
 
 /obj/item/borg/upgrade/hypospray/action(mob/living/silicon/robot/R, user = usr)

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -266,7 +266,7 @@
 	icon_state = "modkit"
 	w_class = WEIGHT_CLASS_SMALL
 	require_module = 1
-	module_type = /obj/item/robot_module/miner
+	module_type = list(/obj/item/robot_module/miner, /obj/item/robot_module/orepup)
 	var/denied_type = null
 	var/maximum_of_type = 1
 	var/cost = 30


### PR DESCRIPTION
## About The Pull Request
A simple edit to permit both Miner and Orepup borgs to receive the same upgrades.
Or, at least, _should_.

## Why It's Good For The Game
When adding the Orepup back into the game, I had made the mistake of forgetting about upgrades. This corrects such an error.

## Changelog
:cl:
fix: Orepup able to be upgraded, alongside the Miner borg.
/:cl: