### PR TITLE
Teleporter Balance Adjustment

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -76,11 +76,23 @@
 
 			if(!calibrated && iscarbon(M) && prob(30 - ((accuracy) * 10))) //oh dear a problem
 				var/mob/living/carbon/C = M
-				if(C.dna?.species && C.dna.species.id != "fly" && !HAS_TRAIT(C, TRAIT_RADIMMUNE))
-					to_chat(C, "<span class='italics'>You hear a buzzing in your ears.</span>")
-					C.set_species(/datum/species/fly)
-					log_game("[C] ([key_name(C)]) was turned into a fly person")
-					C.apply_effect((rand(120 - accuracy * 40, 180 - accuracy * 60)), EFFECT_IRRADIATE, 0)
+
+				//Rework to teleporter mishap
+				log_game("[C] ([key_name(C)]) had a teleporter mishap")
+
+
+				to_chat(C, "<span class='italics'>You feel the world contort and twist....</span>")	//idk a good line
+				C.adjustCloneLoss( rand(40,75) )
+				C.apply_effect((rand(120 - accuracy * 40, 180 - accuracy * 60)), EFFECT_IRRADIATE, 0)	//recycling this for some extra spice
+
+				//Oh yea, random limb removal, adjust/comment out if too harsh a punishment
+
+				for( var/obj/item/bodypart/BP in C.bodyparts )
+					if( BP.body_part != CHEST ) 								//I am not ready to find out what happens if your chest is missing
+						if(prob(50))
+							
+							BP.dismember()
+
 
 			calibrated = FALSE
 	return


### PR DESCRIPTION
---Why---

My personal gripes is that this is a mechanic (among a few others) that will immutably change your char for the rest of the round. To reverse this process is either jarring from a pure IC view (if they have a clone backup you just kill them + clone and act as if it never happened) or immensely tedious, bothering the xenobiologist to breed a very specific slime and make extracts, and even that might not have guaranteed results.

This is a furry rp server with rounds that routinely last 4 hours and longer. I think it's also safe to assume that the majority of people who play here do so to play a character that they have specifically created. Having a meme that turns you into a flyperson doesn't feel very compatible with these traits. Sure, it's a punishment yes, one that can be avoided with a simple button press, but in the same light, isn't that a bit excessive?

---Balance---

I wrote the values as an initial guesstimate. I am not going to pretend I know how to balance an alternative to the fly meme, but I think what I did is a suitable punishment.
you will receive a lot of clone damage, some rads and for each limb it's a 50/50 on whether you loose it, including the head.

---Finally---

I should've done this MONTHS ago, but I guess I was just in a coding mood now. 
Note that even if you are 'dissasembled' and hit with rads and clone damage, ultimately you can be repaired back into the state you were. 