### PR TITLE
Ports tgstation's Color Standardization, adds Color Defines and Signals

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -1,67 +1,155 @@
-// This is eventually for wjohn to add more color standardization stuff like I keep asking him >:(
+#define COLOR_INPUT_DISABLED			"#F0F0F0"
+#define COLOR_INPUT_ENABLED				"#D3B5B5"
 
-#define COLOR_INPUT_DISABLED "#F0F0F0"
-#define COLOR_INPUT_ENABLED "#D3B5B5"
+#define COLOR_DARKMODE_INFO_BUTTONS_BG	"#40628A"
+#define COLOR_DARKMODE_ISSUE_BUTTON_BG	"#A92C2C"
+#define COLOR_DARKMODE_BACKGROUND		"#272727"
+#define COLOR_DARKMODE_DARKBACKGROUND	"#242424"
+#define COLOR_DARKMODE_TEXT				"#E0E0E0"
 
-#define COLOR_DARKMODE_INFO_BUTTONS_BG "#40628A"
-#define COLOR_DARKMODE_ISSUE_BUTTON_BG "#A92C2C"
-#define COLOR_DARKMODE_BACKGROUND "#272727"
-#define COLOR_DARKMODE_DARKBACKGROUND "#242424"
-#define COLOR_DARKMODE_TEXT "#E0E0E0"
+#define COLOR_WHITEMODE_INFO_BUTTONS_BG	"#90B3DD"
+#define COLOR_WHITEMODE_ISSUE_BUTTON_BG	"#EF7F7F"
+#define COLOR_WHITEMODE_BACKGROUND		"#F0F0F0"
+#define COLOR_WHITEMODE_DARKBACKGROUND	"#E6E6E6"
+#define COLOR_WHITEMODE_TEXT			"#000000"
 
-#define COLOR_WHITEMODE_INFO_BUTTONS_BG "#90B3DD"
-#define COLOR_WHITEMODE_ISSUE_BUTTON_BG "##EF7F7F"
-#define COLOR_WHITEMODE_BACKGROUND "#F0F0F0"
-#define COLOR_WHITEMODE_DARKBACKGROUND "#E6E6E6"
-#define COLOR_WHITEMODE_TEXT "#000000"
 
-#define COLOR_FLOORTILE_GRAY   "#8D8B8B"
-#define COLOR_ALMOST_BLACK	   "#333333"
-#define COLOR_SILVER	       "#C0C0C0"
-#define COLOR_BLACK            "#000000"
-#define COLOR_RED              "#FF0000"
-#define COLOR_RED_LIGHT        "#FF3333"
-#define COLOR_MAROON           "#800000"
-#define COLOR_YELLOW           "#FFFF00"
-#define COLOR_OLIVE            "#808000"
-#define COLOR_LIME             "#32CD32"
-#define COLOR_GREEN            "#008000"
-#define COLOR_CYAN             "#00FFFF"
-#define COLOR_TEAL             "#008080"
-#define COLOR_BLUE             "#0000FF"
-#define COLOR_BLUE_LIGHT       "#33CCFF"
-#define COLOR_NAVY             "#000080"
-#define COLOR_PINK             "#FFC0CB"
-#define COLOR_MAGENTA          "#FF00FF"
-#define COLOR_PURPLE           "#800080"
-#define COLOR_ORANGE           "#FF9900"
-#define COLOR_BEIGE            "#CEB689"
-#define COLOR_BLUE_GRAY        "#75A2BB"
-#define COLOR_BROWN            "#BA9F6D"
-#define COLOR_DARK_BROWN       "#997C4F"
-#define COLOR_DARK_ORANGE      "#C3630C"
-#define COLOR_GREEN_GRAY       "#99BB76"
-#define COLOR_RED_GRAY         "#B4696A"
-#define COLOR_PALE_BLUE_GRAY   "#98C5DF"
-#define COLOR_PALE_GREEN_GRAY  "#B7D993"
-#define COLOR_PALE_RED_GRAY    "#D59998"
-#define COLOR_PALE_PURPLE_GRAY "#CBB1CA"
-#define COLOR_PURPLE_GRAY      "#AE8CA8"
+#define COLOR_WHITE						"#FFFFFF"
+#define COLOR_VERY_VERY_LIGHT_GRAY		"#F0F0F0"
+#define COLOR_VERY_LIGHT_GRAY			"#EEEEEE"
+#define COLOR_SILVER					"#C0C0C0"
+#define COLOR_GRAY						"#808080"
+#define COLOR_FLOORTILE_GRAY			"#8D8B8B"
+#define COLOR_ALMOST_BLACK				"#333333"
+#define COLOR_NEARLY_BLACK				"#202020"
+#define COLOR_BLACK						"#000000"
+
+#define COLOR_RED						"#FF0000"
+#define COLOR_MOSTLY_PURE_RED			"#FF3300"
+#define COLOR_DARK_RED					"#A50824"
+#define COLOR_RED_LIGHT					"#FF3333"
+#define COLOR_MAROON					"#800000"
+#define COLOR_VIVID_RED					"#FF3232"
+#define COLOR_LIGHT_GRAYISH_RED			"#E4C7C5"
+#define COLOR_SOFT_RED					"#FA8282"
+
+#define COLOR_YELLOW					"#FFFF00"
+#define COLOR_VIVID_YELLOW				"#FBFF23"
+#define COLOR_VERY_SOFT_YELLOW			"#FAE48E"
+
+#define COLOR_OLIVE						"#808000"
+#define COLOR_GREEN						"#00FF00"
+#define COLOR_LIME						"#32CD32"
+#define COLOR_VERY_PALE_LIME_GREEN		"#DDFFD3"
+#define COLOR_VERY_DARK_LIME_GREEN		"#003300"
+#define COLOR_DARK_GREEN				"#008000"
+#define COLOR_DARK_MODERATE_LIME_GREEN	"#44964A"
+
+#define COLOR_CYAN						"#00FFFF"
+#define COLOR_DARK_CYAN					"#00A2FF"
+#define COLOR_TEAL						"#008080"
+#define COLOR_BLUE						"#0000FF"
+#define COLOR_BRIGHT_BLUE				"#2CB2E8"
+#define COLOR_MODERATE_BLUE				"#555CC2"
+#define COLOR_BLUE_LIGHT				"#33CCFF"
+#define COLOR_NAVY						"#000080"
+#define COLOR_BLUE_GRAY					"#75A2BB"
+
+#define COLOR_PINK						"#FFC0CB"
+#define COLOR_MOSTLY_PURE_PINK			"#E4005B"
+#define COLOR_MAGENTA					"#FF00FF"
+#define COLOR_STRONG_MAGENTA			"#B800B8"
+#define COLOR_PURPLE					"#800080"
+#define COLOR_VIOLET					"#B900F7"
+#define COLOR_STRONG_VIOLET				"#6927C5"
+
+#define COLOR_ORANGE					"#FF9900"
+#define COLOR_TAN_ORANGE				"#FF7B00"
+#define COLOR_BRIGHT_ORANGE				"#E2853D"
+#define COLOR_LIGHT_ORANGE				"#FFC44D"
+#define COLOR_CREAMY_ORANGE				"#FFCC66"
+#define COLOR_PALE_ORANGE				"#FFBE9D"
+#define COLOR_BEIGE						"#CEB689"
+#define COLOR_DARK_ORANGE				"#C3630C"
+#define COLOR_DARK_MODERATE_ORANGE		"#8B633B"
+
+#define COLOR_BROWN						"#BA9F6D"
+#define COLOR_DARK_BROWN				"#997C4F"
+
+#define COLOR_GREEN_GRAY       			"#99BB76"
+#define COLOR_RED_GRAY					"#B4696A"
+#define COLOR_PALE_BLUE_GRAY			"#98C5DF"
+#define COLOR_PALE_GREEN_GRAY			"#B7D993"
+#define COLOR_PALE_RED_GRAY				"#D59998"
+#define COLOR_PALE_PURPLE_GRAY			"#CBB1CA"
+#define COLOR_PURPLE_GRAY				"#AE8CA8"
 
 //Color defines used by the assembly detailer.
-#define COLOR_ASSEMBLY_BLACK   "#545454"
-#define COLOR_ASSEMBLY_BGRAY   "#9497AB"
-#define COLOR_ASSEMBLY_WHITE   "#E2E2E2"
-#define COLOR_ASSEMBLY_RED     "#CC4242"
-#define COLOR_ASSEMBLY_ORANGE  "#E39751"
-#define COLOR_ASSEMBLY_BEIGE   "#AF9366"
-#define COLOR_ASSEMBLY_BROWN   "#97670E"
-#define COLOR_ASSEMBLY_GOLD    "#AA9100"
-#define COLOR_ASSEMBLY_YELLOW  "#CECA2B"
-#define COLOR_ASSEMBLY_GURKHA  "#999875"
-#define COLOR_ASSEMBLY_LGREEN  "#789876"
-#define COLOR_ASSEMBLY_GREEN   "#44843C"
-#define COLOR_ASSEMBLY_LBLUE   "#5D99BE"
-#define COLOR_ASSEMBLY_BLUE    "#38559E"
-#define COLOR_ASSEMBLY_PURPLE  "#6F6192"
-#define COLOR_ASSEMBLY_PINK    "#ff4adc"
+#define COLOR_ASSEMBLY_BLACK			"#545454"
+#define COLOR_ASSEMBLY_BGRAY			"#9497AB"
+#define COLOR_ASSEMBLY_WHITE			"#E2E2E2"
+#define COLOR_ASSEMBLY_RED				"#CC4242"
+#define COLOR_ASSEMBLY_ORANGE			"#E39751"
+#define COLOR_ASSEMBLY_BEIGE			"#AF9366"
+#define COLOR_ASSEMBLY_BROWN			"#97670E"
+#define COLOR_ASSEMBLY_GOLD				"#AA9100"
+#define COLOR_ASSEMBLY_YELLOW			"#CECA2B"
+#define COLOR_ASSEMBLY_GURKHA			"#999875"
+#define COLOR_ASSEMBLY_LGREEN			"#789876"
+#define COLOR_ASSEMBLY_GREEN			"#44843C"
+#define COLOR_ASSEMBLY_LBLUE			"#5D99BE"
+#define COLOR_ASSEMBLY_BLUE				"#38559E"
+#define COLOR_ASSEMBLY_PURPLE			"#6F6192"
+#define COLOR_ASSEMBLY_PINK    			"#FF4ADC"
+
+/**
+ * Some defines to generalise colours used in lighting.
+ *
+ * Important note: colors can end up significantly different from the basic html picture, especially when saturated
+ */
+/// Bright but quickly dissipating neon green. rgb(100, 200, 100)
+#define LIGHT_COLOR_GREEN				"#64C864"
+/// Electric green. rgb(0, 255, 0)
+#define LIGHT_COLOR_ELECTRIC_GREEN		"#00FF00"
+/// Cold, diluted blue. rgb(100, 150, 250)
+#define LIGHT_COLOR_BLUE				"#6496FA"
+/// Light blueish green. rgb(125, 225, 175)
+#define LIGHT_COLOR_BLUEGREEN			"#7DE1AF"
+/// Diluted cyan. rgb(125, 225, 225)
+#define LIGHT_COLOR_CYAN				"#7DE1E1"
+/// Electric cyan rgb(0, 255, 255)
+#define LIGHT_COLOR_ELECTRIC_CYAN		"#00FFFF"
+/// More-saturated cyan. rgb(16, 21, 22)
+#define LIGHT_COLOR_LIGHT_CYAN			"#40CEFF"
+/// Saturated blue. rgb(51, 117, 248)
+#define LIGHT_COLOR_DARK_BLUE			"#6496FA"
+/// Diluted, mid-warmth pink. rgb(225, 125, 225)
+#define LIGHT_COLOR_PINK				"#E17DE1"
+/// Dimmed yellow, leaning kaki. rgb(225, 225, 125)
+#define LIGHT_COLOR_YELLOW				"#E1E17D"
+/// Clear brown, mostly dim. rgb(150, 100, 50)
+#define LIGHT_COLOR_BROWN				"#966432"
+/// Mostly pure orange. rgb(250, 150, 50)
+#define LIGHT_COLOR_ORANGE				"#FA9632"
+/// Light Purple. rgb(149, 44, 244)
+#define LIGHT_COLOR_PURPLE				"#952CF4"
+/// Less-saturated light purple. rgb(155, 81, 255)
+#define LIGHT_COLOR_LAVENDER			"#9B51FF"
+///slightly desaturated bright yellow.
+#define LIGHT_COLOR_HOLY_MAGIC			"#FFF743"
+/// deep crimson
+#define LIGHT_COLOR_BLOOD_MAGIC			"#D00000"
+
+/* These ones aren't a direct colour like the ones above, because nothing would fit */
+/// Warm orange color, leaning strongly towards yellow. rgb(250, 160, 25)
+#define LIGHT_COLOR_FIRE				"#FAA019"
+/// Very warm yellow, leaning slightly towards orange. rgb(196, 138, 24)
+#define LIGHT_COLOR_LAVA				"#C48A18"
+/// Bright, non-saturated red. Leaning slightly towards pink for visibility. rgb(250, 100, 75)
+#define LIGHT_COLOR_FLARE				"#FA644B"
+/// Weird color, between yellow and green, very slimy. rgb(175, 200, 75)
+#define LIGHT_COLOR_SLIME_LAMP			"#AFC84B"
+/// Extremely diluted yellow, close to skin color (for some reason). rgb(250, 225, 175)
+#define LIGHT_COLOR_TUNGSTEN			"#FAE1AF"
+/// Barely visible cyan-ish hue, as the doctor prescribed. rgb(240, 250, 250)
+#define LIGHT_COLOR_HALOGEN				"#F0FAFA"

--- a/code/__DEFINES/cult.dm
+++ b/code/__DEFINES/cult.dm
@@ -1,5 +1,5 @@
 //rune colors, for easy reference
-#define RUNE_COLOR_TALISMAN "#0000FF"
+#define RUNE_COLOR_TALISMAN COLOR_BLUE
 #define RUNE_COLOR_TELEPORT "#551A8B"
 #define RUNE_COLOR_OFFER "#FFFFFF"
 #define RUNE_COLOR_DARKRED "#7D1717"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -112,8 +112,6 @@
 ///from obj/machinery/bsa/full/proc/fire(): ()
 #define COMSIG_ATOM_BSA_BEAM "atom_bsa_beam_pass"
 	#define COMSIG_ATOM_BLOCKS_BSA_BEAM (1<<0)
-///from base of atom/set_light(): (l_range, l_power, l_color)
-#define COMSIG_ATOM_SET_LIGHT "atom_set_light"
 ///from base of atom/setDir(): (old_dir, new_dir)
 #define COMSIG_ATOM_DIR_CHANGE "atom_dir_change"
 ///from base of atom/handle_atom_del(): (atom/deleted)
@@ -160,6 +158,17 @@
 #define COMSIG_ATOM_ATTACK_PAW "atom_attack_paw"				//from base of atom/attack_paw(): (mob/user)
 	#define COMPONENT_NO_ATTACK_HAND 1							//works on all 3.
 /////////////////
+
+///from base of atom/set_light(): (l_range, l_power, l_color)
+#define COMSIG_ATOM_SET_LIGHT "atom_set_light"
+///Called right before the atom changes the value of light_range to a different one, from base atom/set_light_range(): (new_range)
+#define COMSIG_ATOM_SET_LIGHT_RANGE "atom_set_light_range"
+///Called right before the atom changes the value of light_power to a different one, from base atom/set_light_power(): (new_power)
+#define COMSIG_ATOM_SET_LIGHT_POWER "atom_set_light_power"
+///Called right before the atom changes the value of light_color to a different one, from base atom/set_light_color(): (new_color)
+#define COMSIG_ATOM_SET_LIGHT_COLOR "atom_set_light_color"
+///Called right before the atom changes the value of light_on to a different one, from base atom/set_light_on(): (new_value)
+#define COMSIG_ATOM_SET_LIGHT_ON "atom_set_light_on"
 
 //This signal return value bitflags can be found in __DEFINES/misc.dm
 

--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -25,37 +25,6 @@
 		0, 0, 0, 1           \
 	)                        \
 
-
-//Some defines to generalise colours used in lighting.
-//Important note on colors. Colors can end up significantly different from the basic html picture, especially when saturated
-#define LIGHT_COLOR_WHITE		"#FFFFFF"
-#define LIGHT_COLOR_RED        "#FA8282" //Warm but extremely diluted red. rgb(250, 130, 130)
-#define LIGHT_COLOR_GREEN      "#64C864" //Bright but quickly dissipating neon green. rgb(100, 200, 100)
-#define LIGHT_COLOR_BLUE       "#6496FA" //Cold, diluted blue. rgb(100, 150, 250)
-
-#define LIGHT_COLOR_BLUEGREEN  "#7DE1AF" //Light blueish green. rgb(125, 225, 175)
-#define LIGHT_COLOR_PALEBLUE   "#7DAFE1" //A pale blue-ish color. rgb(125, 175, 225)
-#define LIGHT_COLOR_CYAN       "#7DE1E1" //Diluted cyan. rgb(125, 225, 225)
-#define LIGHT_COLOR_LIGHT_CYAN "#40CEFF" //More-saturated cyan. rgb(64, 206, 255)
-#define LIGHT_COLOR_DARK_BLUE  "#6496FA" //Saturated blue. rgb(51, 117, 248)
-#define LIGHT_COLOR_PINK       "#E17DE1" //Diluted, mid-warmth pink. rgb(225, 125, 225)
-#define LIGHT_COLOR_YELLOW     "#E1E17D" //Dimmed yellow, leaning kaki. rgb(225, 225, 125)
-#define LIGHT_COLOR_BROWN      "#966432" //Clear brown, mostly dim. rgb(150, 100, 50)
-#define LIGHT_COLOR_ORANGE     "#FA9632" //Mostly pure orange. rgb(250, 150, 50)
-#define LIGHT_COLOR_PURPLE     "#952CF4" //Light Purple. rgb(149, 44, 244)
-#define LIGHT_COLOR_LAVENDER   "#9B51FF" //Less-saturated light purple. rgb(155, 81, 255)
-
-#define LIGHT_COLOR_HOLY_MAGIC	"#FFF743" //slightly desaturated bright yellow.
-#define LIGHT_COLOR_BLOOD_MAGIC	"#D00000" //deep crimson
-
-//These ones aren't a direct colour like the ones above, because nothing would fit
-#define LIGHT_COLOR_FIRE       "#FAA019" //Warm orange color, leaning strongly towards yellow. rgb(250, 160, 25)
-#define LIGHT_COLOR_LAVA       "#C48A18" //Very warm yellow, leaning slightly towards orange. rgb(196, 138, 24)
-#define LIGHT_COLOR_FLARE      "#FA644B" //Bright, non-saturated red. Leaning slightly towards pink for visibility. rgb(250, 100, 75)
-#define LIGHT_COLOR_SLIME_LAMP "#AFC84B" //Weird color, between yellow and green, very slimy. rgb(175, 200, 75)
-#define LIGHT_COLOR_TUNGSTEN   "#FAE1AF" //Extremely diluted yellow, close to skin color (for some reason). rgb(250, 225, 175)
-#define LIGHT_COLOR_HALOGEN    "#F0FAFA" //Barely visible cyan-ish hue, as the doctor prescribed. rgb(240, 250, 250)
-
 #define LIGHT_RANGE_FIRE		3 //How many tiles standard fires glow.
 
 #define LIGHTING_PLANE_ALPHA_VISIBLE 255
@@ -94,7 +63,7 @@
 /// Parse the hexadecimal color into lumcounts of each perspective.
 #define PARSE_LIGHT_COLOR(source) \
 do { \
-	if (source.light_color) { \
+	if (source.light_color != COLOR_WHITE) { \
 		var/__light_color = source.light_color; \
 		source.lum_r = GETREDPART(__light_color) / 255; \
 		source.lum_g = GETGREENPART(__light_color) / 255; \

--- a/code/__HELPERS/_cit_helpers.dm
+++ b/code/__HELPERS/_cit_helpers.dm
@@ -90,9 +90,9 @@ GLOBAL_LIST_INIT(dildo_colors, list(//mostly neon colors
 		"Blue"		= "#00d2ff",//blue
 		"Lime"		= "#89ff00",//lime
 		"Black"		= "#101010",//black
-		"Red"		= "#ff0000",//red
+		"Red"		= "#FF0000",//red
 		"Orange"	= "#ff9a00",//orange
-		"Purple"	= "#e300ff"//purple
+		"Purple"	= "#e300ff",//purple
 		))
 
 //Crew objective and miscreants stuff

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -256,8 +256,8 @@ world
 	else
 		// solid color
 		I = new(src)
-		I.Blend("#000000", ICON_OVERLAY)
-		I.SwapColor("#000000", null)
+		I.Blend(COLOR_BLACK, ICON_OVERLAY)
+		I.SwapColor(COLOR_BLACK, null)
 		I.Blend(icon, ICON_OVERLAY)
 	var/icon/J = new(src)
 	J.Opaque()
@@ -265,7 +265,7 @@ world
 	Blend(I, ICON_OR)
 
 // make this icon fully opaque--transparent pixels become black
-/icon/proc/Opaque(background = "#000000")
+/icon/proc/Opaque(background = COLOR_BLACK)
 	SwapColor(null, background)
 	MapColors(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,0, 0,0,0,1)
 
@@ -427,10 +427,10 @@ world
 
 /proc/HSVtoRGB(hsv)
 	if(!hsv)
-		return "#000000"
+		return COLOR_BLACK
 	var/list/HSV = ReadHSV(hsv)
 	if(!HSV)
-		return "#000000"
+		return COLOR_BLACK
 
 	var/hue = HSV[1]
 	var/sat = HSV[2]
@@ -682,9 +682,9 @@ world
 	var/tone_gray = TONE[1]*0.3 + TONE[2]*0.59 + TONE[3]*0.11
 
 	if(gray <= tone_gray)
-		return BlendRGB("#000000", tone, gray/(tone_gray || 1))
+		return BlendRGB(COLOR_BLACK, tone, gray/(tone_gray || 1))
 	else
-		return BlendRGB(tone, "#ffffff", (gray-tone_gray)/((255-tone_gray) || 1))
+		return BlendRGB(tone, COLOR_WHITE, (gray-tone_gray)/((255-tone_gray) || 1))
 
 
 //Used in the OLD chem colour mixing algorithm

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -451,19 +451,19 @@
 
 /proc/color2hex(color)	//web colors
 	if(!color)
-		return "#000000"
+		return COLOR_BLACK
 
 	switch(color)
 		if("white")
-			return "#FFFFFF"
+			return COLOR_WHITE
 		if("black")
-			return "#000000"
+			return COLOR_BLACK
 		if("gray")
 			return "#808080"
 		if("brown")
 			return "#A52A2A"
 		if("red")
-			return "#FF0000"
+			return COLOR_RED
 		if("darkred")
 			return "#8B0000"
 		if("crimson")
@@ -471,23 +471,23 @@
 		if("orange")
 			return "#FFA500"
 		if("yellow")
-			return "#FFFF00"
+			return COLOR_YELLOW
 		if("green")
-			return "#008000"
+			return COLOR_DARK_GREEN
 		if("lime")
-			return "#00FF00"
+			return COLOR_GREEN
 		if("darkgreen")
 			return "#006400"
 		if("cyan")
-			return "#00FFFF"
+			return COLOR_CYAN
 		if("blue")
-			return "#0000FF"
+			return COLOR_BLUE
 		if("navy")
-			return "#000080"
+			return COLOR_NAVY
 		if("teal")
-			return "#008080"
+			return COLOR_TEAL
 		if("purple")
-			return "#800080"
+			return COLOR_PURPLE
 		if("indigo")
 			return "#4B0082"
 		else

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -145,13 +145,13 @@
 	alpha = 80
 
 /obj/screen/fullscreen/color_vision/green
-	color = "#00ff00"
+	color = COLOR_GREEN
 
 /obj/screen/fullscreen/color_vision/red
-	color = "#ff0000"
+	color = COLOR_RED
 
 /obj/screen/fullscreen/color_vision/blue
-	color = "#0000ff"
+	color = COLOR_BLUE
 
 /obj/screen/fullscreen/lighting_backdrop
 	icon = 'icons/mob/screen_gen.dmi'

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -154,9 +154,9 @@
 	item_overlay.alpha = 92
 
 	if(!user.can_equip(holding, slot_id, TRUE))
-		item_overlay.color = "#FF0000"
+		item_overlay.color = COLOR_RED
 	else
-		item_overlay.color = "#00ff00"
+		item_overlay.color = COLOR_GREEN
 
 	object_overlays += item_overlay
 	add_overlay(object_overlays)

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -244,7 +244,7 @@ SUBSYSTEM_DEF(air)
 	active_turfs -= T
 	SSair_turfs.currentrun -= T
 	#ifdef VISUALIZE_ACTIVE_TURFS
-	T.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, "#00ff00")
+	T.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, COLOR_GREEN)
 	#endif
 	if(istype(T))
 		T.excited = 0
@@ -255,7 +255,7 @@ SUBSYSTEM_DEF(air)
 /datum/controller/subsystem/air/proc/add_to_active(turf/open/T, blockchanges = 1)
 	if(istype(T) && T.air)
 		#ifdef VISUALIZE_ACTIVE_TURFS
-		T.add_atom_colour("#00ff00", TEMPORARY_COLOUR_PRIORITY)
+		T.add_atom_colour(COLOR_GREEN, TEMPORARY_COLOUR_PRIORITY)
 		#endif
 		T.excited = TRUE
 		active_turfs[T] = SSair_turfs.currentrun[T] = TRUE

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -395,7 +395,7 @@
 /datum/status_effect/sword_spin/on_apply()
 	owner.visible_message("<span class='danger'>[owner] begins swinging the sword with inhuman strength!</span>")
 	var/oldcolor = owner.color
-	owner.color = "#ff0000"
+	owner.color = COLOR_RED
 	owner.add_stun_absorption("bloody bastard sword", duration, 2, "doesn't even flinch as the sword's power courses through them!", "You shrug off the stun!", " glowing with a blazing red aura!")
 	owner.spin(duration,1)
 	animate(owner, color = oldcolor, time = duration, easing = EASE_IN)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -13,6 +13,19 @@
 	//HUD images that this atom can provide.
 	var/list/hud_possible
 
+	///Range of the emitted light in tiles. Zero means no light.
+	var/light_range = 0
+	///Intensity of the light. The stronger, the less shadows you will see on the lit area.
+	var/light_power = 1
+	///Hexidecimal RGB string representing the colour of the light. White by default.
+	var/light_color = COLOR_WHITE
+	///Boolean variable for togglable lights. Has no effect without the proper light_system, light_range and light_power values.
+	var/light_on = TRUE
+	///Our light source. Don't fuck with this directly unless you have a good reason!
+	var/tmp/datum/light_source/light
+	///Any light sources that are "inside" of us, for example, if src here was a mob that's carrying a flashlight, that flashlight's light source would be part of this list.
+	var/tmp/list/light_sources
+
 	/// Last name used to calculate a color for the chatmessage overlays
 	var/chat_color_name
 	/// Last color calculated for the the chatmessage overlays

--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -67,7 +67,7 @@
 	sharpness = IS_BLUNT
 	item_color = "yellow"
 	heat = 0
-	light_color = "#ffff00"
+	light_color = COLOR_YELLOW
 	var/next_trombone_allowed = 0
 
 /obj/item/melee/transforming/energy/sword/bananium/Initialize()

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -2,12 +2,12 @@
 	name = "\improper AI system integrity restorer"
 	desc = "Used with intelliCards containing nonfunctional AIs to restore them to working order."
 	req_access = list(ACCESS_CAPTAIN, ACCESS_ROBOTICS, ACCESS_HEADS)
-	var/mob/living/silicon/ai/occupier = null
-	var/active = 0
 	circuit = /obj/item/circuitboard/computer/aifixer
 	icon_keyboard = "tech_key"
 	icon_screen = "ai-fixer"
 	light_color = LIGHT_COLOR_PINK
+	var/mob/living/silicon/ai/occupier = null
+	var/active = 0
 
 /obj/machinery/computer/aifixer/attackby(obj/I, mob/user, params)
 	if(occupier && istype(I, /obj/item/screwdriver))

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -11,6 +11,7 @@
 	icon_keyboard = null
 	icon_screen = "invaders"
 	clockwork = TRUE //it'd look weird
+	light_color = LIGHT_COLOR_GREEN
 	var/list/prizes = list(
 		/obj/item/toy/balloon = ARCADE_WEIGHT_USELESS,
 		/obj/item/toy/beach_ball = ARCADE_WEIGHT_USELESS,
@@ -71,8 +72,6 @@
 
 		/obj/item/clothing/mask/fakemoustache/italian = ARCADE_WEIGHT_RARE
 	)
-
-	light_color = LIGHT_COLOR_GREEN
 
 /obj/machinery/computer/arcade/proc/Reset()
 	return

--- a/code/game/machinery/computer/atmos_alert.dm
+++ b/code/game/machinery/computer/atmos_alert.dm
@@ -4,12 +4,11 @@
 	circuit = /obj/item/circuitboard/computer/atmos_alert
 	icon_screen = "alert:0"
 	icon_keyboard = "atmos_key"
+	light_color = LIGHT_COLOR_CYAN
 	var/list/priority_alarms = list()
 	var/list/minor_alarms = list()
 	var/receive_frequency = FREQ_ATMOS_ALARMS
 	var/datum/radio_frequency/radio_connection
-
-	light_color = LIGHT_COLOR_CYAN
 
 /obj/machinery/computer/atmos_alert/Initialize()
 	. = ..()

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -91,6 +91,7 @@ GLOBAL_LIST_EMPTY(atmos_air_controllers)
 	icon_screen = "tank"
 	icon_keyboard = "atmos_key"
 	circuit = /obj/item/circuitboard/computer/atmos_control
+	light_color = LIGHT_COLOR_CYAN
 	ui_x = 400
 	ui_y = 925
 
@@ -110,8 +111,6 @@ GLOBAL_LIST_EMPTY(atmos_air_controllers)
 	)
 	var/list/sensor_information = list()
 	var/datum/radio_frequency/radio_connection
-
-	light_color = LIGHT_COLOR_CYAN
 
 /obj/machinery/computer/atmos_control/Initialize()
 	. = ..()

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -4,11 +4,10 @@
 	icon_screen = "cameras"
 	icon_keyboard = "security_key"
 	circuit = /obj/item/circuitboard/computer/security
+	light_color = COLOR_SOFT_RED
 	var/last_pic = 1
 	var/list/network = list("ss13")
 	var/list/watchers = list() //who's using the console, associated with the camera they're on.
-
-	light_color = LIGHT_COLOR_RED
 
 /obj/machinery/computer/security/Initialize()
 	. = ..()

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -3,6 +3,7 @@
 	desc = "Used to access the various cameras on the station."
 	icon_screen = "cameras"
 	icon_keyboard = "security_key"
+	light_color = COLOR_SOFT_RED
 	var/list/z_lock = list() // Lock use to these z levels
 	var/lock_override = NONE
 	var/mob/camera/aiEye/remote/eyeobj
@@ -11,8 +12,6 @@
 	var/datum/action/innate/camera_off/off_action = new
 	var/datum/action/innate/camera_jump/jump_action = new
 	var/list/actions = list()
-
-	light_color = LIGHT_COLOR_RED
 
 /obj/machinery/computer/camera_advanced/Initialize()
 	. = ..()

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -16,6 +16,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 	icon_keyboard = "id_key"
 	req_one_access = list(ACCESS_HEADS, ACCESS_CHANGE_IDS)
 	circuit = /obj/item/circuitboard/computer/card
+	light_color = LIGHT_COLOR_BLUE
 	var/mode = 0
 	var/printing = null
 	var/target_dept = 0 //Which department this computer has access to. 0=all departments
@@ -48,8 +49,6 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 	var/obj/item/card/id/inserted_modify_id
 	var/list/region_access = null
 	var/list/head_subordinates = null
-
-	light_color = LIGHT_COLOR_BLUE
 
 /obj/machinery/computer/card/proc/get_jobs()
 	return get_all_jobs()
@@ -621,8 +620,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 /obj/machinery/computer/card/minor/hos
 	target_dept = 2
 	icon_screen = "idhos"
-
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 
 /obj/machinery/computer/card/minor/cmo
 	target_dept = 3
@@ -631,19 +629,16 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 /obj/machinery/computer/card/minor/rd
 	target_dept = 4
 	icon_screen = "idrd"
-
 	light_color = LIGHT_COLOR_PINK
 
 /obj/machinery/computer/card/minor/ce
 	target_dept = 5
 	icon_screen = "idce"
-
 	light_color = LIGHT_COLOR_YELLOW
 
 /obj/machinery/computer/card/minor/qm
 	target_dept = 6
 	icon_screen = "idqm"
-
 	light_color = LIGHT_COLOR_ORANGE
 
 #undef JOB_ALLOWED

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -6,6 +6,7 @@
 	icon_keyboard = "tech_key"
 	req_access = list(ACCESS_HEADS)
 	circuit = /obj/item/circuitboard/computer/communications
+	light_color = LIGHT_COLOR_BLUE
 	var/auth_id = "Unknown" //Who is currently logged in?
 	var/list/datum/comm_message/messages = list()
 	var/datum/comm_message/currmsg
@@ -31,8 +32,6 @@
 	var/stat_msg2
 
 	var/datum/lore/atc_controller/ATC
-
-	light_color = LIGHT_COLOR_BLUE
 
 /obj/machinery/computer/communications/proc/checkCCcooldown()
 	var/obj/item/circuitboard/computer/communications/CM = circuit

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -7,6 +7,7 @@
 	icon_keyboard = "med_key"
 	req_one_access = list(ACCESS_MEDICAL, ACCESS_FORENSICS_LOCKERS)
 	circuit = /obj/item/circuitboard/computer/med_data
+	light_color = LIGHT_COLOR_BLUE
 	var/rank = null
 	var/screen = null
 	var/datum/data/record/active1
@@ -16,8 +17,6 @@
 	//Sorting Variables
 	var/sortBy = "name"
 	var/order = 1 // -1 = Descending - 1 = Ascending
-
-	light_color = LIGHT_COLOR_BLUE
 
 /obj/machinery/computer/med_data/syndie
 	icon_keyboard = "syndie_key"

--- a/code/game/machinery/computer/prisoner/gulag_teleporter.dm
+++ b/code/game/machinery/computer/prisoner/gulag_teleporter.dm
@@ -6,6 +6,7 @@
 	icon_keyboard = "security_key"
 	req_access = list(ACCESS_ARMORY)
 	circuit = /obj/item/circuitboard/computer/gulag_teleporter_console
+	light_color = COLOR_SOFT_RED
 	ui_x = 350
 	ui_y = 295
 
@@ -14,8 +15,6 @@
 	var/obj/structure/gulag_beacon/beacon = null
 	var/mob/living/carbon/human/prisoner = null
 	var/datum/data/record/temporary_record = null
-
-	light_color = LIGHT_COLOR_RED
 
 /obj/machinery/computer/prisoner/gulag_teleporter_computer/Initialize()
 	. = ..()

--- a/code/game/machinery/computer/prisoner/management.dm
+++ b/code/game/machinery/computer/prisoner/management.dm
@@ -5,15 +5,14 @@
 	icon_screen = "explosive"
 	icon_keyboard = "security_key"
 	req_access = list(ACCESS_BRIG)
+	circuit = /obj/item/circuitboard/computer/prisoner
+	light_color = COLOR_SOFT_RED
 	var/id = 0
 	var/temp = null
 	var/status = 0
 	var/timeleft = 60
 	var/stop = 0
 	var/screen = 0 // 0 - No Access Denied, 1 - Access allowed
-	circuit = /obj/item/circuitboard/computer/prisoner
-
-	light_color = LIGHT_COLOR_RED
 
 /obj/machinery/computer/prisoner/management/ui_interact(mob/user)
 	. = ..()

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -5,6 +5,7 @@
 	icon_keyboard = "security_key"
 	req_one_access = list(ACCESS_SECURITY, ACCESS_FORENSICS_LOCKERS)
 	circuit = /obj/item/circuitboard/computer/secure_data
+	light_color = COLOR_SOFT_RED
 	var/rank = null
 	var/screen = null
 	var/datum/data/record/active1 = null
@@ -17,8 +18,6 @@
 	//Sorting Variables
 	var/sortBy = "name"
 	var/order = 1 // -1 = Descending - 1 = Ascending
-
-	light_color = LIGHT_COLOR_RED
 
 /obj/machinery/computer/secure_data/syndie
 	icon_keyboard = "syndie_key"

--- a/code/game/machinery/computer/telecrystalconsoles.dm
+++ b/code/game/machinery/computer/telecrystalconsoles.dm
@@ -11,7 +11,7 @@ GLOBAL_LIST_INIT(possible_uplinker_IDs, list("Alfa","Bravo","Charlie","Delta","E
 	clockwork = TRUE //it'd look weird, at least if ratvar ever got there
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 
 /////////////////////////////////////////////
 /obj/machinery/computer/telecrystals/uplinker

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -141,58 +141,58 @@
 	FOR_DVIEW(var/turf/t, 3, get_turf(src),INVISIBILITY_LIGHTING)
 		if(t.x == cen.x && t.y > cen.y)
 			var/obj/item/flashlight/spotlight/L = new /obj/item/flashlight/spotlight(t)
-			L.light_color = LIGHT_COLOR_RED
-			L.light_power = 30-(get_dist(src,L)*8)
-			L.range = 1+get_dist(src, L)
+			L.set_light_color(COLOR_SOFT_RED)
+			L.set_light_power(30-(get_dist(src,L)*8))
+			L.set_light_range(1+get_dist(src, L))
 			spotlights+=L
 			continue
 		if(t.x == cen.x && t.y < cen.y)
 			var/obj/item/flashlight/spotlight/L = new /obj/item/flashlight/spotlight(t)
-			L.light_color = LIGHT_COLOR_PURPLE
-			L.light_power = 30-(get_dist(src,L)*8)
-			L.range = 1+get_dist(src, L)
+			L.set_light_color(LIGHT_COLOR_PURPLE)
+			L.set_light_power(30-(get_dist(src,L)*8))
+			L.set_light_range(1+get_dist(src, L))
 			spotlights+=L
 			continue
 		if(t.x > cen.x && t.y == cen.y)
 			var/obj/item/flashlight/spotlight/L = new /obj/item/flashlight/spotlight(t)
-			L.light_color = LIGHT_COLOR_YELLOW
-			L.light_power = 30-(get_dist(src,L)*8)
-			L.range = 1+get_dist(src, L)
+			L.set_light_color(LIGHT_COLOR_YELLOW)
+			L.set_light_power((get_dist(src,L)*8))
+			L.set_light_range(1+get_dist(src, L))
 			spotlights+=L
 			continue
 		if(t.x < cen.x && t.y == cen.y)
 			var/obj/item/flashlight/spotlight/L = new /obj/item/flashlight/spotlight(t)
-			L.light_color = LIGHT_COLOR_GREEN
-			L.light_power = 30-(get_dist(src,L)*8)
-			L.range = 1+get_dist(src, L)
+			L.set_light_color(LIGHT_COLOR_GREEN)
+			L.set_light_power((get_dist(src,L)*8))
+			L.set_light_range(1+get_dist(src, L))
 			spotlights+=L
 			continue
 		if((t.x+1 == cen.x && t.y+1 == cen.y) || (t.x+2==cen.x && t.y+2 == cen.y))
 			var/obj/item/flashlight/spotlight/L = new /obj/item/flashlight/spotlight(t)
-			L.light_color = LIGHT_COLOR_ORANGE
-			L.light_power = 30-(get_dist(src,L)*8)
-			L.range = 1.4+get_dist(src, L)
+			L.set_light_color(LIGHT_COLOR_ORANGE)
+			L.set_light_power(30-(get_dist(src,L)*8))
+			L.set_light_range(1.4+get_dist(src, L))
 			spotlights+=L
 			continue
 		if((t.x-1 == cen.x && t.y-1 == cen.y) || (t.x-2==cen.x && t.y-2 == cen.y))
 			var/obj/item/flashlight/spotlight/L = new /obj/item/flashlight/spotlight(t)
-			L.light_color = LIGHT_COLOR_CYAN
-			L.light_power = 30-(get_dist(src,L)*8)
-			L.range = 1.4+get_dist(src, L)
+			L.set_light_color(LIGHT_COLOR_CYAN)
+			L.set_light_power(30-(get_dist(src,L)*8))
+			L.set_light_range(1.4+get_dist(src, L))
 			spotlights+=L
 			continue
 		if((t.x-1 == cen.x && t.y+1 == cen.y) || (t.x-2==cen.x && t.y+2 == cen.y))
 			var/obj/item/flashlight/spotlight/L = new /obj/item/flashlight/spotlight(t)
-			L.light_color = LIGHT_COLOR_BLUEGREEN
-			L.light_power = 30-(get_dist(src,L)*8)
-			L.range = 1.4+get_dist(src, L)
+			L.set_light_color(LIGHT_COLOR_BLUEGREEN)
+			L.set_light_power(30-(get_dist(src,L)*8))
+			L.set_light_range(1.4+get_dist(src, L))
 			spotlights+=L
 			continue
 		if((t.x+1 == cen.x && t.y-1 == cen.y) || (t.x+2==cen.x && t.y-2 == cen.y))
 			var/obj/item/flashlight/spotlight/L = new /obj/item/flashlight/spotlight(t)
-			L.light_color = LIGHT_COLOR_BLUE
-			L.light_power = 30-(get_dist(src,L)*8)
-			L.range = 1.4+get_dist(src, L)
+			L.set_light_color(LIGHT_COLOR_BLUE)
+			L.set_light_power(30-(get_dist(src,L)*8))
+			L.set_light_range(1.4+get_dist(src, L))
 			spotlights+=L
 			continue
 		continue
@@ -233,50 +233,50 @@
 		for(var/obj/item/flashlight/spotlight/glow in spotlights) // The multiples reflects custom adjustments to each colors after dozens of tests
 			if(QDELETED(src) || !active || QDELETED(glow))
 				return
-			if(glow.light_color == LIGHT_COLOR_RED)
-				glow.light_color = LIGHT_COLOR_BLUE
-				glow.light_power = glow.light_power * 1.48
-				glow.light_range = 0
+			if(glow.light_color == COLOR_SOFT_RED)
+				glow.set_light_color(LIGHT_COLOR_BLUE)
+				glow.set_light_power(glow.light_power * 1.48)
+				glow.set_light_range(0)
 				glow.update_light()
 				continue
 			if(glow.light_color == LIGHT_COLOR_BLUE)
-				glow.light_color = LIGHT_COLOR_GREEN
-				glow.light_range = glow.range * DISCO_INFENO_RANGE
-				glow.light_power = glow.light_power * 2 // Any changes to power must come in pairs to neutralize it for other colors
+				glow.set_light_color(LIGHT_COLOR_GREEN)
+				glow.set_light_power(glow.light_power * 2) // Any changes to power must come in pairs to neutralize it for other colors
+				glow.set_light_range(glow.range * DISCO_INFENO_RANGE)
 				glow.update_light()
 				continue
 			if(glow.light_color == LIGHT_COLOR_GREEN)
-				glow.light_color = LIGHT_COLOR_ORANGE
-				glow.light_power = glow.light_power * 0.5
-				glow.light_range = 0
+				glow.set_light_color(LIGHT_COLOR_ORANGE)
+				glow.set_light_power(glow.light_power * 0.5)
+				glow.set_light_range(0)
 				glow.update_light()
 				continue
 			if(glow.light_color == LIGHT_COLOR_ORANGE)
-				glow.light_color = LIGHT_COLOR_PURPLE
-				glow.light_power = glow.light_power * 2.27
-				glow.light_range = glow.range * DISCO_INFENO_RANGE
+				glow.set_light_color(LIGHT_COLOR_PURPLE)
+				glow.set_light_power(glow.light_power * 2.27)
+				glow.set_light_range(glow.range * DISCO_INFENO_RANGE)
 				glow.update_light()
 				continue
 			if(glow.light_color == LIGHT_COLOR_PURPLE)
-				glow.light_color = LIGHT_COLOR_BLUEGREEN
-				glow.light_power = glow.light_power * 0.44
-				glow.light_range = 0
+				glow.set_light_color(LIGHT_COLOR_BLUEGREEN)
+				glow.set_light_power(glow.light_power * 0.44)
+				glow.set_light_range(0)
 				glow.update_light()
 				continue
 			if(glow.light_color == LIGHT_COLOR_BLUEGREEN)
-				glow.light_color = LIGHT_COLOR_YELLOW
-				glow.light_range = glow.range * DISCO_INFENO_RANGE
+				glow.set_light_color(LIGHT_COLOR_YELLOW)
+				glow.set_light_power(glow.range * DISCO_INFENO_RANGE)
 				glow.update_light()
 				continue
 			if(glow.light_color == LIGHT_COLOR_YELLOW)
-				glow.light_color = LIGHT_COLOR_CYAN
-				glow.light_range = 0
+				glow.set_light_color(LIGHT_COLOR_CYAN)
+				glow.set_light_range(0)
 				glow.update_light()
 				continue
 			if(glow.light_color == LIGHT_COLOR_CYAN)
-				glow.light_color = LIGHT_COLOR_RED
-				glow.light_power = glow.light_power * 0.68
-				glow.light_range = glow.range * DISCO_INFENO_RANGE
+				glow.set_light_color(COLOR_SOFT_RED)
+				glow.set_light_power(glow.light_power * 0.68)
+				glow.set_light_range(glow.range * DISCO_INFENO_RANGE)
 				glow.update_light()
 				continue
 		if(prob(2))  // Unique effects for the dance floor that show up randomly to mix things up

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -671,9 +671,9 @@
 	else
 		if(lights && hasPower())
 			if(locked)
-				set_light(1, 0.1, "#0000FF")
+				set_light(1, 0.1, COLOR_BLUE)
 			else if(emergency)
-				set_light(1, 0.1, "#FFFF00")
+				set_light(1, 0.1, COLOR_YELLOW)
 			else
 				set_light(0)
 		else

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -352,7 +352,7 @@
 	note_overlay_file = 'icons/obj/doors/airlocks/external/overlays.dmi'
 	color_overlay_file = 'icons/obj/doors/airlocks/external/color.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_ext
-	basecolor = "#ff0000" //red
+	basecolor = COLOR_RED
 
 
 /obj/machinery/door/airlock/external/glass

--- a/code/game/machinery/exp_cloner.dm
+++ b/code/game/machinery/exp_cloner.dm
@@ -81,13 +81,12 @@
 	icon_screen = "dna"
 	icon_keyboard = "med_key"
 	circuit = /obj/item/circuitboard/computer/prototype_cloning
+	light_color = LIGHT_COLOR_BLUE
 	var/obj/machinery/dna_scannernew/scanner = null //Linked scanner. For scanning.
 	var/list/pods //Linked experimental cloning pods
 	var/temp = "Inactive"
 	var/scantemp = "Ready to Scan"
 	var/loading = FALSE // Nice loading text
-
-	light_color = LIGHT_COLOR_BLUE
 
 /obj/machinery/computer/prototype_cloning/Initialize()
 	. = ..()

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -24,10 +24,9 @@
 	active_power_usage = 6
 	power_channel = ENVIRON
 	resistance_flags = FIRE_PROOF
-
 	light_power = 0
 	light_range = 7
-	light_color = "#ff3232"
+	light_color = COLOR_VIVID_RED
 
 	var/detecting = 1
 	var/buildstage = 2 // 2 = complete, 1 = no wires, 0 = circuit gone

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -7,7 +7,7 @@
 	icon_state = "mflash1"
 	max_integrity = 250
 	integrity_failure = 100
-	light_color = LIGHT_COLOR_WHITE
+	light_color = COLOR_WHITE
 	light_power = FLASH_LIGHT_POWER
 	var/obj/item/assembly/flash/handheld/bulb
 	var/id = null

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -55,7 +55,7 @@
 /obj/structure/emergency_shield/invoker
 	name = "Invoker's Shield"
 	desc = "A weak shield summoned by cultists to protect them while they carry out delicate rituals."
-	color = "#FF0000"
+	color = COLOR_RED
 	max_integrity = 20
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	layer = ABOVE_MOB_LAYER

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -21,6 +21,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 50
 	circuit = /obj/item/circuitboard/computer/slot_machine
+	light_color = LIGHT_COLOR_BROWN
 	var/money = 3000 //How much money it has CONSUMED
 	var/plays = 0
 	var/working = 0
@@ -29,8 +30,6 @@
 	var/list/coinvalues = list()
 	var/list/reels = list(list("", "", "") = 0, list("", "", "") = 0, list("", "", "") = 0, list("", "", "") = 0, list("", "", "") = 0)
 	var/list/symbols = list(SEVEN = 1, "<font color='orange'>&</font>" = 2, "<font color='yellow'>@</font>" = 2, "<font color='green'>$</font>" = 2, "<font color='blue'>?</font>" = 2, "<font color='grey'>#</font>" = 2, "<font color='white'>!</font>" = 2, "<font color='fuchsia'>%</font>" = 2) //if people are winning too much, multiply every number in this list by 2 and see if they are still winning too much.
-
-	light_color = LIGHT_COLOR_BROWN
 
 /obj/machinery/computer/slot_machine/Initialize()
 	. = ..()

--- a/code/game/machinery/telecomms/computers/message.dm
+++ b/code/game/machinery/telecomms/computers/message.dm
@@ -9,6 +9,7 @@
 	desc = "Used to monitor the crew's PDA messages, as well as request console messages."
 	icon_screen = "comm_logs"
 	circuit = /obj/item/circuitboard/computer/message_monitor
+	light_color = LIGHT_COLOR_GREEN
 
 	//Servers, and server linked to.
 	var/network = "tcommsat"		// the network to probe
@@ -33,8 +34,6 @@
 	var/customsender = "System Administrator"
 	var/customjob		= "Admin"
 	var/custommessage 	= "This is a test, please ignore."
-
-	light_color = LIGHT_COLOR_GREEN
 
 /obj/machinery/computer/message_monitor/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE,\
 														datum/tgui/master_ui = null, datum/tgui_state/state = GLOB.tgui_default_state)

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -73,8 +73,8 @@
 	icon_screen = "recharge_comp"
 	icon_keyboard = "rd_key"
 	circuit = /obj/item/circuitboard/computer/mech_bay_power_console
-	var/obj/machinery/mech_bay_recharge_port/recharge_port
 	light_color = LIGHT_COLOR_PINK
+	var/obj/machinery/mech_bay_recharge_port/recharge_port
 
 /obj/machinery/computer/mech_bay_power_console/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/tgui_state/state = GLOB.tgui_default_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)

--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -8,7 +8,7 @@
 	invisibility = INVISIBILITY_OBSERVER
 	anchored = TRUE
 	layer = GHOST_LAYER
-	color = "#ff0000" // text color
+	color = COLOR_RED // text color
 	var/text_size = 3 // larger values clip when the displayed text is larger than 2 digits.
 	var/started = FALSE
 	var/displayed_text

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -115,7 +115,7 @@
 	name = "Red Orb"
 	desc = "You feel angry just looking at it."
 	duration = 1200 //2min
-	color = "#FF0000"
+	color = COLOR_RED
 
 /obj/effect/mine/pickup/bloodbath/mineEffect(mob/living/carbon/victim)
 	if(!victim.client || !istype(victim))
@@ -152,7 +152,7 @@
 /obj/effect/mine/pickup/healing
 	name = "Blue Orb"
 	desc = "You feel better just looking at it."
-	color = "#0000FF"
+	color = COLOR_BLUE
 
 /obj/effect/mine/pickup/healing/mineEffect(mob/living/carbon/victim)
 	if(!victim.client || !istype(victim))
@@ -163,7 +163,7 @@
 /obj/effect/mine/pickup/speed
 	name = "Yellow Orb"
 	desc = "You feel faster just looking at it."
-	color = "#FFFF00"
+	color = COLOR_YELLOW
 	duration = 300
 
 /obj/effect/mine/pickup/speed/mineEffect(mob/living/carbon/victim)

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -75,7 +75,7 @@
 	name = "lighting fx obj"
 	desc = "Tell a coder if you're seeing this."
 	icon_state = "nothing"
-	light_color = "#FFFFFF"
+	light_color = COLOR_WHITE
 	light_range = MINIMUM_USEFUL_LIGHT_RANGE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 

--- a/code/game/objects/effects/spawners/bundle.dm
+++ b/code/game/objects/effects/spawners/bundle.dm
@@ -2,7 +2,7 @@
 	name = "bundle spawner"
 	icon = 'icons/mob/screen_gen.dmi'
 	icon_state = "x2"
-	color = "#00FF00"
+	color = COLOR_GREEN
 
 	var/list/items
 

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -764,7 +764,7 @@ RLD
 						var/obj/machinery/light/L = new /obj/machinery/light(light)
 						L.setDir(align)
 						L.color = color_choice
-						L.light_color = L.color
+						L.set_light_color(L.color)
 						return TRUE
 				return FALSE
 
@@ -784,7 +784,7 @@ RLD
 						var/destination = get_turf(A)
 						var/obj/machinery/light/floor/FL = new /obj/machinery/light/floor(destination)
 						FL.color = color_choice
-						FL.light_color = FL.color
+						FL.set_light_color(FL.color)
 						return TRUE
 				return FALSE
 
@@ -794,7 +794,7 @@ RLD
 				to_chat(user, "<span class='notice'>You fire a glowstick!</span>")
 				var/obj/item/flashlight/glowstick/G  = new /obj/item/flashlight/glowstick(start)
 				G.color = color_choice
-				G.light_color = G.color
+				G.set_light_color(G.color)
 				G.throw_at(A, 9, 3, user)
 				G.on = TRUE
 				G.update_brightness()

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -571,7 +571,7 @@
 //Polychromatic Knight Badge
 
 /obj/item/card/id/knight
-	var/id_color = "#00FF00" //defaults to green
+	var/id_color = COLOR_GREEN //defaults to green
 	name = "knight badge"
 	icon_state = "knight"
 	desc = "A badge denoting the owner as a knight! It has a strip for swiping like an ID"
@@ -621,7 +621,7 @@
 	. += "<span class='notice'>Alt-click to recolor it.</span>"
 
 /obj/item/card/id/knight/blue
-	id_color = "#0000FF"
+	id_color = COLOR_BLUE
 
 /obj/item/card/id/knight/captain
 	id_color = "#FFD700"

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -502,10 +502,14 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon = 'icons/obj/cigarettes.dmi'
 	icon_state = "zippo"
 	item_state = "zippo"
+	heat = 1500
+	grind_results = list(/datum/reagent/iron = 1, /datum/reagent/fuel = 5, /datum/reagent/oil = 5)
 	w_class = WEIGHT_CLASS_TINY
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
+	resistance_flags = FIRE_PROOF
 	price = 1
+	light_color = LIGHT_COLOR_FIRE
 	var/lit = 0
 	var/fancy = TRUE
 	var/overlay_state
@@ -515,10 +519,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		"thirteen",
 		"snake"
 		)
-	heat = 1500
-	resistance_flags = FIRE_PROOF
-	light_color = LIGHT_COLOR_FIRE
-	grind_results = list(/datum/reagent/iron = 1, /datum/reagent/fuel = 5, /datum/reagent/oil = 5)
 
 /obj/item/lighter/Initialize()
 	. = ..()
@@ -907,7 +907,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_state = null
 	item_state = null
 	w_class = WEIGHT_CLASS_NORMAL
-	light_color = "#FFCC66"
+	light_color = COLOR_CREAMY_ORANGE
 	var/icon_off = "bong"
 	var/icon_on = "bong_lit"
 	var/chem_volume = 100

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -30,7 +30,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	attack_verb = list("attacked", "coloured")
 	grind_results = list()
-	var/paint_color = "#FF0000" //RGB
+	var/paint_color = COLOR_RED
 
 	var/drawtype
 	var/text_buffer = ""
@@ -791,7 +791,7 @@
 	charges = 100
 	reagent_contents = list(/datum/reagent/clf3 = 1)
 	actually_paints = FALSE
-	paint_color = "#000000"
+	paint_color = COLOR_BLACK
 
 /obj/item/toy/crayon/spraycan/lubecan
 	name = "slippery spraycan"

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -44,7 +44,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/current_overlays = PDA_STANDARD_OVERLAYS
 	var/font_index = 0 //This int tells DM which font is currently selected and lets DM know when the last font has been selected so that it can cycle back to the first font when "toggle font" is pressed again.
 	var/font_mode = "font-family:monospace;" //The currently selected font.
-	var/background_color = "#808000" //The currently selected background color.
+	var/background_color = COLOR_OLIVE //The currently selected background color.
 
 	#define FONT_MONO "font-family:monospace;"
 	#define FONT_SHARE "font-family:\"Share Tech Mono\", monospace;letter-spacing:0px;"
@@ -60,7 +60,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/fon = FALSE //Is the flashlight function on?
 	var/f_lum = 2.3 //Luminosity for the flashlight function
 	var/f_pow = 0.6 //Power for the flashlight function
-	var/f_col = "#FFCC66" //Color for the flashlight function
+	var/f_col = COLOR_CREAMY_ORANGE //Color for the flashlight function
 	var/silent = FALSE //To beep or not to beep, that is the question
 	var/toff = FALSE //If TRUE, messenger disabled
 	var/tnote = null //Current Texts

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -11,10 +11,10 @@
 	slot_flags = ITEM_SLOT_BELT
 	materials = list(MAT_METAL=50, MAT_GLASS=20)
 	actions_types = list(/datum/action/item_action/toggle_light)
+	light_color = COLOR_CREAMY_ORANGE
 	var/on = FALSE
 	var/brightness_on = 4 //range of light when on
 	var/flashlight_power = 0.8 //strength of the light when on
-	light_color = "#FFCC66"
 
 /obj/item/flashlight/Initialize()
 	. = ..()
@@ -26,9 +26,10 @@
 	if(on)
 		icon_state = "[initial(icon_state)]-on"
 		if(flashlight_power)
-			set_light(l_range = brightness_on, l_power = flashlight_power)
+			set_light_range(brightness_on)
+			set_light_power(flashlight_power)
 		else
-			set_light(brightness_on)
+			set_light_range(brightness_on)
 	else
 		icon_state = initial(icon_state)
 		set_light(0)
@@ -258,16 +259,15 @@
 	desc = "A red Kinaris issued flare. There are instructions on the side, it reads 'pull cord, make light'."
 	w_class = WEIGHT_CLASS_SMALL
 	brightness_on = 7 // Pretty bright.
-	light_color = "#FA421A"
 	icon_state = "flare"
 	item_state = "flare"
 	actions_types = list()
-	var/fuel = 0
-	var/on_damage = 7
-	var/produce_heat = 1500
 	heat = 1000
 	light_color = LIGHT_COLOR_FLARE
 	grind_results = list(/datum/reagent/sulfur = 15)
+	var/fuel = 0
+	var/on_damage = 7
+	var/produce_heat = 1500
 
 /obj/item/flashlight/flare/New()
 	fuel = rand(800, 1000) // Sorry for changing this so much but I keep under-estimating how long X number of ticks last in seconds.
@@ -332,14 +332,13 @@
 	desc = "A torch fashioned from some leaves and a log."
 	w_class = WEIGHT_CLASS_BULKY
 	brightness_on = 4
-	light_color = "#FAA44B"
 	icon_state = "torch"
 	item_state = "torch"
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
-	light_color = LIGHT_COLOR_ORANGE
 	on_damage = 10
 	slot_flags = null
+	light_color = LIGHT_COLOR_FIRE
 
 /obj/item/flashlight/lantern
 	name = "lantern"
@@ -349,8 +348,8 @@
 	righthand_file = 'icons/mob/inhands/equipment/mining_righthand.dmi'
 	desc = "A mining lantern."
 	brightness_on = 6			// luminosity when on
-	light_color = "#FFAA44"
 	flashlight_power = 0.75
+	light_color = LIGHT_COLOR_FIRE
 
 
 /obj/item/flashlight/slime
@@ -491,7 +490,7 @@
 
 /obj/item/flashlight/glowstick/red
 	name = "red glowstick"
-	color = LIGHT_COLOR_RED
+	color = COLOR_SOFT_RED
 
 /obj/item/flashlight/glowstick/blue
 	name = "blue glowstick"
@@ -517,7 +516,7 @@
 	name = "disco light"
 	desc = "Groovy..."
 	icon_state = null
-	light_color = null
+	light_color = COLOR_WHITE
 	brightness_on = 0
 	flashlight_power = 1
 	light_range = 0

--- a/code/game/objects/items/devices/reverse_bear_trap.dm
+++ b/code/game/objects/items/devices/reverse_bear_trap.dm
@@ -112,7 +112,7 @@
 		playsound(src, 'sound/effects/splat.ogg', 50, TRUE, frequency = 0.5)
 		jill.apply_damage(9999, BRUTE, BODY_ZONE_HEAD)
 		jill.death() //just in case, for some reason, they're still alive
-		flash_color(jill, flash_color = "#FF0000", flash_time = 100)
+		flash_color(jill, flash_color = COLOR_RED, flash_time = 100)
 
 /obj/item/reverse_bear_trap/proc/reset()
 	ticking = FALSE

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -14,6 +14,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	materials = list(MAT_METAL=500)
 	resistance_flags = FIRE_PROOF
+	trigger_guard = TRIGGER_GUARD_NORMAL
 	var/status = FALSE
 	var/lit = FALSE	//on or off
 	var/operating = FALSE//cooldown
@@ -25,7 +26,6 @@
 	var/create_full = FALSE
 	var/create_with_tank = FALSE
 	var/igniter_type = /obj/item/assembly/igniter
-	trigger_guard = TRIGGER_GUARD_NORMAL
 
 /obj/item/flamethrower/Destroy()
 	if(weldtool)

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -13,7 +13,7 @@
 		return
 	do_sparks(rand(5, 9), FALSE, src)
 	playsound(flashbang_turf, 'sound/weapons/flashbang.ogg', 100, TRUE, 8, 0.9)
-	new /obj/effect/dummy/lighting_obj (flashbang_turf, LIGHT_COLOR_WHITE, (flashbang_range + 2), 4, 2)
+	new /obj/effect/dummy/lighting_obj (flashbang_turf, COLOR_WHITE, (flashbang_range + 2), 4, 2)
 	for(var/mob/living/M in get_hearers_in_view(flashbang_range, flashbang_turf))
 		bang(get_turf(M), M)
 	qdel(src)

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -114,7 +114,7 @@
 	icon_state = "cuff"
 	item_state = "coil"
 	item_color = "red"
-	color = "#ff0000"
+	color = COLOR_RED
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	materials = list(MAT_METAL=150, MAT_GLASS=75)
@@ -136,11 +136,11 @@
 
 /obj/item/restraints/handcuffs/cable/red
 	item_color = "red"
-	color = "#ff0000"
+	color = COLOR_RED
 
 /obj/item/restraints/handcuffs/cable/yellow
 	item_color = "yellow"
-	color = "#ffff00"
+	color = COLOR_YELLOW
 
 /obj/item/restraints/handcuffs/cable/blue
 	item_color = "blue"
@@ -160,7 +160,7 @@
 
 /obj/item/restraints/handcuffs/cable/cyan
 	item_color = "cyan"
-	color = "#00ffff"
+	color = COLOR_CYAN
 
 /obj/item/restraints/handcuffs/cable/white
 	item_color = "white"

--- a/code/game/objects/items/hot_potato.dm
+++ b/code/game/objects/items/hot_potato.dm
@@ -46,7 +46,7 @@
 	color_val = !color_val
 	if(istype(target))
 		current = WEAKREF(target)
-		target.add_atom_colour(color_val? "#ffff00" : "#00ffff", FIXED_COLOUR_PRIORITY)
+		target.add_atom_colour(color_val? COLOR_YELLOW : COLOR_CYAN, FIXED_COLOUR_PRIORITY)
 
 /obj/item/hot_potato/proc/detonate()
 	var/atom/location = loc

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -81,8 +81,8 @@
 	armour_penetration = 100
 	attack_verb_off = list("attacked", "chopped", "cleaved", "torn", "cut")
 	attack_verb_on = list()
-	light_color = "#40ceff"
 	total_mass = null
+	light_color = LIGHT_COLOR_LIGHT_CYAN
 
 /obj/item/melee/transforming/energy/axe/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] swings [src] towards [user.p_their()] head! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -141,15 +141,15 @@
 	hitcost = 75 //Costs more than a standard cyborg esword
 	w_class = WEIGHT_CLASS_NORMAL
 	sharpness = IS_SHARP
-	light_color = "#40ceff"
 	tool_behaviour = TOOL_SAW
 	toolspeed = 0.7
+	light_color = LIGHT_COLOR_LIGHT_CYAN
 
 /obj/item/melee/transforming/energy/sword/cyborg/saw/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	return 0
 
 /obj/item/melee/transforming/energy/sword/saber
-	var/list/possible_colors = list("red" = LIGHT_COLOR_RED, "blue" = LIGHT_COLOR_LIGHT_CYAN, "green" = LIGHT_COLOR_GREEN, "purple" = LIGHT_COLOR_LAVENDER)
+	var/list/possible_colors = list("red" = COLOR_SOFT_RED, "blue" = LIGHT_COLOR_LIGHT_CYAN, "green" = LIGHT_COLOR_GREEN, "purple" = LIGHT_COLOR_LAVENDER)
 	var/hacked = FALSE
 
 /obj/item/melee/transforming/energy/sword/saber/Initialize(mapload)
@@ -163,11 +163,11 @@
 	. = ..()
 	if(hacked)
 		var/set_color = pick(possible_colors)
-		light_color = possible_colors[set_color]
+		set_light_color(possible_colors[set_color])
 		update_light()
 
 /obj/item/melee/transforming/energy/sword/saber/red
-	possible_colors = list("red" = LIGHT_COLOR_RED)
+	possible_colors = list("red" = COLOR_SOFT_RED)
 
 /obj/item/melee/transforming/energy/sword/saber/blue
 	possible_colors = list("blue" = LIGHT_COLOR_LIGHT_CYAN)
@@ -200,7 +200,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	icon_state_on = "cutlass1"
-	light_color = "#ff0000"
+	light_color = COLOR_RED
 
 /obj/item/melee/transforming/energy/blade
 	name = "energy blade"

--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -249,11 +249,11 @@
 
 /obj/item/godstaff/red
 	icon_state = "godstaff-red"
-	conversion_color = "#ff0000"
+	conversion_color = COLOR_RED
 
 /obj/item/godstaff/blue
 	icon_state = "godstaff-blue"
-	conversion_color = "#0000ff"
+	conversion_color = COLOR_BLUE
 
 /obj/item/clothing/gloves/plate
 	name = "Plate Gauntlets"

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -82,21 +82,21 @@
 	item_state = "tile-fairygrass"
 	turf_type = /turf/open/floor/grass/fairy
 	resistance_flags = FLAMMABLE
-	color = "#33CCFF"
+	color = COLOR_BLUE_LIGHT
 
 /obj/item/stack/tile/fairygrass/white
 	name = "white fairygrass tile"
 	singular_name = "white fairygrass floor tile"
 	desc = "A patch of odd, glowing white grass."
 	turf_type = /turf/open/floor/grass/fairy/white
-	color = "#FFFFFF"
+	color = COLOR_WHITE
 
 /obj/item/stack/tile/fairygrass/red
 	name = "red fairygrass tile"
 	singular_name = "red fairygrass floor tile"
 	desc = "A patch of odd, glowing red grass."
 	turf_type = /turf/open/floor/grass/fairy/red
-	color = "#FF3333"
+	color = COLOR_RED_LIGHT
 
 /obj/item/stack/tile/fairygrass/yellow
 	name = "yellow fairygrass tile"

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -13,14 +13,14 @@
 	throwforce = 5
 	hitsound = "swing_hit"
 	usesound = list('sound/items/welder.ogg', 'sound/items/welder2.ogg')
-	var/acti_sound = 'sound/items/welderactivate.ogg'
-	var/deac_sound = 'sound/items/welderdeactivate.ogg'
 	throw_speed = 3
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 30)
 	resistance_flags = FIRE_PROOF
-
+	heat = 3800
+	tool_behaviour = TOOL_WELDER
+	toolspeed = 1
 	materials = list(MAT_METAL=70, MAT_GLASS=30)
 	var/welding = 0 	//Whether or not the welding tool is off(0), on(1) or currently welding(2)
 	var/status = TRUE 		//Whether the welder is secured or unsecured (able to attach rods to it to make a flamethrower)
@@ -30,9 +30,8 @@
 	var/light_intensity = 2 //how powerful the emitted light is when used.
 	var/progress_flash_divisor = 10
 	var/burned_fuel_for = 0	//when fuel was last removed
-	heat = 3800
-	tool_behaviour = TOOL_WELDER
-	toolspeed = 1
+	var/acti_sound = 'sound/items/welderactivate.ogg'
+	var/deac_sound = 'sound/items/welderdeactivate.ogg'
 
 	drop_sound = 'sound/items/handling/weldingtool_drop.ogg'
 	pickup_sound =  'sound/items/handling/weldingtool_pickup.ogg'
@@ -353,12 +352,12 @@
 	item_state = "exwelder"
 	max_fuel = 40
 	materials = list(MAT_METAL=70, MAT_GLASS=120)
-	var/last_gen = 0
 	change_icons = 0
 	can_off_process = 1
 	light_intensity = 1
 	toolspeed = 0.5
 	var/nextrefueltick = 0
+	var/last_gen = 0
 
 /obj/item/weldingtool/experimental/brass
 	name = "brass welding tool"

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -284,7 +284,7 @@
 	var/hitsound_on = 'sound/weapons/blade1.ogg'
 	armour_penetration = 35
 	item_color = "green"
-	light_color = "#00ff00"//green
+	light_color = COLOR_GREEN
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	block_chance = 75
 	max_integrity = 200
@@ -293,7 +293,7 @@
 	var/hacked = FALSE
 	var/brightness_on = 6 //TWICE AS BRIGHT AS A REGULAR ESWORD
 	var/list/possible_colors = list("red", "blue", "green", "purple")
-	var/list/rainbow_colors = list(LIGHT_COLOR_RED, LIGHT_COLOR_GREEN, LIGHT_COLOR_LIGHT_CYAN, LIGHT_COLOR_LAVENDER)
+	var/list/rainbow_colors = list(COLOR_SOFT_RED, LIGHT_COLOR_GREEN, LIGHT_COLOR_LIGHT_CYAN, LIGHT_COLOR_LAVENDER)
 	var/spinnable = TRUE
 	total_mass = 0.4 //Survival flashlights typically weigh around 5 ounces.
 	var/total_mass_on = 3.4
@@ -329,7 +329,7 @@
 		item_color = pick(possible_colors)
 		switch(item_color)
 			if("red")
-				light_color = LIGHT_COLOR_RED
+				light_color = COLOR_SOFT_RED
 			if("green")
 				light_color = LIGHT_COLOR_GREEN
 			if("blue")
@@ -711,7 +711,7 @@
 
 /obj/item/twohanded/pitchfork/demonic/Initialize()
 	. = ..()
-	set_light(3,6,LIGHT_COLOR_RED)
+	set_light(3,6,COLOR_SOFT_RED)
 
 /obj/item/twohanded/pitchfork/demonic/greater
 	force = 24

--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -174,11 +174,11 @@
 		var/obj/item/pen/P = I
 		switch(P.colour)
 			if("black")
-				return "#000000"
+				return COLOR_BLACK
 			if("blue")
-				return "#0000ff"
+				return COLOR_BLUE
 			if("red")
-				return "#ff0000"
+				return COLOR_RED
 		return P.colour
 	else if(istype(I, /obj/item/soap) || istype(I, /obj/item/reagent_containers/rag))
 		return canvas_color

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -350,7 +350,7 @@
 	name = "photosynthetic potted plant"
 	desc = "A bioluminescent plant."
 	icon_state = "plant-09"
-	light_color = "#2cb2e8"
+	light_color = COLOR_BRIGHT_BLUE
 	light_range = 3
 
 

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -109,19 +109,19 @@
 	floor_tile = /obj/item/stack/tile/fairygrass
 	light_range = 2
 	light_power = 0.80
-	light_color = "#33CCFF"
-	color = "#33CCFF"
+	light_color = COLOR_BLUE_LIGHT
+	color = COLOR_BLUE_LIGHT
 
 /turf/open/floor/grass/fairy/white
 	name = "white fairygrass patch"
-	light_color = "#FFFFFF"
-	color = "#FFFFFF"
+	light_color = COLOR_WHITE
+	color = COLOR_WHITE
 	floor_tile = /obj/item/stack/tile/fairygrass/white
 
 /turf/open/floor/grass/fairy/red
 	name = "red fairygrass patch"
-	light_color = "#FF3333"
-	color = "#FF3333"
+	light_color = COLOR_RED_LIGHT
+	color = COLOR_RED_LIGHT
 	floor_tile = /obj/item/stack/tile/fairygrass/red
 
 /turf/open/floor/grass/fairy/yellow

--- a/code/game/turfs/simulated/floor/light_floor.dm
+++ b/code/game/turfs/simulated/floor/light_floor.dm
@@ -23,7 +23,7 @@
 
 /turf/open/floor/light/break_tile()
 	..()
-	light_range = 0
+	set_light_range(0)
 	update_light()
 
 /turf/open/floor/light/update_icon()

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -31,10 +31,10 @@
 	if(on)
 		if(LAZYLEN(SSmapping.nuke_threats))
 			icon_state = "rcircuitanim"
-			light_color = LIGHT_COLOR_FLARE
+			set_light_color(LIGHT_COLOR_FLARE)
 		else
 			icon_state = icon_normal
-			light_color = initial(light_color)
+			set_light_color(initial(light_color))
 		set_light(1.4, 0.5)
 	else
 		icon_state = "[icon_normal]off"

--- a/code/modules/VR/vr_sleeper.dm
+++ b/code/modules/VR/vr_sleeper.dm
@@ -216,7 +216,7 @@
 /obj/effect/vr_clean_master // Will keep VR areas that have this relatively clean.
 	icon = 'icons/mob/screen_gen.dmi'
 	icon_state = "x2"
-	color = "#00FF00"
+	color = COLOR_GREEN
 	invisibility = INVISIBILITY_ABSTRACT
 	var/area/vr_area
 

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -660,7 +660,7 @@
 					"playersonly" = list("desc" = "Only spawn ghost-controlled mobs", "type" = "boolean", "value" = "No"),
 					"ghostpoll" = list("desc" = "Ghost poll question", "type" = "string", "value" = "Do you want to play as %TYPE% portal invader?"),
 					"delay" = list("desc" = "Time between portals, in deciseconds", "type" = "number", "value" = 50),
-					"color" = list("desc" = "Portal color", "type" = "color", "value" = "#00FF00"),
+					"color" = list("desc" = "Portal color", "type" = "color", "value" = COLOR_GREEN),
 					"playlightning" = list("desc" = "Play lightning sounds on announcement", "type" = "boolean", "value" = "Yes"),
 					"announce_players" = list("desc" = "Make an announcement", "type" = "boolean", "value" = "Yes"),
 					"announcement" = list("desc" = "Announcement", "type" = "string", "value" = "Massive bluespace anomaly detected en route to %STATION%. Brace for impact."),

--- a/code/modules/antagonists/blob/blob/blobs/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob/blobs/blob_mobs.dm
@@ -36,7 +36,7 @@
 			if(overmind)
 				H.color = overmind.blob_reagent_datum.complementary_color
 			else
-				H.color = "#000000"
+				H.color = COLOR_BLACK
 		adjustHealth(-maxHealth*0.0125)
 
 /mob/living/simple_animal/hostile/blob/fire_act(exposed_temperature, exposed_volume)
@@ -240,14 +240,14 @@
 				if(overmind)
 					H.color = overmind.blob_reagent_datum.complementary_color
 				else
-					H.color = "#000000"
+					H.color = COLOR_BLACK
 			if(locate(/obj/structure/blob/node) in blobs_in_area)
 				adjustHealth(-maxHealth*0.05)
 				var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(src))
 				if(overmind)
 					H.color = overmind.blob_reagent_datum.complementary_color
 				else
-					H.color = "#000000"
+					H.color = COLOR_BLACK
 		if(damagesources)
 			for(var/i in 1 to damagesources)
 				adjustHealth(maxHealth*0.025) //take 2.5% of max health as damage when not near the blob or if the naut has no factory, 5% if both

--- a/code/modules/antagonists/bloodsucker/datum_bloodsucker.dm
+++ b/code/modules/antagonists/bloodsucker/datum_bloodsucker.dm
@@ -721,7 +721,7 @@ datum/antagonist/bloodsucker/proc/SpendRank()
 
 	// Update Rank Counter
 	if(owner.current.hud_used.vamprank_display)
-		var/valuecolor = vamplevel_unspent ? "#FFFF00" : "#FF0000"
+		var/valuecolor = vamplevel_unspent ? COLOR_YELLOW : COLOR_RED
 		owner.current.hud_used.vamprank_display.update_counter(vamplevel, valuecolor)
 		if(updateRank) // Only change icon on special request.
 			owner.current.hud_used.vamprank_display.icon_state = (vamplevel_unspent > 0) ? "rank_up" : "rank"

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -503,7 +503,7 @@
 	name = "Binding Aura"
 	desc = "Allows you to bind a victim and temporarily silence them."
 	invocation = "In'totum Lig'abis."
-	color = "#000000" // black
+	color = COLOR_BLACK
 
 /obj/item/melee/blood_magic/shackles/afterattack(atom/target, mob/living/carbon/user, proximity)
 	if(iscultist(user) && iscarbon(target) && proximity)
@@ -553,7 +553,7 @@
 	name = "Corrupting Aura"
 	desc = "Corrupts metal and plasteel into more sinister forms."
 	invocation = "Ethra p'ni dedol."
-	color = "#000000" // black
+	color = COLOR_BLACK
 
 /obj/item/melee/blood_magic/construction/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(proximity_flag && iscultist(user))

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -110,7 +110,7 @@
 	throw_speed = 1
 	throw_range = 3
 	sharpness = IS_SHARP
-	light_color = "#ff0000"
+	light_color = COLOR_RED
 	attack_verb = list("cleaved", "slashed", "torn", "hacked", "ripped", "diced", "carved")
 	icon_state = "cultbastard"
 	item_state = "cultbastard"
@@ -625,7 +625,7 @@
 	brightness_on = 1
 	icon_state = "torch"
 	item_state = "torch"
-	color = "#ff0000"
+	color = COLOR_RED
 	on_damage = 15
 	slot_flags = null
 	on = TRUE
@@ -783,7 +783,7 @@
 /obj/item/gun/ballistic/shotgun/boltaction/enchanted/arcane_barrage/blood
 	name = "blood bolt barrage"
 	desc = "Blood for blood."
-	color = "#ff0000"
+	color = COLOR_RED
 	guns_left = 24
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/enchanted/arcane_barrage/blood
 	fire_sound = 'sound/magic/wand_teleport.ogg'
@@ -872,9 +872,9 @@
 		if(i > 1)
 			sleep(15)
 		if(i < 4)
-			O = new /obj/effect/temp_visual/cult/rune_spawn/rune1/inner(user.loc, 30, "#ff0000")
+			O = new /obj/effect/temp_visual/cult/rune_spawn/rune1/inner(user.loc, 30, COLOR_RED)
 		else
-			O = new /obj/effect/temp_visual/cult/rune_spawn/rune5(user.loc, 30, "#ff0000")
+			O = new /obj/effect/temp_visual/cult/rune_spawn/rune5(user.loc, 30, COLOR_RED)
 			new /obj/effect/temp_visual/dir_setting/cult/phase/out(user.loc, user.dir)
 	if(O)
 		qdel(O)

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -12,8 +12,8 @@
 	visible_message("<span class='danger'>[src] fades away.</span>")
 	invisibility = INVISIBILITY_OBSERVER
 	alpha = 100 //To help ghosts distinguish hidden runes
-	light_range = 0
-	light_power = 0
+	set_light_range(0)
+	set_light_range(0)
 	update_light()
 	STOP_PROCESSING(SSfastprocess, src)
 
@@ -22,8 +22,8 @@
 	invisibility = 0
 	visible_message("<span class='danger'>[src] suddenly appears!</span>")
 	alpha = initial(alpha)
-	light_range = initial(light_range)
-	light_power = initial(light_power)
+	set_light_range(initial(light_range))
+	set_light_power(initial(light_power))
 	update_light()
 	START_PROCESSING(SSfastprocess, src)
 
@@ -180,7 +180,7 @@
 	desc = "A floating crystal that slowly heals those faithful to Nar'Sie."
 	icon_state = "pylon"
 	light_range = 1.5
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	break_sound = 'sound/effects/glassbr2.ogg'
 	break_message = "<span class='warning'>The blood-red crystal falls to the floor and shatters!</span>"
 	var/heal_delay = 25

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -428,14 +428,14 @@ structure_check() searches for nearby cultist structures required for the invoca
 	playsound(T, pick('sound/effects/sparks1.ogg', 'sound/effects/sparks2.ogg', 'sound/effects/sparks3.ogg', 'sound/effects/sparks4.ogg'), 100, TRUE, 14)
 	inner_portal = new /obj/effect/temp_visual/cult/portal(T)
 	if(portal_type == "space")
-		light_color = color
+		set_light_color(color)
 		desc += "<br><b>A tear in reality reveals a black void interspersed with dots of light... something recently teleported here from space.<br><u>The void feels like it's trying to pull you to the [dir2text(get_dir(T, origin))]!</u></b>"
 	else
 		inner_portal.icon_state = "lava"
-		light_color = LIGHT_COLOR_FIRE
+		set_light_color(LIGHT_COLOR_FIRE)
 		desc += "<br><b>A tear in reality reveals a coursing river of lava... something recently teleported here from the Lavaland Mines!</b>"
 	outer_portal = new(T, 600, color)
-	light_range = 4
+	set_light_range(4)
 	update_light()
 	addtimer(CALLBACK(src, .proc/close_portal), 600, TIMER_UNIQUE)
 
@@ -443,7 +443,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	qdel(inner_portal)
 	qdel(outer_portal)
 	desc = initial(desc)
-	light_range = 0
+	set_light_range(0)
 	update_light()
 
 //Ritual of Dimensional Rending: Calls forth the avatar of Nar'Sie upon the station.

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -707,7 +707,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 	user.visible_message("<span class='suicide'>[user] is going delta! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	playsound(src, 'sound/machines/alarm.ogg', 50, -1, 1)
 	for(var/i in 1 to 100)
-		addtimer(CALLBACK(user, /atom/proc/add_atom_colour, (i % 2)? "#00FF00" : "#FF0000", ADMIN_COLOUR_PRIORITY), i)
+		addtimer(CALLBACK(user, /atom/proc/add_atom_colour, (i % 2)? COLOR_GREEN : COLOR_RED, ADMIN_COLOUR_PRIORITY), i)
 	addtimer(CALLBACK(src, .proc/manual_suicide, user), 101)
 	return MANUAL_SUICIDE
 

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -10,7 +10,6 @@
 	w_class = WEIGHT_CLASS_TINY
 	materials = list(MAT_METAL = 300, MAT_GLASS = 300)
 	crit_fail = FALSE     //Is the flash burnt out?
-	light_color = LIGHT_COLOR_WHITE
 	light_power = FLASH_LIGHT_POWER
 	var/flashing_overlay = "flash-f"
 	var/times_used = 0 //Number of times it's been used.

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -652,17 +652,17 @@
 		if(0)
 			add_overlay(AALARM_OVERLAY_GREEN)
 			overlay_state = AALARM_OVERLAY_GREEN
-			light_color = LIGHT_COLOR_GREEN
+			set_light_color(LIGHT_COLOR_GREEN)
 			set_light(brightness_on)
 		if(1)
 			add_overlay(AALARM_OVERLAY_WARN)
 			overlay_state = AALARM_OVERLAY_WARN
-			light_color = LIGHT_COLOR_LAVA
+			set_light_color(LIGHT_COLOR_LAVA)
 			set_light(brightness_on)
 		if(2)
 			add_overlay(AALARM_OVERLAY_DANGER)
 			overlay_state = AALARM_OVERLAY_DANGER
-			light_color = LIGHT_COLOR_RED
+			set_light_color(COLOR_SOFT_RED)
 			set_light(brightness_on)
 
 	SSvis_overlays.add_vis_overlay(src, icon, overlay_state, ABOVE_LIGHTING_LAYER, ABOVE_LIGHTING_PLANE, dir)

--- a/code/modules/atmospherics/machinery/other/miner.dm
+++ b/code/modules/atmospherics/machinery/other/miner.dm
@@ -158,7 +158,7 @@
 
 /obj/machinery/atmospherics/miner/toxins
 	name = "\improper Plasma Gas Miner"
-	overlay_color = "#FF0000"
+	overlay_color = COLOR_RED
 	spawn_id = /datum/gas/plasma
 
 /obj/machinery/atmospherics/miner/carbon_dioxide

--- a/code/modules/cargo/bounty_console.dm
+++ b/code/modules/cargo/bounty_console.dm
@@ -7,7 +7,7 @@
 	desc = "Used to check and claim bounties offered by Kinaris"
 	icon_screen = "bounty"
 	circuit = /obj/item/circuitboard/computer/bounty
-	light_color = "#E2853D"//orange
+	light_color = COLOR_BRIGHT_ORANGE
 	var/printer_ready = 0 //cooldown var
 
 /obj/machinery/computer/bounty/Initialize()

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -3,6 +3,7 @@
 	desc = "Used to order supplies, approve requests, and control the shuttle."
 	icon_screen = "supply"
 	circuit = /obj/item/circuitboard/computer/cargo
+	light_color = COLOR_BRIGHT_ORANGE
 	ui_x = 780
 	ui_y = 750
 
@@ -17,8 +18,6 @@
 	var/obj/item/radio/headset/radio
 	/// var that tracks message cooldown
 	var/message_cooldown
-
-	light_color = "#E2853D"//orange
 
 /obj/machinery/computer/cargo/request
 	name = "supply request console"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -65,7 +65,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/allow_midround_antag = 1
 	var/preferred_map = null
 	var/pda_style = MONO
-	var/pda_color = "#808000"
+	var/pda_color = COLOR_OLIVE
 	var/pda_skin = PDA_SKIN_ALT
 
 	var/list/alt_titles_preferences = list()
@@ -2013,11 +2013,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 						//Now that we changed our species, we must verify that the mutant colour is still allowed.
 						var/temp_hsv = RGBtoHSV(features["mcolor"])
-						if(features["mcolor"] == "#000" || (!(MUTCOLORS_PARTSONLY in pref_species.species_traits) && ReadHSV(temp_hsv)[3] < ReadHSV("#202020")[3]))
+						if(features["mcolor"] == "#000" || (!(MUTCOLORS_PARTSONLY in pref_species.species_traits) && ReadHSV(temp_hsv)[3] < ReadHSV(COLOR_NEARLY_BLACK)[3]))
 							features["mcolor"] = pref_species.default_color
-						if(features["mcolor2"] == "#000" || (!(MUTCOLORS_PARTSONLY in pref_species.species_traits) && ReadHSV(temp_hsv)[3] < ReadHSV("#202020")[3]))
+						if(features["mcolor2"] == "#000" || (!(MUTCOLORS_PARTSONLY in pref_species.species_traits) && ReadHSV(temp_hsv)[3] < ReadHSV(COLOR_NEARLY_BLACK)[3]))
 							features["mcolor2"] = pref_species.default_color
-						if(features["mcolor3"] == "#000" || (!(MUTCOLORS_PARTSONLY in pref_species.species_traits) && ReadHSV(temp_hsv)[3] < ReadHSV("#202020")[3]))
+						if(features["mcolor3"] == "#000" || (!(MUTCOLORS_PARTSONLY in pref_species.species_traits) && ReadHSV(temp_hsv)[3] < ReadHSV(COLOR_NEARLY_BLACK)[3]))
 							features["mcolor3"] = pref_species.default_color
 
 				if("custom_species")
@@ -2031,10 +2031,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/new_mutantcolor = input(user, "Choose your character's alien/mutant color:", "Character Preference","#"+features["mcolor"]) as color|null
 					if(new_mutantcolor)
 						var/temp_hsv = RGBtoHSV(new_mutantcolor)
-						if(new_mutantcolor == "#000000")
+						if(new_mutantcolor == COLOR_BLACK)
 							features["mcolor"] = pref_species.default_color
 							update_preview_icon()
-						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV("#202020")[3]) // mutantcolors must be bright, but only if they affect the skin
+						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV(COLOR_NEARLY_BLACK)[3]) // mutantcolors must be bright, but only if they affect the skin
 							features["mcolor"] = sanitize_hexcolor(new_mutantcolor)
 							update_preview_icon()
 						else
@@ -2044,10 +2044,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/new_mutantcolor = input(user, "Choose your character's secondary alien/mutant color:", "Character Preference") as color|null
 					if(new_mutantcolor)
 						var/temp_hsv = RGBtoHSV(new_mutantcolor)
-						if(new_mutantcolor == "#000000")
+						if(new_mutantcolor == COLOR_BLACK)
 							features["mcolor2"] = pref_species.default_color
 							update_preview_icon()
-						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV("#202020")[3]) // mutantcolors must be bright, but only if they affect the skin
+						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV(COLOR_NEARLY_BLACK)[3]) // mutantcolors must be bright, but only if they affect the skin
 							features["mcolor2"] = sanitize_hexcolor(new_mutantcolor)
 							update_preview_icon()
 						else
@@ -2057,10 +2057,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/new_mutantcolor = input(user, "Choose your character's tertiary alien/mutant color:", "Character Preference") as color|null
 					if(new_mutantcolor)
 						var/temp_hsv = RGBtoHSV(new_mutantcolor)
-						if(new_mutantcolor == "#000000")
+						if(new_mutantcolor == COLOR_BLACK)
 							features["mcolor3"] = pref_species.default_color
 							update_preview_icon()
-						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV("#202020")[3]) // mutantcolors must be bright, but only if they affect the skin
+						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV(COLOR_NEARLY_BLACK)[3]) // mutantcolors must be bright, but only if they affect the skin
 							features["mcolor3"] = sanitize_hexcolor(new_mutantcolor)
 							update_preview_icon()
 						else
@@ -2187,7 +2187,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("wings_color")
 					var/new_wing_color = input(user, "Choose your character's wing colour:", "Character Preference","#"+wing_color) as color|null
 					if(new_wing_color)
-						if (new_wing_color == "#000000")
+						if (new_wing_color == COLOR_BLACK)
 							wing_color = "#FFFFFF"
 						else
 							wing_color = sanitize_hexcolor(new_wing_color)
@@ -2423,9 +2423,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/new_cockcolor = input(user, "Penis color:", "Character Preference") as color|null
 					if(new_cockcolor)
 						var/temp_hsv = RGBtoHSV(new_cockcolor)
-						if(new_cockcolor == "#000000")
+						if(new_cockcolor == COLOR_BLACK)
 							features["cock_color"] = pref_species.default_color
-						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV("#202020")[3])
+						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV(COLOR_NEARLY_BLACK)[3])
 							features["cock_color"] = sanitize_hexcolor(new_cockcolor)
 						else
 							to_chat(user,"<span class='danger'>Invalid color. Your color is not bright enough.</span>")
@@ -2455,9 +2455,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/new_ballscolor = input(user, "Testicle Color:", "Character Preference") as color|null
 					if(new_ballscolor)
 						var/temp_hsv = RGBtoHSV(new_ballscolor)
-						if(new_ballscolor == "#000000")
+						if(new_ballscolor == COLOR_BLACK)
 							features["balls_color"] = pref_species.default_color
-						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV("#202020")[3])
+						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV(COLOR_NEARLY_BLACK)[3])
 							features["balls_color"] = sanitize_hexcolor(new_ballscolor)
 						else
 							to_chat(user,"<span class='danger'>Invalid color. Your color is not bright enough.</span>")
@@ -2466,9 +2466,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/new_bellycolor = input(user, "Belly Color:", "Character Preference") as color|null
 					if(new_bellycolor)
 						var/temp_hsv = RGBtoHSV(new_bellycolor)
-						if(new_bellycolor == "#000000")
+						if(new_bellycolor == COLOR_BLACK)
 							features["belly_color"] = pref_species.default_color
-						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV("#202020")[3])
+						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV(COLOR_NEARLY_BLACK)[3])
 							features["belly_color"] = sanitize_hexcolor(new_bellycolor)
 						else
 							to_chat(user,"<span class='danger'>Invalid color. Your color is not bright enough.</span>")
@@ -2477,9 +2477,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/new_buttcolor = input(user, "Butt Color:", "Character Preference") as color|null
 					if(new_buttcolor)
 						var/temp_hsv = RGBtoHSV(new_buttcolor)
-						if(new_buttcolor == "#000000")
+						if(new_buttcolor == COLOR_BLACK)
 							features["butt_color"] = pref_species.default_color
-						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV("#202020")[3])
+						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV(COLOR_NEARLY_BLACK)[3])
 							features["butt_color"] = sanitize_hexcolor(new_buttcolor)
 						else
 							to_chat(user,"<span class='danger'>Invalid color. Your color is not bright enough.</span>")
@@ -2516,7 +2516,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/new_egg_color = input(user, "Egg Color:", "Character Preference") as color|null
 					if(new_egg_color)
 						var/temp_hsv = RGBtoHSV(new_egg_color)
-						if(ReadHSV(temp_hsv)[3] >= ReadHSV("#202020")[3])
+						if(ReadHSV(temp_hsv)[3] >= ReadHSV(COLOR_NEARLY_BLACK)[3])
 							features["eggsack_egg_color"] = sanitize_hexcolor(new_egg_color)
 						else
 							to_chat(user,"<span class='danger'>Invalid color. Your color is not bright enough.</span>")
@@ -2552,9 +2552,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/new_breasts_color = input(user, "Breast Color:", "Character Preference") as color|null
 					if(new_breasts_color)
 						var/temp_hsv = RGBtoHSV(new_breasts_color)
-						if(new_breasts_color == "#000000")
+						if(new_breasts_color == COLOR_BLACK)
 							features["breasts_color"] = pref_species.default_color
-						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV("#202020")[3])
+						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV(COLOR_NEARLY_BLACK)[3])
 							features["breasts_color"] = sanitize_hexcolor(new_breasts_color)
 						else
 							to_chat(user,"<span class='danger'>Invalid color. Your color is not bright enough.</span>")
@@ -2580,9 +2580,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/new_vagcolor = input(user, "Vagina color:", "Character Preference") as color|null
 					if(new_vagcolor)
 						var/temp_hsv = RGBtoHSV(new_vagcolor)
-						if(new_vagcolor == "#000000")
+						if(new_vagcolor == COLOR_BLACK)
 							features["vag_color"] = pref_species.default_color
-						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV("#202020")[3])
+						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV(COLOR_NEARLY_BLACK)[3])
 							features["vag_color"] = sanitize_hexcolor(new_vagcolor)
 						else
 							to_chat(user,"<span class='danger'>Invalid color. Your color is not bright enough.</span>")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -52,7 +52,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(current_version < 19)
 		pda_style = "mono"
 	if(current_version < 20)
-		pda_color = "#808000"
+		pda_color = COLOR_OLIVE
 	if(current_version < 22)
 		if(features["balls_fluid"])
 			features["balls_fluid"] = /datum/reagent/consumable/semen

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -3,16 +3,16 @@
 	desc = "A piece of headgear used in dangerous working conditions to protect the head. Comes with a built-in flashlight."
 	icon_state = "hardhat0_yellow"
 	item_state = "hardhat0_yellow"
-	var/brightness_on = 4 //luminosity when on
-	light_color = "#FFCC66"
-	var/power_on = 0.8
-	var/on = FALSE
+	light_color = COLOR_CREAMY_ORANGE
 	item_color = "yellow" //Determines used sprites: hardhat[on]_[item_color] and hardhat[on]_[item_color]2 (lying down sprite)
 	armor = list("melee" = 15, "bullet" = 5, "laser" = 20,"energy" = 10, "bomb" = 20, "bio" = 10, "rad" = 20, "fire" = 100, "acid" = 50)
 	flags_inv = 0
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	resistance_flags = FIRE_PROOF
 	dynamic_hair_suffix = "+generic"
+	light_on = FALSE
+	var/brightness_on = 4 //luminosity when on
+	var/power_on = 0.8
 
 	dog_fashion = /datum/dog_fashion/head
 
@@ -20,16 +20,16 @@
 	toggle_helmet_light(user)
 
 /obj/item/clothing/head/hardhat/proc/toggle_helmet_light(mob/living/user)
-	on = !on
-	if(on)
+	set_light_on(!light_on)
+	if(light_on)
 		turn_on(user)
 	else
 		turn_off(user)
 	update_icon()
 
 /obj/item/clothing/head/hardhat/update_icon()
-	icon_state = "hardhat[on]_[item_color]"
-	item_state = "hardhat[on]_[item_color]"
+	icon_state = "hardhat[light_on]_[item_color]"
+	item_state = "hardhat[light_on]_[item_color]"
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
 		H.update_inv_head()

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -77,7 +77,7 @@
 	STOP_PROCESSING(SSobj, src)
 
 /obj/item/clothing/head/hardhat/cakehat/is_hot()
-	return on * heat
+	return light_on * heat
 /*
  * Ushanka
  */

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -939,9 +939,8 @@
 	var/energy_color = "#35FFF0"
 
 /obj/item/clothing/suit/space/hardsuit/lavaknight/Initialize()
-	..()
-	light_color = energy_color
-	set_light(1)
+	. = ..()
+	set_light(l_range=1, l_color = energy_color)
 	update_icon()
 
 /obj/item/clothing/suit/space/hardsuit/lavaknight/update_icon()

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -48,7 +48,7 @@
 	var/brightness_on = 4 //luminosity when the light is on
 	var/on = FALSE
 	var/smile = FALSE
-	var/smile_color = "#FF0000"
+	var/smile_color = COLOR_RED
 	var/visor_icon = "envisor"
 	var/smile_state = "envirohelm_smile"
 	actions_types = list(/datum/action/item_action/toggle_helmet_light, /datum/action/item_action/toggle_welding_screen/plasmaman)

--- a/code/modules/events/aurora_aquilae.dm
+++ b/code/modules/events/aurora_aquilae.dm
@@ -14,7 +14,7 @@
 	announceWhen = 30
 	startWhen = 1
 	endWhen = 115
-	var/list/aurora_colors = list("#ffc8bc", "#ed927f", "#d5745f", "#bf3a1d", "#c71414", "#FF3131", "#ee0808", "#ff0000")
+	var/list/aurora_colors = list("#ffc8bc", "#ed927f", "#d5745f", "#bf3a1d", "#c71414", "#FF3131", "#ee0808", COLOR_RED)
 	var/aurora_progress = 0 //this cycles from 1 to 8, slowly grading towards a bright red
 	var/list/areasToFlicker = list(/area/hallway,
 									/area/security,

--- a/code/modules/events/aurora_caelus.dm
+++ b/code/modules/events/aurora_caelus.dm
@@ -15,7 +15,7 @@
 	announceWhen = 1
 	startWhen = 8	//Delayed with sleep()
 	endWhen = 50
-	var/list/aurora_colors = list("#ffd980", "#eaff80", "#eaff80", "#ffd980", "#eaff80", "#A2FFC7", "#9400D3", "#FFC0CB")
+	var/list/aurora_colors = list("#ffd980", "#eaff80", "#eaff80", "#ffd980", "#eaff80", "#A2FFC7", "#9400D3", COLOR_PINK)
 	var/aurora_progress = 0 //this cycles from 1 to 8, slowly changing colors from gentle green to gentle blue
 	var/list/applicable_areas = list()
 

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -178,7 +178,7 @@
 	shuttleId = "pirateship"
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	possible_destinations = "pirateship_away;pirateship_home;pirateship_custom"
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/pirate

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -64,7 +64,7 @@
 
 /datum/round_event/portal_storm/setup()
 	storm = mutable_appearance('icons/obj/tesla_engine/energy_ball.dmi', "energy_ball_fast", FLY_LAYER)
-	storm.color = "#00FF00"
+	storm.color = COLOR_GREEN
 
 	number_of_bosses = 0
 	for(var/boss in boss_types)

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -74,7 +74,7 @@
 
 /datum/spacevine_mutation/light
 	name = "light"
-	hue = "#ffff00"
+	hue = COLOR_YELLOW
 	quality = POSITIVE
 	severity = 4
 
@@ -84,7 +84,7 @@
 
 /datum/spacevine_mutation/toxicity
 	name = "toxic"
-	hue = "#ff00ff"
+	hue = COLOR_MAGENTA
 	severity = 10
 	quality = NEGATIVE
 
@@ -101,7 +101,7 @@
 
 /datum/spacevine_mutation/explosive  //OH SHIT IT CAN CHAINREACT RUN!!!
 	name = "explosive"
-	hue = "#ff0000"
+	hue = COLOR_RED
 	quality = NEGATIVE
 	severity = 2
 
@@ -192,7 +192,7 @@
 
 /datum/spacevine_mutation/carbondioxide_eater
 	name = "CO2 consuming"
-	hue = "#00ffff"
+	hue = COLOR_CYAN
 	severity = 3
 	quality = POSITIVE
 

--- a/code/modules/events/wizard/greentext.dm
+++ b/code/modules/events/wizard/greentext.dm
@@ -47,14 +47,14 @@
 		last_holder = user
 	if(!(user in color_altered_mobs))
 		color_altered_mobs += user
-	user.add_atom_colour("#00FF00", ADMIN_COLOUR_PRIORITY)
+	user.add_atom_colour(COLOR_GREEN, ADMIN_COLOUR_PRIORITY)
 	START_PROCESSING(SSobj, src)
 	..()
 
 /obj/item/greentext/dropped(mob/living/user as mob)
 	if(user in color_altered_mobs)
 		to_chat(user, "<span class='warning'>A sudden wave of failure washes over you...</span>")
-		user.add_atom_colour("#FF0000", ADMIN_COLOUR_PRIORITY) //ya blew it
+		user.add_atom_colour(COLOR_RED, ADMIN_COLOUR_PRIORITY) //ya blew it
 	last_holder 	= null
 	new_holder 		= null
 	STOP_PROCESSING(SSobj, src)
@@ -75,7 +75,7 @@
 /obj/item/greentext/process()
 	if(last_holder && last_holder != new_holder) //Somehow it was swiped without ever getting dropped
 		to_chat(last_holder, "<span class='warning'>A sudden wave of failure washes over you...</span>")
-		last_holder.add_atom_colour("#FF0000", ADMIN_COLOUR_PRIORITY)
+		last_holder.add_atom_colour(COLOR_RED, ADMIN_COLOUR_PRIORITY)
 		last_holder = new_holder //long live the king
 
 /obj/item/greentext/Destroy(force)
@@ -89,7 +89,7 @@
 		var/message = "<span class='warning'>A dark temptation has passed from this world"
 		if(M in color_altered_mobs)
 			message += " and you're finally able to forgive yourself"
-			if(M.color == "#FF0000" || M.color == "#00FF00")
+			if(M.color == COLOR_RED || M.color == COLOR_GREEN)
 				M.remove_atom_colour(ADMIN_COLOUR_PRIORITY)
 		message += "...</span>"
 		// can't skip the mob check as it also does the decolouring

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -47,7 +47,7 @@
 /mob/living/simple_animal/hostile/carp/ranged/chaos
 	name = "chaos magicarp"
 	desc = "50% carp, 100% magic, 150% horrible."
-	color = "#00FFFF"
+	color = COLOR_CYAN
 	maxHealth = 75
 	health = 75
 

--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -103,8 +103,8 @@
 
 /obj/item/reagent_containers/food/snacks/customizable/update_snack_overlays(obj/item/reagent_containers/food/snacks/S)
 	var/mutable_appearance/filling = mutable_appearance(icon, "[initial(icon_state)]_filling")
-	if(S.filling_color == "#FFFFFF")
-		filling.color = pick("#FF0000","#0000FF","#008000","#FFFF00")
+	if(S.filling_color == COLOR_WHITE)
+		filling.color = pick(COLOR_RED, COLOR_BLUE, COLOR_DARK_GREEN, COLOR_YELLOW)
 	else
 		filling.color = S.filling_color
 

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -271,7 +271,7 @@ All foods are distributed among various categories. Use common sense.
 	cut_overlays()
 	var/mutable_appearance/filling = mutable_appearance(icon, "[initial(icon_state)]_filling")
 	if(S.filling_color == "#FFFFFF")
-		filling.color = pick("#FF0000","#0000FF","#008000","#FFFF00")
+		filling.color = pick(COLOR_RED, COLOR_BLUE, COLOR_DARK_GREEN, COLOR_YELLOW)
 	else
 		filling.color = S.filling_color
 

--- a/code/modules/food_and_drinks/food/snacks/meat.dm
+++ b/code/modules/food_and_drinks/food/snacks/meat.dm
@@ -12,7 +12,7 @@
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/plain
 	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/plain
 	slices_num = 3
-	filling_color = "#FF0000"
+	filling_color = COLOR_RED
 	tastes = list("meat" = 1)
 	foodtype = MEAT | RAW
 
@@ -90,7 +90,7 @@
 	icon_state = "slimemeat"
 	desc = "Because jello wasn't offensive enough to vegans."
 	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/toxin/slimejelly = 3)
-	filling_color = "#00FFFF"
+	filling_color = COLOR_CYAN
 	tastes = list("slime" = 1, "jelly" = 1)
 	foodtype = MEAT | RAW | TOXIC
 
@@ -125,7 +125,7 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/shadow
 	icon_state = "shadowmeat"
 	desc = "Ow, the edge."
-	filling_color = "#202020"
+	filling_color = COLOR_NEARLY_BLACK
 	tastes = list("darkness" = 1, "meat" = 1)
 	foodtype = MEAT | RAW
 
@@ -147,7 +147,7 @@
 	name = "bone"
 	icon_state = "skeletonmeat"
 	desc = "There's a point where this needs to stop, and clearly we have passed it."
-	filling_color = "#F0F0F0"
+	filling_color = COLOR_VERY_VERY_LIGHT_GRAY
 	tastes = list("bone" = 1)
 	slice_path = null  //can't slice a bone into cutlets
 	foodtype = GROSS
@@ -167,7 +167,7 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/ipc
 	icon_state = "ipcmeat"
 	desc = "Gross robot meat."
-	filling_color = "#000000"
+	filling_color = COLOR_BLACK
 	tastes = list("metal" = 1)
 
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/avian
@@ -218,7 +218,7 @@
 	desc = "A slice from a huge tomato."
 	icon_state = "tomatomeat"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 2)
-	filling_color = "#FF0000"
+	filling_color = COLOR_RED
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/killertomato
 	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/killertomato
 	tastes = list("tomato" = 1)
@@ -241,7 +241,7 @@
 	icon_state = "xenomeat"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 1)
 	bitesize = 4
-	filling_color = "#32CD32"
+	filling_color = COLOR_LIME
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/xeno
 	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/xeno
 	tastes = list("meat" = 1, "acid" = 1)

--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -72,7 +72,7 @@
 	name = "xenomeatbread slice"
 	desc = "A slice of delicious meatbread. Extra Heretical."
 	icon_state = "xenobreadslice"
-	filling_color = "#32CD32"
+	filling_color = COLOR_LIME
 	list_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 1)
 	foodtype = GRAIN | MEAT
 

--- a/code/modules/food_and_drinks/food/snacks_cake.dm
+++ b/code/modules/food_and_drinks/food/snacks_cake.dm
@@ -125,7 +125,7 @@
 	name = "lime cake slice"
 	desc = "Just a slice of cake, it is enough for everyone."
 	icon_state = "limecake_slice"
-	filling_color = "#00FF00"
+	filling_color = COLOR_GREEN
 	tastes = list("cake" = 5, "sweetness" = 2, "unbearable sourness" = 2)
 	foodtype = GRAIN | DAIRY | FRUIT | SUGAR | ANTITOXIC
 
@@ -222,7 +222,7 @@
 	name = "slime cake slice"
 	desc = "A slice of slime cake."
 	icon_state = "slimecake_slice"
-	filling_color = "#00FFFF"
+	filling_color = COLOR_CYAN
 	tastes = list("cake" = 5, "sweetness" = 1, "slime" = 1)
 	foodtype = GRAIN | DAIRY | SUGAR
 
@@ -290,7 +290,7 @@
 	name = "angel food cake slice"
 	desc = "A slice of heavenly cake."
 	icon_state = "holy_cake_slice"
-	filling_color = "#00FFFF"
+	filling_color = COLOR_CYAN
 	tastes = list("cake" = 5, "sweetness" = 1, "clouds" = 1)
 	foodtype = GRAIN | DAIRY | SUGAR
 
@@ -308,7 +308,7 @@ obj/item/reagent_containers/food/snacks/store/cake/pound_cake
 	name = "pound cake slice"
 	desc = "A slice of condensed cake made for filling people up quickly."
 	icon_state = "pound_cake_slice"
-	filling_color = "#00FFFF"
+	filling_color = COLOR_CYAN
 	tastes = list("cake" = 5, "sweetness" = 5, "batter" = 1)
 	foodtype = GRAIN | DAIRY | SUGAR | JUNKFOOD
 
@@ -325,7 +325,7 @@ obj/item/reagent_containers/food/snacks/store/cake/pound_cake
 	name = "hardware cake slice"
 	desc = "A slice of electronic boards and some acid."
 	icon_state = "hardware_cake_slice"
-	filling_color = "#00FFFF"
+	filling_color = COLOR_CYAN
 	tastes = list("acid" = 1, "metal" = 1, "regret" = 10)
 	foodtype = GRAIN | GROSS
 
@@ -342,7 +342,7 @@ obj/item/reagent_containers/food/snacks/store/cake/pound_cake
 	name = "vanilla cake slice"
 	desc = "A slice of vanilla frosted cake."
 	icon_state = "vanillacake_slice"
-	filling_color = "#00FFFF"
+	filling_color = COLOR_CYAN
 	tastes = list("cake" = 1, "sugar" = 1, "vanilla" = 10)
 	foodtype = GRAIN | SUGAR | DAIRY
 
@@ -359,7 +359,7 @@ obj/item/reagent_containers/food/snacks/store/cake/pound_cake
 	name = "clown cake slice"
 	desc = "A slice of bad jokes, and silly props."
 	icon_state = "clowncake_slice"
-	filling_color = "#00FFFF"
+	filling_color = COLOR_CYAN
 	tastes = list("cake" = 1, "sugar" = 1, "joy" = 10)
 	foodtype = GRAIN | SUGAR | DAIRY
 
@@ -376,7 +376,7 @@ obj/item/reagent_containers/food/snacks/store/cake/pound_cake
 	name = "peach cake slice"
 	desc = "A slice of peach cake."
 	icon_state = "peach_slice"
-	filling_color = "#00FFFF"
+	filling_color = COLOR_CYAN
 	tastes = list("cake" = 1, "sugar" = 1, "peachjuice" = 10)
 	foodtype = GRAIN | SUGAR | DAIRY
 

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -108,7 +108,7 @@
 	icon_state = "spiderleg"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/toxin = 2)
 	cooked_type = /obj/item/reagent_containers/food/snacks/boiledspiderleg
-	filling_color = "#000000"
+	filling_color = COLOR_BLACK
 	tastes = list("cobwebs" = 1)
 	foodtype = MEAT | TOXIC
 
@@ -137,7 +137,7 @@
 	desc = "A ball of meat."
 	icon_state = "meatball"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/nutriment/vitamin = 1)
-	filling_color = "#800000"
+	filling_color = COLOR_RED
 	tastes = list("meat" = 1)
 	foodtype = MEAT
 
@@ -207,7 +207,7 @@
 	icon_state = "khinkali"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/nutriment/vitamin = 2)
 	bitesize = 3
-	filling_color = "#F0F0F0"
+	filling_color = COLOR_VERY_VERY_LIGHT_GRAY
 	tastes = list("meat" = 1, "onions" = 1, "garlic" = 1)
 	foodtype = MEAT
 
@@ -274,7 +274,7 @@
 	trash = /obj/item/trash/plate
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/capsaicin = 2, /datum/reagent/consumable/nutriment/vitamin = 2)
 	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/capsaicin = 2)
-	filling_color = "#000000"
+	filling_color = COLOR_BLACK
 	tastes = list("hot peppers" = 1, "cobwebs" = 1)
 	foodtype = MEAT
 
@@ -320,7 +320,7 @@
 	icon_state = "pigblanket"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 1)
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 1)
-	filling_color = "#800000"
+	filling_color = COLOR_RED
 	tastes = list("meat" = 1, "butter" = 1)
 
 /obj/item/reagent_containers/food/snacks/kebab/rat

--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -175,7 +175,7 @@
 	bitesize = 1
 	trash = /obj/item/trash/plate
 	list_reagents = list(/datum/reagent/toxin/minttoxin = 2)
-	filling_color = "#800000"
+	filling_color = COLOR_RED
 	foodtype = TOXIC | SUGAR
 
 /obj/item/reagent_containers/food/snacks/eggwrap
@@ -203,7 +203,7 @@
 	desc = "A cluster of juicy spider eggs. A great side dish for when you care not for your health."
 	icon_state = "spidereggs"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/toxin = 2)
-	filling_color = "#008000"
+	filling_color = COLOR_DARK_GREEN
 	tastes = list("cobwebs" = 1)
 	foodtype = MEAT | TOXIC
 
@@ -231,7 +231,7 @@
 	icon = 'modular_citadel/icons/obj/food/food.dmi'
 	icon_state = "sushie_egg"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 2)
-	filling_color = "#FF3333" // R225 G051 B051
+	filling_color = COLOR_RED_LIGHT // R225 G051 B051
 	tastes = list("seaweed" = 1, "cobwebs" = 1, "salty" = 2)
 	foodtype = MEAT | VEGETABLES
 

--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -466,7 +466,7 @@
 	desc = "The food of choice for the seasoned botanist."
 	icon_state = "dankpocket"
 	list_reagents = list(/datum/reagent/toxin/lipolicide = 3, /datum/reagent/drug/space_drugs = 3, /datum/reagent/consumable/nutriment = 4)
-	filling_color = "#00FF00"
+	filling_color = COLOR_GREEN
 	tastes = list("meat" = 2, "dough" = 2)
 	foodtype = GRAIN | VEGETABLES
 

--- a/code/modules/food_and_drinks/food/snacks_sushi.dm
+++ b/code/modules/food_and_drinks/food/snacks_sushi.dm
@@ -71,7 +71,7 @@
 	icon = 'modular_citadel/icons/obj/food/food.dmi'
 	icon_state = "sushie_egg"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 2)
-	filling_color = "#FF3333" // R225 G051 B051
+	filling_color = COLOR_RED_LIGHT // R225 G051 B051
 	tastes = list("seaweed" = 1, "salty" = 2)
 	foodtype = MEAT | VEGETABLES
 

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -358,7 +358,7 @@ datum/crafting_recipe/food/donut/meat
 	desc = "The food of choice for the seasoned botanist."
 	icon_state = "dankpocket"
 	list_reagents = list(/datum/reagent/toxin/lipolicide = 3, /datum/reagent/drug/space_drugs = 3, /datum/reagent/consumable/nutriment = 4)
-	filling_color = "#00FF00"
+	filling_color = COLOR_GREEN
 	tastes = list("meat" = 2, "dough" = 2)
 	foodtype = GRAIN | VEGETABLES
 

--- a/code/modules/holiday/halloween/jacqueen.dm
+++ b/code/modules/holiday/halloween/jacqueen.dm
@@ -48,17 +48,18 @@
 	var/active = TRUE //Turn this to false to keep normal mob behavour
 	var/cached_z
 	var/static/blacklisted_items = typecacheof(list(
-	/obj/singularity,
-	/obj/structure/destructible/clockwork/massive/ratvar,
-	/obj/item/projectile,
-	/obj/item/gun,
-	/obj/item/antag_spawner,
-	/obj/effect,
-	/obj/belly,
-	/obj/decal,
-	/obj/docking_port,
-	/obj/shapeshift_holder,
-	/obj/screen))
+		/obj/singularity,
+		/obj/structure/destructible/clockwork/massive/ratvar,
+		/obj/item/projectile,
+		/obj/item/gun,
+		/obj/item/antag_spawner,
+		/obj/effect,
+		/obj/belly,
+		/obj/decal,
+		/obj/docking_port,
+		/obj/shapeshift_holder,
+		/obj/screen,
+		))
 
 /mob/living/simple_animal/jacq/Initialize()
 	..()

--- a/code/modules/hydroponics/grown/ambrosia.dm
+++ b/code/modules/hydroponics/grown/ambrosia.dm
@@ -5,7 +5,7 @@
 	desc = "This is a plant."
 	icon_state = "ambrosiavulgaris"
 	slot_flags = ITEM_SLOT_HEAD
-	filling_color = "#008000"
+	filling_color = COLOR_DARK_GREEN
 	bitesize_mod = 2
 	foodtype = VEGETABLES
 	tastes = list("ambrosia" = 1)

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -21,7 +21,7 @@
 	icon_state = "banana"
 	item_state = "banana"
 	trash = /obj/item/grown/bananapeel
-	filling_color = "#FFFF00"
+	filling_color = COLOR_YELLOW
 	bitesize = 5
 	foodtype = FRUIT
 	juice_results = list(/datum/reagent/consumable/banana = 0)
@@ -115,7 +115,7 @@
 	icon_state = "banana_blue"
 	item_state = "bluespace_peel"
 	trash = /obj/item/grown/bananapeel/bluespace
-	filling_color = "#0000FF"
+	filling_color = COLOR_BLUE
 	tastes = list("banana" = 1)
 	wine_power = 60
 	wine_flavor = "slippery hypercubes"

--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -23,7 +23,7 @@
 	desc = "Nutritious!"
 	icon_state = "berrypile"
 	gender = PLURAL
-	filling_color = "#FF00FF"
+	filling_color = COLOR_MAGENTA
 	bitesize_mod = 2
 	foodtype = FRUIT
 	juice_results = list(/datum/reagent/consumable/berryjuice = 0)
@@ -132,7 +132,7 @@
 	desc = "Great for toppings!"
 	icon_state = "cherry"
 	gender = PLURAL
-	filling_color = "#FF0000"
+	filling_color = COLOR_RED
 	bitesize_mod = 2
 	foodtype = FRUIT
 	grind_results = list(/datum/reagent/consumable/cherryjelly = 0)
@@ -181,7 +181,7 @@
 	name = "cherry bulbs"
 	desc = "They're like little Space Christmas lights!"
 	icon_state = "cherry_bulb"
-	filling_color = "#FF0000"
+	filling_color = COLOR_RED
 	bitesize_mod = 2
 	foodtype = FRUIT
 	grind_results = list(/datum/reagent/consumable/cherryjelly = 0)

--- a/code/modules/hydroponics/grown/cannabis.dm
+++ b/code/modules/hydroponics/grown/cannabis.dm
@@ -86,7 +86,7 @@
 	name = "cannabis leaf"
 	desc = "Recently legalized in most galaxies."
 	icon_state = "cannabis"
-	filling_color = "#00FF00"
+	filling_color = COLOR_GREEN
 	bitesize_mod = 2
 	foodtype = VEGETABLES //i dont really know what else weed could be to be honest
 	tastes = list("cannabis" = 1)

--- a/code/modules/hydroponics/grown/chili.dm
+++ b/code/modules/hydroponics/grown/chili.dm
@@ -23,7 +23,7 @@
 	name = "chili"
 	desc = "It's spicy! Wait... IT'S BURNING ME!!"
 	icon_state = "chilipepper"
-	filling_color = "#FF0000"
+	filling_color = COLOR_RED
 	bitesize_mod = 2
 	foodtype = FRUIT
 	wine_power = 20

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -31,7 +31,7 @@
 	desc = "It's so sour, your face will twist."
 	foodtype = FRUIT | ANTITOXIC
 	icon_state = "lime"
-	filling_color = "#00FF00"
+	filling_color = COLOR_GREEN
 	juice_results = list(/datum/reagent/consumable/limejuice = 0)
 
 // Orange

--- a/code/modules/hydroponics/grown/corn.dm
+++ b/code/modules/hydroponics/grown/corn.dm
@@ -21,7 +21,7 @@
 	desc = "Needs some butter!"
 	icon_state = "corn"
 	cooked_type = /obj/item/reagent_containers/food/snacks/popcorn
-	filling_color = "#FFFF00"
+	filling_color = COLOR_YELLOW
 	trash = /obj/item/grown/corncob
 	bitesize_mod = 2
 	foodtype = VEGETABLES

--- a/code/modules/hydroponics/grown/eggplant.dm
+++ b/code/modules/hydroponics/grown/eggplant.dm
@@ -20,7 +20,7 @@
 	name = "eggplant"
 	desc = "Maybe there's a chicken inside?"
 	icon_state = "eggplant"
-	filling_color = "#800080"
+	filling_color = COLOR_PURPLE
 	bitesize_mod = 2
 	foodtype = FRUIT
 	wine_power = 20

--- a/code/modules/hydroponics/grown/grass_carpet.dm
+++ b/code/modules/hydroponics/grown/grass_carpet.dm
@@ -23,7 +23,7 @@
 	name = "grass"
 	desc = "Green and lush."
 	icon_state = "grassclump"
-	filling_color = "#32CD32"
+	filling_color = COLOR_LIME
 	bitesize_mod = 2
 	var/stacktype = /obj/item/stack/tile/grass
 	var/tile_coefficient = 0.02 // 1/50

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -30,7 +30,7 @@
 	slices_num = 5
 	dried_type = null
 	w_class = WEIGHT_CLASS_NORMAL
-	filling_color = "#008000"
+	filling_color = COLOR_DARK_GREEN
 	bitesize_mod = 3
 	foodtype = FRUIT
 	juice_results = list(/datum/reagent/consumable/watermelonjuice = 0)

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -380,8 +380,7 @@
 			icon_state = "coconut_grenade_active"
 			desc = "RUN!"
 			if(!seed.get_gene(/datum/plant_gene/trait/glow))
-				light_color = "#FFCC66" //for the fuse
-				set_light(3, 0.8)
+				set_light(3, 0.8, COLOR_CREAMY_ORANGE)
 			return
 
 	//ADDING A FUSE, NADE LOGIC

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -86,7 +86,7 @@
 	name = "fly amanita"
 	desc = "<I>Amanita Muscaria</I>: Learn poisonous mushrooms by heart. Only pick mushrooms you know."
 	icon_state = "amanita"
-	filling_color = "#FF0000"
+	filling_color = COLOR_RED
 
 // Destroying Angel
 /obj/item/seeds/angel

--- a/code/modules/hydroponics/grown/tea_coffee.dm
+++ b/code/modules/hydroponics/grown/tea_coffee.dm
@@ -21,7 +21,7 @@
 	name = "Tea Aspera tips"
 	desc = "These aromatic tips of the tea plant can be dried to make tea."
 	icon_state = "tea_aspera_leaves"
-	filling_color = "#008000"
+	filling_color = COLOR_DARK_GREEN
 	grind_results = list(/datum/reagent/toxin/teapowder = 0)
 	dry_grind = TRUE
 	can_distill = FALSE

--- a/code/modules/hydroponics/grown/tobacco.dm
+++ b/code/modules/hydroponics/grown/tobacco.dm
@@ -20,7 +20,7 @@
 	name = "tobacco leaves"
 	desc = "Dry them out to make some smokes."
 	icon_state = "tobacco_leaves"
-	filling_color = "#008000"
+	filling_color = COLOR_DARK_GREEN
 	distill_reagent = /datum/reagent/consumable/ethanol/creme_de_menthe //Menthol, I guess.
 
 // Space Tobacco

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -45,7 +45,7 @@
 	desc = "So bloody...so...very...bloody....AHHHH!!!!"
 	icon_state = "bloodtomato"
 	splat_type = /obj/effect/gibspawner/generic
-	filling_color = "#FF0000"
+	filling_color = COLOR_RED
 	foodtype = FRUIT | GROSS
 	grind_results = list(/datum/reagent/consumable/ketchup = 0, /datum/reagent/blood/tomato = 0)
 	distill_reagent = /datum/reagent/consumable/ethanol/bloody_mary
@@ -71,7 +71,7 @@
 	desc = "I say blue-mah-to, you say blue-mae-to."
 	icon_state = "bluetomato"
 	splat_type = /obj/effect/decal/cleanable/oil
-	filling_color = "#0000FF"
+	filling_color = COLOR_BLUE
 	distill_reagent = /datum/reagent/consumable/laughter
 
 // Bluespace Tomato
@@ -119,7 +119,7 @@
 	desc = "I say to-mah-to, you say tom-mae-to... OH GOD IT'S EATING MY LEGS!!"
 	icon_state = "killertomato"
 	var/awakening = 0
-	filling_color = "#FF0000"
+	filling_color = COLOR_RED
 	distill_reagent = /datum/reagent/consumable/ethanol/demonsblood
 
 /obj/item/reagent_containers/food/snacks/grown/tomato/killer/attack(mob/M, mob/user, def_zone)

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -329,7 +329,7 @@ datum/plant_gene/trait/glow/white
 
 /datum/plant_gene/trait/glow/red
 	name = "Red Bioluminescence"
-	glow_color = "#FF3333"
+	glow_color = COLOR_RED_LIGHT
 
 /datum/plant_gene/trait/glow/yellow
 	//not the disgusting glowshroom yellow hopefully

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -298,11 +298,11 @@
 	outputs = list()
 	activators = list()
 	inputs_default = list(
-		"2" = "#FF0000"
+		"2" = COLOR_RED
 	)
 	power_draw_idle = 0 // Raises to 1 when lit.
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	var/led_color = "#FF0000"
+	var/led_color = COLOR_RED
 
 /obj/item/integrated_circuit/output/led/on_data_written()
 	power_draw_idle = get_pin_data(IC_INPUT, 1) ? 1 : 0

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -152,9 +152,7 @@
 	var/hash = md5(hidden_message)
 	var/newcolor = copytext_char(hash, 1, 7)
 	add_atom_colour("#[newcolor]", FIXED_COLOUR_PRIORITY)
-	light_color = "#[newcolor]"
-	light_power = 0.3
-	set_light(1)
+	set_light(1, 0.3, "#[newcolor]")
 
 /obj/structure/chisel_message/proc/pack()
 	var/list/data = list()

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -4,13 +4,13 @@
 /atom/proc/set_light(var/l_range, var/l_power, var/l_color = NONSENSICAL_VALUE)
 	l_range = max(l_range, MINIMUM_USEFUL_LIGHT_RANGE)	//Brings the range up to 1.4, which is just barely brighter than the soft lighting that surrounds players.
 	if (l_power != null)
-		light_power = l_power
+		set_light_power(l_power)
 
 	if (l_range != null)
-		light_range = l_range
+		set_light_range(l_range)
 
 	if (l_color != NONSENSICAL_VALUE)
-		light_color = l_color
+		set_light_color(l_color)
 
 	SEND_SIGNAL(src, COMSIG_ATOM_SET_LIGHT, l_range, l_power, l_color)
 

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -1,18 +1,8 @@
-
-/atom
-	var/light_power = 1 // Intensity of the light.
-	var/light_range = 0 // Range in tiles of the light.
-	var/light_color     // Hexadecimal RGB string representing the colour of the light.
-
-	var/tmp/datum/light_source/light // Our light source. Don't fuck with this directly unless you have a good reason!
-	var/tmp/list/light_sources       // Any light sources that are "inside" of us, for example, if src here was a mob that's carrying a flashlight, that flashlight's light source would be part of this list.
-
 // The proc you should always use to set the light of this atom.
 // Nonesensical value for l_color default, so we can detect if it gets set to null.
 #define NONSENSICAL_VALUE -99999
 /atom/proc/set_light(var/l_range, var/l_power, var/l_color = NONSENSICAL_VALUE)
-	if(l_range > 0 && l_range < MINIMUM_USEFUL_LIGHT_RANGE)
-		l_range = MINIMUM_USEFUL_LIGHT_RANGE	//Brings the range up to 1.4, which is just barely brighter than the soft lighting that surrounds players.
+	l_range = max(l_range, MINIMUM_USEFUL_LIGHT_RANGE)	//Brings the range up to 1.4, which is just barely brighter than the soft lighting that surrounds players.
 	if (l_power != null)
 		light_power = l_power
 
@@ -107,15 +97,15 @@
 	return ..()
 
 
-/atom/proc/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = LIGHT_COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
+/atom/proc/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
 	return
 
-/turf/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = LIGHT_COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
+/turf/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
 	if(!_duration)
 		stack_trace("Lighting FX obj created on a turf without a duration")
 	new /obj/effect/dummy/lighting_obj (src, _color, _range, _power, _duration)
 
-/obj/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = LIGHT_COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
+/obj/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
 	var/temp_color
 	var/temp_power
 	var/temp_range
@@ -126,9 +116,38 @@
 	set_light(_range, _power, _color)
 	addtimer(CALLBACK(src, /atom/proc/set_light, _reset_lighting ? initial(light_range) : temp_range, _reset_lighting ? initial(light_power) : temp_power, _reset_lighting ? initial(light_color) : temp_color), _duration, TIMER_OVERRIDE|TIMER_UNIQUE)
 
-/mob/living/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = LIGHT_COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
+/mob/living/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
 	mob_light(_color, _range, _power, _duration)
 
 /mob/living/proc/mob_light(_color, _range, _power, _duration)
 	var/obj/effect/dummy/lighting_obj/moblight/mob_light_obj = new (src, _color, _range, _power, _duration)
 	return mob_light_obj
+
+
+/atom/proc/set_light_range(new_range)
+	if(new_range == light_range)
+		return
+	SEND_SIGNAL(src, COMSIG_ATOM_SET_LIGHT_RANGE, new_range)
+	. = light_range
+	light_range = new_range
+
+/atom/proc/set_light_power(new_power)
+	if(new_power == light_power)
+		return
+	SEND_SIGNAL(src, COMSIG_ATOM_SET_LIGHT_POWER, new_power)
+	. = light_power
+	light_power = new_power
+
+/atom/proc/set_light_color(new_color)
+	if(new_color == light_color)
+		return
+	SEND_SIGNAL(src, COMSIG_ATOM_SET_LIGHT_COLOR, new_color)
+	. = light_color
+	light_color = new_color
+
+/atom/proc/set_light_on(new_value)
+	if(new_value == light_on)
+		return
+	SEND_SIGNAL(src, COMSIG_ATOM_SET_LIGHT_ON, new_value)
+	. = light_on
+	light_on = new_value

--- a/code/modules/mapping/mapping_helpers/network_builder/power_cables.dm
+++ b/code/modules/mapping/mapping_helpers/network_builder/power_cables.dm
@@ -7,7 +7,7 @@
 	name = "power line autobuilder"
 	icon_state = "powerlinebuilder"
 
-	color = "#ff0000"
+	color = COLOR_RED
 
 	/// Whether or not we forcefully make a knot
 	var/knot = NO_KNOT
@@ -82,7 +82,7 @@
 
 // Red
 /obj/effect/mapping_helpers/network_builder/power_cable/red
-	color = "#ff0000"
+	color = COLOR_RED
 	cable_color = "red"
 
 /obj/effect/mapping_helpers/network_builder/power_cable/red/knot
@@ -108,7 +108,7 @@
 
 // Cyan
 /obj/effect/mapping_helpers/network_builder/power_cable/cyan
-	color = "#00ffff"
+	color = COLOR_CYAN
 	cable_color = "cyan"
 
 /obj/effect/mapping_helpers/network_builder/power_cable/cyan/knot
@@ -173,7 +173,7 @@
 
 // Yellow
 /obj/effect/mapping_helpers/network_builder/power_cable/yellow
-	color = "#ffff00"
+	color = COLOR_YELLOW
 	cable_color = "yellow"
 
 /obj/effect/mapping_helpers/network_builder/power_cable/yellow/knot

--- a/code/modules/mapping/minimaps.dm
+++ b/code/modules/mapping/minimaps.dm
@@ -53,15 +53,15 @@
 		meta_icon.DrawBox(meta_color, img_x, img_y)
 
 		if(istype(T, /turf/closed/wall))
-			map_icon.DrawBox("#000000", img_x, img_y)
+			map_icon.DrawBox(COLOR_BLACK, img_x, img_y)
 
 		else if(!istype(A, /area/space))
-			var/color = A.minimap_color || "#FF00FF"
+			var/color = A.minimap_color || COLOR_MAGENTA
 			if(locate(/obj/machinery/power/solar) in T)
 				color = "#02026a"
 
 			if((locate(/obj/effect/spawner/structure/window) in T) || (locate(/obj/structure/grille) in T))
-				color = BlendRGB(color, "#000000", 0.5)
+				color = BlendRGB(color, COLOR_BLACK, 0.5)
 			map_icon.DrawBox(color, img_x, img_y)
 
 	map_icon.Crop(crop_x1, crop_y1, crop_x2, crop_y2)

--- a/code/modules/mining/aux_base_camera.dm
+++ b/code/modules/mining/aux_base_camera.dm
@@ -29,11 +29,14 @@
 /obj/machinery/computer/camera_advanced/base_construction
 	name = "base construction console"
 	desc = "An industrial computer integrated with a camera-assisted rapid construction drone."
+	icon_screen = "mining"
+	icon_keyboard = "rd_key"
 	networks = list("ss13")
-	var/obj/item/construction/rcd/internal/RCD //Internal RCD. The computer passes user commands to this in order to avoid massive copypaste.
-	circuit = /obj/item/circuitboard/computer/base_construction
-	off_action = new/datum/action/innate/camera_off/base_construction
 	jump_action = null
+	off_action = new/datum/action/innate/camera_off/base_construction
+	circuit = /obj/item/circuitboard/computer/base_construction
+	light_color = LIGHT_COLOR_PINK
+	var/obj/item/construction/rcd/internal/RCD //Internal RCD. The computer passes user commands to this in order to avoid massive copypaste.
 	var/datum/action/innate/aux_base/switch_mode/switch_mode_action = new //Action for switching the RCD's build modes
 	var/datum/action/innate/aux_base/build/build_action = new //Action for using the RCD
 	var/datum/action/innate/aux_base/airlock_type/airlock_mode_action = new //Action for setting the airlock type
@@ -43,11 +46,6 @@
 	var/datum/action/innate/aux_base/install_turret/turret_action = new //Action for spawning turrets
 	var/turret_stock = 0 //Turrets in stock
 	var/obj/machinery/computer/auxillary_base/found_aux_console //Tracker for the Aux base console, so the eye can always find it.
-
-	icon_screen = "mining"
-	icon_keyboard = "rd_key"
-
-	light_color = LIGHT_COLOR_PINK
 
 /obj/machinery/computer/camera_advanced/base_construction/Initialize()
 	. = ..()

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -23,12 +23,12 @@
 	attack_verb = list("smashed", "crushed", "cleaved", "chopped", "pulped")
 	sharpness = IS_SHARP
 	actions_types = list(/datum/action/item_action/toggle_light)
+	light_on = FALSE
 	var/list/trophies = list()
 	var/charged = TRUE
 	var/charge_time = 15
 	var/detonation_damage = 50
 	var/backstab_bonus = 30
-	var/light_on = FALSE
 	var/brightness_on = 5	//same light as a lit seclite on a PKA
 
 /obj/item/twohanded/kinetic_crusher/Initialize()

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -185,12 +185,12 @@
 	desc = "A heated storage unit."
 	icon_state = "donkvendor"
 	icon = 'icons/obj/lavaland/donkvendor.dmi'
+	pixel_y = -4
+	max_n_of_items = 10
+	flags_1 = NODECONSTRUCT_1
 	light_range = 5
 	light_power = 1.2
-	light_color = "#DDFFD3"
-	max_n_of_items = 10
-	pixel_y = -4
-	flags_1 = NODECONSTRUCT_1
+	light_color = COLOR_VERY_PALE_LIME_GREEN
 	var/empty = FALSE
 
 /obj/machinery/smartfridge/survival_pod/update_icon()

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -991,7 +991,7 @@
 	name = "blood contract"
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "scroll2"
-	color = "#FF0000"
+	color = COLOR_RED
 	desc = "Mark your target for death."
 	var/used = FALSE
 
@@ -1030,7 +1030,7 @@
 	L.mind.objectives += survive
 	log_combat(user, L, "took out a blood contract on", src)
 	to_chat(L, "<span class='userdanger'>You've been marked for death! Don't let the demons get you! KILL THEM ALL!</span>")
-	L.add_atom_colour("#FF0000", ADMIN_COLOUR_PRIORITY)
+	L.add_atom_colour(COLOR_RED, ADMIN_COLOUR_PRIORITY)
 	var/obj/effect/mine/pickup/bloodbath/B = new(L)
 	INVOKE_ASYNC(B, /obj/effect/mine/pickup/bloodbath/.proc/mineEffect, L)
 

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -34,8 +34,8 @@
 	healable = 0
 	loot = list(/obj/effect/decal/cleanable/robot_debris)
 	del_on_death = TRUE
+	light_on = FALSE
 	var/mode = MINEDRONE_COLLECT
-	var/light_on = 0
 	var/obj/item/gun/energy/kinetic_accelerator/minebot/stored_gun
 
 /mob/living/simple_animal/hostile/mining_drone/Initialize()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -708,7 +708,7 @@
 /mob/living/carbon/human/proc/electrocution_animation(anim_duration)
 	//Handle mutant parts if possible
 	if(dna && dna.species)
-		add_atom_colour("#000000", TEMPORARY_COLOUR_PRIORITY)
+		add_atom_colour(COLOR_BLACK, TEMPORARY_COLOUR_PRIORITY)
 		var/static/mutable_appearance/electrocution_skeleton_anim
 		if(!electrocution_skeleton_anim)
 			electrocution_skeleton_anim = mutable_appearance(icon, "electrocuted_base")
@@ -720,7 +720,7 @@
 		flick_overlay_view(image(icon,src,"electrocuted_generic",ABOVE_MOB_LAYER), src, anim_duration)
 
 /mob/living/carbon/human/proc/end_electrocution_animation(mutable_appearance/MA)
-	remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, "#000000")
+	remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, COLOR_BLACK)
 	cut_overlay(MA)
 
 //medical scan animation

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -449,7 +449,7 @@
 	name = "luminescent glow"
 	desc = "Tell a coder if you're seeing this."
 	icon_state = "nothing"
-	light_color = "#FFFFFF"
+	light_color = COLOR_WHITE
 	light_range = LUMINESCENT_DEFAULT_GLOW
 
 /obj/effect/dummy/luminescent_glow/Initialize()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -71,7 +71,7 @@
 
 	var/lamp_max = 10 //Maximum brightness of a borg lamp. Set as a var for easy adjusting.
 	var/lamp_intensity = 0 //Luminosity of the headlamp. 0 is off. Higher settings than the minimum require power.
-	light_color = "#FFCC66"
+	light_color = COLOR_CREAMY_ORANGE
 	light_power = 0.8
 	var/lamp_cooldown = 0 //Flag for if the lamp is on cooldown after being forcibly disabled.
 

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -21,7 +21,7 @@
 	window_name = "Automatic Security Unit v2.6"
 	allow_pai = 0
 	data_hud_type = DATA_HUD_SECURITY_ADVANCED
-	path_image_color = "#FF0000"
+	path_image_color = COLOR_RED
 
 	var/lastfired = 0
 	var/shot_delay = 15

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -19,7 +19,7 @@
 	window_name = "Automatic Security Unit v1.6"
 	allow_pai = 0
 	data_hud_type = DATA_HUD_SECURITY_ADVANCED
-	path_image_color = "#FF0000"
+	path_image_color = COLOR_RED
 
 	var/baton_type = /obj/item/melee/baton
 	var/mob/living/carbon/target

--- a/code/modules/mob/living/simple_animal/guardian/guardiannaming.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardiannaming.dm
@@ -55,7 +55,7 @@
 
 /datum/guardianname/carp/aqua
 	suffixcolour = "Aqua"
-	colour = "#00FFFF"
+	colour = COLOR_CYAN
 
 /datum/guardianname/carp/paleaqua
 	suffixcolour = "Pale Aqua"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -29,7 +29,7 @@ Difficulty: Medium
 	icon_living = "miner"
 	icon = 'icons/mob/broadMobs.dmi'
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	light_color = "#E4C7C5"
+	light_color = COLOR_LIGHT_GRAYISH_RED
 	movement_type = GROUND
 	speak_emote = list("roars")
 	speed = 1

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -144,7 +144,7 @@ Difficulty: Hard
 	walk(src, 0)
 	setDir(get_dir(src, T))
 	var/obj/effect/temp_visual/decoy/D = new /obj/effect/temp_visual/decoy(loc,src)
-	animate(D, alpha = 0, color = "#FF0000", transform = matrix()*2, time = 5)
+	animate(D, alpha = 0, color = COLOR_RED, transform = matrix()*2, time = 5)
 	sleep(5)
 	throw_at(T, get_dist(src, T), 1, src, 0)
 	charging = 0

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -338,7 +338,7 @@ Difficulty: Medium
 	layer = BELOW_MOB_LAYER
 	pixel_x = -32
 	pixel_y = -32
-	color = "#FF0000"
+	color = COLOR_RED
 	duration = 5
 
 /obj/effect/temp_visual/dragon_flight

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -11,7 +11,7 @@
 /obj/effect/light_emitter/red_energy_sword //used so there's a combination of both their head light and light coming off the energy sword
 	set_luminosity = 2
 	set_cap = 2.5
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 
 
 /mob/living/simple_animal/hostile/syndicate
@@ -115,7 +115,7 @@
 	attacktext = "slashes"
 	attack_sound = 'sound/weapons/blade1.ogg'
 	armour_penetration = 35
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	status_flags = 0
 	var/obj/effect/light_emitter/red_energy_sword/sord
 

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -4,6 +4,12 @@
 /obj/item/modular_computer
 	name = "modular microcomputer"
 	desc = "A small portable microcomputer."
+	icon = 'icons/obj/computer.dmi'
+	icon_state = "laptop-open"
+	light_on = FALSE
+	integrity_failure = 50
+	max_integrity = 100
+	armor = list("melee" = 0, "bullet" = 20, "laser" = 20, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
 
 	var/enabled = 0											// Whether the computer is turned on.
 	var/screen_on = 1										// Whether the computer is active/opened/it's screen is on.
@@ -21,17 +27,11 @@
 	// must have it's own DMI file. Icon states must be called exactly the same in all files, but may look differently
 	// If you create a program which is limited to Laptops and Consoles you don't have to add it's icon_state overlay for Tablets too, for example.
 
-	icon = 'icons/obj/computer.dmi'
-	icon_state = "laptop-open"
 	var/icon_state_unpowered = null							// Icon state when the computer is turned off.
 	var/icon_state_powered = null							// Icon state when the computer is turned on.
 	var/icon_state_menu = "menu"							// Icon state overlay when the computer is turned on, but no program is loaded that would override the screen.
 	var/max_hardware_size = 0								// Maximal hardware w_class. Tablets/PDAs have 1, laptops 2, consoles 4.
 	var/steel_sheet_cost = 5								// Amount of steel sheets refunded when disassembling an empty frame of this computer.
-
-	integrity_failure = 50
-	max_integrity = 100
-	armor = list("melee" = 0, "bullet" = 20, "laser" = 20, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
 
 	// Important hardware (must be installed for computer to work)
 
@@ -42,7 +42,6 @@
 	var/list/idle_threads							// Idle programs on background. They still receive process calls but can't be interacted with.
 	var/obj/physical = null									// Object that represents our computer. It's used for Adjacent() and UI visibility checks.
 	var/has_light = FALSE						//If the computer has a flashlight/LED light/what-have-you installed
-	var/light_on = FALSE						//If that light is enabled
 	var/comp_light_luminosity = 3				//The brightness of that light
 	var/comp_light_color			//The color of that light
 

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -155,7 +155,7 @@
 					to_chat(user, "<span class='warning'>That color is too dark! Choose a lighter one.</span>")
 					new_color = null
 			comp_light_color = new_color
-			light_color = new_color
+			set_light_color(new_color)
 			update_light()
 			return TRUE
 		else

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -9,7 +9,7 @@
 	item_state = "camera"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
-	light_color = LIGHT_COLOR_WHITE
+	light_color = COLOR_WHITE
 	light_power = FLASH_LIGHT_POWER
 	w_class = WEIGHT_CLASS_SMALL
 	flags_1 = CONDUCT_1

--- a/code/modules/pool/pool_noodles.dm
+++ b/code/modules/pool/pool_noodles.dm
@@ -6,7 +6,7 @@
 	name = "pool noodle"
 	desc = "A strange, bulky, bendable toy that can annoy people."
 	force = 0
-	color = "#000000"
+	color = COLOR_BLACK
 	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 1
 	throw_speed = 10 //weeee

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -333,16 +333,15 @@
 
 		switch(charging)
 			if(APC_NOT_CHARGING)
-				light_color = LIGHT_COLOR_RED
+				set_light_color(COLOR_SOFT_RED)
 			if(APC_CHARGING)
-				light_color = LIGHT_COLOR_BLUE
+				set_light_color(LIGHT_COLOR_BLUE)
 			if(APC_FULLY_CHARGED)
-				light_color = LIGHT_COLOR_GREEN
-		set_light(lon_range)
+				set_light_color(LIGHT_COLOR_GREEN)
+		set_light(l_range=lon_range)
 		lighteffect.color = light_color
 	else if(update_state & UPSTATE_BLUESCREEN)
-		light_color = LIGHT_COLOR_BLUE
-		set_light(lon_range)
+		set_light(l_range=lon_range, l_color=LIGHT_COLOR_BLUE)
 	else
 		set_light(0)
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -1,12 +1,12 @@
 GLOBAL_LIST_INIT(cable_colors, list(
-	"yellow" = "#ffff00",
+	"yellow" = COLOR_YELLOW,
 	"green" = "#00aa00",
 	"blue" = "#1919c8",
 	"pink" = "#ff3cc8",
 	"orange" = "#ff8000",
-	"cyan" = "#00ffff",
+	"cyan" = COLOR_CYAN,
 	"white" = "#ffffff",
-	"red" = "#ff0000"
+	"red" = COLOR_RED
 	))
 
 ///////////////////////////////
@@ -48,11 +48,11 @@ By design, d1 is the smallest direction and d2 is the highest
 	var/obj/item/stack/cable_coil/stored
 
 	var/cable_color = "red"
-	color = "#ff0000"
+	color = COLOR_RED
 
 /obj/structure/cable/yellow
 	cable_color = "yellow"
-	color = "#ffff00"
+	color = COLOR_YELLOW
 
 /obj/structure/cable/green
 	cable_color = "green"
@@ -72,7 +72,7 @@ By design, d1 is the smallest direction and d2 is the highest
 
 /obj/structure/cable/cyan
 	cable_color = "cyan"
-	color = "#00ffff"
+	color = COLOR_CYAN
 
 /obj/structure/cable/white
 	cable_color = "white"
@@ -770,11 +770,11 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 
 /obj/item/stack/cable_coil/red
 	item_color = "red"
-	color = "#ff0000"
+	color = COLOR_RED
 
 /obj/item/stack/cable_coil/yellow
 	item_color = "yellow"
-	color = "#ffff00"
+	color = COLOR_YELLOW
 
 /obj/item/stack/cable_coil/blue
 	item_color = "blue"
@@ -794,7 +794,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 
 /obj/item/stack/cable_coil/cyan
 	item_color = "cyan"
-	color = "#00ffff"
+	color = COLOR_CYAN
 
 /obj/item/stack/cable_coil/white
 	item_color = "white"
@@ -821,11 +821,11 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 
 /obj/item/stack/cable_coil/cut/red
 	item_color = "red"
-	color = "#ff0000"
+	color = COLOR_RED
 
 /obj/item/stack/cable_coil/cut/yellow
 	item_color = "yellow"
-	color = "#ffff00"
+	color = COLOR_YELLOW
 
 /obj/item/stack/cable_coil/cut/blue
 	item_color = "blue"
@@ -845,7 +845,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 
 /obj/item/stack/cable_coil/cut/cyan
 	item_color = "cyan"
-	color = "#00ffff"
+	color = COLOR_CYAN
 
 /obj/item/stack/cable_coil/cut/white
 	item_color = "white"

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -219,7 +219,7 @@
 	var/emergency_mode = FALSE	// if true, the light is in emergency mode
 	var/no_emergency = FALSE	// if true, this light cannot ever have an emergency mode
 	var/bulb_emergency_brightness_mul = 0.6	// multiplier for this light's base brightness in emergency power mode
-	var/bulb_emergency_colour = "#FF3232"	// determines the colour of the light while it's in emergency mode
+	var/bulb_emergency_colour = COLOR_VIVID_RED	// determines the colour of the light while it's in emergency mode
 	var/bulb_emergency_pow_mul = 0.75	// the multiplier for determining the light's power in emergency mode
 	var/bulb_emergency_pow_min = 0.5	// the minimum value for the light's power in emergency mode
 

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -121,7 +121,7 @@
 /obj/item/firing_pin/clown
 	name = "hilarious firing pin"
 	desc = "Advanced clowntech that can convert any firearm into a far more useful object."
-	color = "#FFFF00"
+	color = COLOR_YELLOW
 	fail_message = "<span class='warning'>HONK!</span>"
 	force_replace = TRUE
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -10,7 +10,7 @@
 	flag = "laser"
 	eyeblur = 2
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	ricochets_max = 50	//Honk!
 	ricochet_chance = 80
 	is_reflectable = TRUE
@@ -143,7 +143,7 @@
 	icon_state = "laser"
 	suit_types = list(/obj/item/clothing/suit/bluetag)
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	tracer_type = /obj/effect/projectile/tracer/laser
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
@@ -182,7 +182,7 @@
 /obj/item/projectile/beam/instakill/red
 	icon_state = "red_laser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 
 /obj/item/projectile/beam/instakill/on_hit(atom/target)
 	. = ..()

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -24,7 +24,7 @@
 	jitter = 20
 	range = 7
 	icon_state = "spark"
-	color = "#FFFF00"
+	color = COLOR_YELLOW
 
 /obj/item/projectile/bullet/shotgun_meteorslug
 	name = "meteorslug"

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -12,7 +12,7 @@
 /obj/item/projectile/energy/electrode
 	name = "electrode"
 	icon_state = "spark"
-	color = "#FFFF00"
+	color = COLOR_YELLOW
 	nodamage = 1
 	knockdown = 100
 	stutter = 5

--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -9,12 +9,12 @@
 	hitsound = 'sound/weapons/emitter2.ogg'
 	impact_type = /obj/effect/projectile/impact/xray
 	var/static/list/particle_colors = list(
-		"red" = "#FF0000",
-		"blue" = "#00FF00",
-		"green" = "#0000FF",
-		"yellow" = "#FFFF00",
-		"cyan" = "#00FFFF",
-		"purple" = "#FF00FF"
+		"red" = COLOR_RED,
+		"blue" = COLOR_GREEN,
+		"green" = COLOR_BLUE,
+		"yellow" = COLOR_YELLOW,
+		"cyan" = COLOR_CYAN,
+		"purple" = COLOR_MAGENTA
 	)
 
 /obj/item/projectile/energy/nuclear_particle/Initialize()

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/energy/electrode
 	name = "electrode"
 	icon_state = "spark"
-	color = "#FFFF00"
+	color = COLOR_YELLOW
 	nodamage = 1
 	knockdown = 60
 	knockdown_stamoverride = 36

--- a/code/modules/projectiles/projectile/special/gravity.dm
+++ b/code/modules/projectiles/projectile/special/gravity.dm
@@ -6,7 +6,7 @@
 	damage = 0
 	damage_type = BRUTE
 	nodamage = 1
-	color = "#33CCFF"
+	color = COLOR_BLUE_LIGHT
 	var/turf/T
 	var/power = 4
 	var/list/thrown_items = list()

--- a/code/modules/projectiles/projectile/special/hallucination.dm
+++ b/code/modules/projectiles/projectile/special/hallucination.dm
@@ -158,7 +158,7 @@
 	name = "electrode"
 	damage_type = BURN
 	hal_icon_state = "spark"
-	color = "#FFFF00"
+	color = COLOR_YELLOW
 	hal_fire_sound = 'sound/weapons/taser.ogg'
 	hal_hitsound = 'sound/weapons/taserhit.ogg'
 	hal_hitsound_wall = null

--- a/code/modules/projectiles/projectile/special/wormhole.dm
+++ b/code/modules/projectiles/projectile/special/wormhole.dm
@@ -6,7 +6,7 @@
 	nodamage = TRUE
 	pass_flags = PASSGLASS | PASSTABLE | PASSGRILLE | PASSMOB
 	var/obj/item/gun/energy/wormhole_projector/gun
-	color = "#33CCFF"
+	color = COLOR_BLUE_LIGHT
 	tracer_type = /obj/effect/projectile/tracer/wormhole
 	impact_type = /obj/effect/projectile/impact/wormhole
 	muzzle_type = /obj/effect/projectile/muzzle/wormhole

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/list/data
 	var/current_cycle = 0
 	var/volume = 0									//pretend this is moles
-	var/color = "#000000" // rgb: 0, 0, 0
+	var/color = COLOR_BLACK
 	var/can_synth = TRUE // can this reagent be synthesized? (for example: odysseus syringe gun)
 	var/metabolization_rate = REAGENTS_METABOLISM //how fast the reagent is metabolized by the mob
 	var/overrides_metab = 0

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1514,7 +1514,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/triple_sec
 	name = "Triple Sec"
 	description = "A sweet and vibrant orange liqueur."
-	color = "#ffcc66"
+	color = COLOR_CREAMY_ORANGE
 	boozepwr = 30
 	taste_description = "a warm flowery orange taste which recalls the ocean air and summer wind of the caribbean"
 	glass_icon_state = "glass_orange"
@@ -1576,7 +1576,7 @@ datum/reagent/consumable/ethanol/creme_de_coconut
 /datum/reagent/consumable/ethanol/quintuple_sec
 	name = "Quintuple Sec"
 	description = "Law, Order, Alcohol, and Police Brutality distilled into one single elixir of JUSTICE."
-	color = "#ff3300"
+	color = COLOR_MOSTLY_PURE_RED
 	boozepwr = 80
 	quality = DRINK_FANTASTIC
 	taste_description = "THE LAW"
@@ -1622,7 +1622,7 @@ datum/reagent/consumable/ethanol/creme_de_coconut
 /datum/reagent/consumable/ethanol/bastion_bourbon
 	name = "Bastion Bourbon"
 	description = "Soothing hot herbal brew with restorative properties. Hints of citrus and berry flavors."
-	color = "#00FFFF"
+	color = COLOR_CYAN
 	boozepwr = 30
 	quality = DRINK_FANTASTIC
 	taste_description = "hot herbal brew with a hint of fruit"
@@ -1661,7 +1661,7 @@ datum/reagent/consumable/ethanol/creme_de_coconut
 /datum/reagent/consumable/ethanol/squirt_cider
 	name = "Squirt Cider"
 	description = "Fermented squirt extract with a nose of stale bread and ocean water. Whatever a squirt is."
-	color = "#FF0000"
+	color = COLOR_RED
 	boozepwr = 40
 	taste_description = "stale bread with a staler aftertaste"
 	nutriment_factor = 2 * REAGENTS_METABOLISM

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -4,7 +4,7 @@
 	description = "shouldn't exist and you should adminhelp immediately."
 	color = "#FFFFFF"
 	taste_description = "bad code and slime"
-	var/complementary_color = "#000000" //a color that's complementary to the normal blob color
+	var/complementary_color = COLOR_BLACK //a color that's complementary to the normal blob color
 	var/shortdesc = null //just damage and on_mob effects, doesn't include special, blob-tile only effects
 	var/effectdesc = null //any long, blob-tile specific effects
 	var/analyzerdescdamage = "Unknown. Report this bug to a coder, or just adminhelp."

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -481,7 +481,7 @@
 /datum/reagent/consumable/space_up
 	name = "Space-Up"
 	description = "Tastes like a hull breach in your mouth."
-	color = "#00FF00" // rgb: 0, 255, 0
+	color = COLOR_GREEN // rgb: 0, 255, 0
 	taste_description = "cherry soda"
 	glass_icon_state = "space-up_glass"
 	glass_name = "glass of Space-Up"
@@ -679,7 +679,7 @@
 /datum/reagent/consumable/chocolatepudding
 	name = "Chocolate Pudding"
 	description = "A great dessert for chocolate lovers."
-	color = "#800000"
+	color = COLOR_RED
 	quality = DRINK_VERYGOOD
 	nutriment_factor = 4 * REAGENTS_METABOLISM
 	taste_description = "sweet chocolate"

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -428,7 +428,7 @@
 	name = "Sprinkles"
 	value = 3
 	description = "Multi-colored little bits of sugar, commonly found on donuts. Loved by cops."
-	color = "#FF00FF" // rgb: 255, 0, 255
+	color = COLOR_MAGENTA // rgb: 255, 0, 255
 	taste_description = "childhood whimsy"
 
 /datum/reagent/consumable/sprinkles/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -82,7 +82,7 @@
 /datum/reagent/medicine/synaptizine
 	name = "Synaptizine"
 	description = "Increases resistance to stuns as well as reducing drowsiness and hallucinations."
-	color = "#FF00FF"
+	color = COLOR_MAGENTA
 	pH = 4
 
 /datum/reagent/medicine/synaptizine/on_mob_life(mob/living/carbon/M)
@@ -458,7 +458,7 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 	name = "Charcoal"
 	description = "Heals toxin damage as well as slowly removing any other chemicals the patient has in their bloodstream."
 	reagent_state = LIQUID
-	color = "#000000"
+	color = COLOR_BLACK
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	taste_description = "ash"
 	pH = 5
@@ -598,7 +598,7 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 	name = "Salbutamol"
 	description = "Rapidly restores oxygen deprivation as well as preventing more of it to an extent."
 	reagent_state = LIQUID
-	color = "#00FFFF"
+	color = COLOR_CYAN
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	pH = 2
 
@@ -786,7 +786,7 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 	name = "Atropine"
 	description = "If a patient is in critical condition, rapidly heals all damage types as well as regulating oxygen in the body. Excellent for stabilizing wounded patients."
 	reagent_state = LIQUID
-	color = "#000000"
+	color = COLOR_BLACK
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	overdose_threshold = 35
 	pH = 12

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1584,7 +1584,7 @@
 /datum/reagent/plantnutriment
 	name = "Generic nutriment"
 	description = "Some kind of nutriment. You can't really tell what it is. You should probably report it, along with how you obtained it."
-	color = "#000000" // RBG: 0, 0, 0
+	color = COLOR_BLACK
 	var/tox_prob = 0
 	taste_description = "plant food"
 	pH = 3
@@ -1694,7 +1694,7 @@
 	name = "Colorful Reagent"
 	description = "Thoroughly sample the rainbow."
 	reagent_state = LIQUID
-	color = "#FFFF00"
+	color = COLOR_YELLOW
 	var/list/random_color_list = list("#00aedb","#a200ff","#f47835","#d41243","#d11141","#00b159","#00aedb","#f37735","#ffc425","#008744","#0057e7","#d62d20","#ffa700")
 	taste_description = "rainbows"
 	var/no_mob_color = FALSE
@@ -2020,7 +2020,7 @@
 /datum/reagent/growthserum //neutered to use as a chemical base for sizecode shit
 	name = "Growth Serum"
 	description = "A commercial chemical designed to help older men in the bedroom."//not really it just makes you a giant
-	color = "#ff0000"//strong red. rgb 255, 0, 0
+	color = COLOR_RED//strong red. rgb 255, 0, 0
 	taste_description = "bitterness" // apparently what viagra tastes like
 
 /datum/reagent/plastic_polymers
@@ -2176,7 +2176,7 @@
 	name = "UNKNOWN"
 	description = "404: Chemical not found."
 	metabolization_rate = REAGENTS_METABOLISM
-	color = "#0000FF"
+	color = COLOR_BLUE
 	can_synth = FALSE
 	var/datum/dna/original_dna
 	var/reagent_ticks = 0

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -26,7 +26,7 @@
 	name = "Stabilizing Agent"
 	description = "Keeps unstable chemicals stable. This does not work on everything."
 	reagent_state = LIQUID
-	color = "#FFFF00"
+	color = COLOR_YELLOW
 	value = 3
 	taste_description = "metal"
 
@@ -92,7 +92,7 @@
 	name = "Black Powder"
 	description = "Explodes. Violently."
 	reagent_state = LIQUID
-	color = "#000000"
+	color = COLOR_BLACK
 	value = 5
 	metabolization_rate = 0.05
 	taste_description = "salt"

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -27,7 +27,7 @@
 /datum/reagent/toxin/mutagen
 	name = "Unstable mutagen"
 	description = "Might cause unpredictable mutations. Keep away from children."
-	color = "#00FF00"
+	color = COLOR_GREEN
 	toxpwr = 0
 	taste_description = "slime"
 	taste_mult = 0.9
@@ -562,7 +562,7 @@
 	name = "Sodium Thiopental"
 	description = "Sodium Thiopental induces heavy weakness in its target as well as unconsciousness."
 	reagent_state = LIQUID
-	color = "#6496FA"
+	color = LIGHT_COLOR_BLUE
 	metabolization_rate = 0.75 * REAGENTS_METABOLISM
 	toxpwr = 0
 

--- a/code/modules/reagents/reagent_containers/rags.dm
+++ b/code/modules/reagents/reagent_containers/rags.dm
@@ -174,7 +174,7 @@
 	force = initial(force) + round(reagents.total_volume * 0.5)
 
 /obj/item/reagent_containers/rag/towel/random
-	possible_colors = list("#FF0000","#FF7F00","#FFFF00","#00FF00","#0000FF","#4B0082","#8F00FF")
+	possible_colors = list(COLOR_RED,"#FF7F00",COLOR_YELLOW,COLOR_GREEN,COLOR_BLUE,"#4B0082","#8F00FF")
 
 /obj/item/reagent_containers/rag/towel/syndicate
 	name = "syndicate towel"

--- a/code/modules/research/xenobiology/crossbreeding/__corecross.dm
+++ b/code/modules/research/xenobiology/crossbreeding/__corecross.dm
@@ -51,15 +51,15 @@ To add a crossbreed:
 		if("metal")
 			itemcolor = "#7E7E7E"
 		if("yellow")
-			itemcolor = "#FFFF00"
+			itemcolor = COLOR_YELLOW
 		if("dark purple")
 			itemcolor = "#551A8B"
 		if("dark blue")
-			itemcolor = "#0000FF"
+			itemcolor = COLOR_BLUE
 		if("silver")
 			itemcolor = "#D3D3D3"
 		if("bluespace")
-			itemcolor = "#32CD32"
+			itemcolor = COLOR_LIME
 		if("sepia")
 			itemcolor = "#704214"
 		if("cerulean")
@@ -67,9 +67,9 @@ To add a crossbreed:
 		if("pyrite")
 			itemcolor = "#FAFAD2"
 		if("red")
-			itemcolor = "#FF0000"
+			itemcolor = COLOR_RED
 		if("green")
-			itemcolor = "#00FF00"
+			itemcolor = COLOR_GREEN
 		if("pink")
 			itemcolor = "#FF69B4"
 		if("gold")
@@ -77,7 +77,7 @@ To add a crossbreed:
 		if("oil")
 			itemcolor = "#505050"
 		if("black")
-			itemcolor = "#000000"
+			itemcolor = COLOR_BLACK
 		if("light pink")
 			itemcolor = "#FFB6C1"
 		if("adamantine")
@@ -113,7 +113,7 @@ To add a crossbreed:
 /obj/item/slimecrossbeaker/bloodpack //Pack of 50u blood. Deletes on empty.
 	name = "blood extract"
 	desc = "A sphere of liquid blood, somehow managing to stay together."
-	color = "#FF0000"
+	color = COLOR_RED
 	list_reagents = list(/datum/reagent/blood = 50)
 
 /obj/item/slimecrossbeaker/pax //5u synthpax.
@@ -125,7 +125,7 @@ To add a crossbreed:
 /obj/item/slimecrossbeaker/omnizine //15u omnizine.
 	name = "healing extract"
 	desc = "A gelatinous extract of pure omnizine."
-	color = "#FF00FF"
+	color = COLOR_MAGENTA
 	list_reagents = list(/datum/reagent/medicine/omnizine = 15)
 
 /obj/item/slimecrossbeaker/autoinjector //As with the above, but automatically injects whomever it is used on with contents.
@@ -159,7 +159,7 @@ To add a crossbreed:
 	ignore_flags = TRUE //It is, after all, intended to heal.
 	name = "mending solution"
 	desc = "A strange glob of sweet-smelling semifluid, which seems to stick to skin rather easily."
-	color = "#FF00FF"
+	color = COLOR_MAGENTA
 	list_reagents = list(/datum/reagent/medicine/regen_jelly = 20)
 
 /obj/item/slimecrossbeaker/autoinjector/slimejelly //Primarily for slimepeople, but you do you.
@@ -167,7 +167,7 @@ To add a crossbreed:
 	ignore_flags = TRUE
 	name = "slime jelly bubble"
 	desc = "A sphere of slime jelly. It seems to stick to your skin, but avoids other surfaces."
-	color = "#00FF00"
+	color = COLOR_GREEN
 	list_reagents = list(/datum/reagent/toxin/slimejelly = 50)
 
 /obj/item/slimecrossbeaker/autoinjector/peaceandlove
@@ -183,5 +183,5 @@ To add a crossbreed:
 /obj/item/slimecrossbeaker/autoinjector/slimestimulant
 	name = "invigorating gel"
 	desc = "A bubbling purple mixture, designed to heal and boost movement."
-	color = "#FF00FF"
+	color = COLOR_MAGENTA
 	list_reagents = list(/datum/reagent/medicine/regen_jelly = 30, /datum/reagent/drug/methamphetamine = 9)

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -502,7 +502,7 @@ datum/status_effect/rebreathing/tick()
 		is_healing = TRUE
 	if(is_healing)
 		examine_text = "<span class='warning'>SUBJECTPRONOUN is regenerating slowly, purplish goo filling in small injuries!</span>"
-		new /obj/effect/temp_visual/heal(get_turf(owner), "#FF0000")
+		new /obj/effect/temp_visual/heal(get_turf(owner), COLOR_RED)
 	else
 		examine_text = null
 	..()

--- a/code/modules/research/xenobiology/crossbreeding/charged.dm
+++ b/code/modules/research/xenobiology/crossbreeding/charged.dm
@@ -329,7 +329,7 @@ Charged extracts:
 	to_chat(user, "<span class='notice'>You slather the blue gunk over the [C], making it airtight.</span>")
 	C.name = "pressure-resistant [C.name]"
 	C.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
-	C.add_atom_colour("#000080", FIXED_COLOUR_PRIORITY)
+	C.add_atom_colour(COLOR_NAVY, FIXED_COLOUR_PRIORITY)
 	C.min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
 	C.cold_protection = C.body_parts_covered
 	C.clothing_flags |= STOPSPRESSUREDAMAGE
@@ -363,7 +363,7 @@ Charged extracts:
 	to_chat(user, "<span class='notice'>You slather the red gunk over the [C], making it lavaproof.</span>")
 	C.name = "lavaproof [C.name]"
 	C.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
-	C.add_atom_colour("#800000", FIXED_COLOUR_PRIORITY)
+	C.add_atom_colour(COLOR_RED, FIXED_COLOUR_PRIORITY)
 	C.resistance_flags |= LAVA_PROOF
 	if (istype(C, /obj/item/clothing))
 		var/obj/item/clothing/CL = C

--- a/code/modules/research/xenobiology/crossbreeding/consuming.dm
+++ b/code/modules/research/xenobiology/crossbreeding/consuming.dm
@@ -283,25 +283,25 @@ Consuming extracts:
 	switch(rand(1,7))
 		if(1)
 			tastemessage = "red dye"
-			colour = "#FF0000"
+			colour = COLOR_RED
 		if(2)
 			tastemessage = "orange dye"
 			colour = "#FFA500"
 		if(3)
 			tastemessage = "yellow dye"
-			colour = "#FFFF00"
+			colour = COLOR_YELLOW
 		if(4)
 			tastemessage = "green dye"
-			colour = "#00FF00"
+			colour = COLOR_GREEN
 		if(5)
 			tastemessage = "blue dye"
-			colour = "#0000FF"
+			colour = COLOR_BLUE
 		if(6)
 			tastemessage = "indigo dye"
 			colour = "#4B0082"
 		if(7)
 			tastemessage = "violet dye"
-			colour = "#FF00FF"
+			colour = COLOR_MAGENTA
 	taste += tastemessage
 
 /obj/item/slime_cookie/pyrite/do_effect(mob/living/M, mob/user)

--- a/code/modules/research/xenobiology/crossbreeding/prismatic.dm
+++ b/code/modules/research/xenobiology/crossbreeding/prismatic.dm
@@ -46,7 +46,7 @@ Prismatic extracts:
 	colour = "metal"
 
 /obj/item/slimecross/prismatic/yellow
-	paintcolor = "#FFFF00"
+	paintcolor = COLOR_YELLOW
 	colour = "yellow"
 
 /obj/item/slimecross/prismatic/darkpurple
@@ -54,7 +54,7 @@ Prismatic extracts:
 	colour = "dark purple"
 
 /obj/item/slimecross/prismatic/darkblue
-	paintcolor = "#0000FF"
+	paintcolor = COLOR_BLUE
 	colour = "dark blue"
 
 /obj/item/slimecross/prismatic/silver
@@ -62,7 +62,7 @@ Prismatic extracts:
 	colour = "silver"
 
 /obj/item/slimecross/prismatic/bluespace
-	paintcolor = "#32CD32"
+	paintcolor = COLOR_LIME
 	colour = "bluespace"
 
 /obj/item/slimecross/prismatic/sepia
@@ -78,11 +78,11 @@ Prismatic extracts:
 	colour = "pyrite"
 
 /obj/item/slimecross/prismatic/red
-	paintcolor = "#FF0000"
+	paintcolor = COLOR_RED
 	colour = "red"
 
 /obj/item/slimecross/prismatic/green
-	paintcolor = "#00FF00"
+	paintcolor = COLOR_GREEN
 	colour = "green"
 
 /obj/item/slimecross/prismatic/pink
@@ -98,7 +98,7 @@ Prismatic extracts:
 	colour = "oil"
 
 /obj/item/slimecross/prismatic/black
-	paintcolor = "#000000"
+	paintcolor = COLOR_BLACK
 	colour = "black"
 
 /obj/item/slimecross/prismatic/lightpink

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -119,7 +119,7 @@ Regenerative extracts:
 /obj/item/slimecross/regenerative/darkblue/proc/fireproof(obj/item/clothing/C)
 	C.name = "fireproofed [C.name]"
 	C.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
-	C.add_atom_colour("#000080", FIXED_COLOUR_PRIORITY)
+	C.add_atom_colour(COLOR_NAVY, FIXED_COLOUR_PRIORITY)
 	C.max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	C.heat_protection = C.body_parts_covered
 	C.resistance_flags |= FIRE_PROOF

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -861,7 +861,7 @@
 
 	to_chat(user, "<span class='notice'>You slather the red gunk over the [C], making it faster.</span>")
 	C.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
-	C.add_atom_colour("#FF0000", FIXED_COLOUR_PRIORITY)
+	C.add_atom_colour(COLOR_RED, FIXED_COLOUR_PRIORITY)
 	qdel(src)
 
 /obj/item/slimepotion/fireproof
@@ -885,7 +885,7 @@
 	to_chat(user, "<span class='notice'>You slather the blue gunk over the [C], fireproofing it.</span>")
 	C.name = "fireproofed [C.name]"
 	C.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
-	C.add_atom_colour("#000080", FIXED_COLOUR_PRIORITY)
+	C.add_atom_colour(COLOR_NAVY, FIXED_COLOUR_PRIORITY)
 	C.max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	C.heat_protection = C.body_parts_covered
 	C.resistance_flags |= FIRE_PROOF

--- a/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
@@ -185,7 +185,7 @@ GLOBAL_DATUM(necropolis_gate, /obj/structure/necropolis_gate/legion_gate)
 			if(M.z == z)
 				to_chat(M, "<span class='userdanger'>Discordant whispers flood your mind in a thousand voices. Each one speaks your name, over and over. Something horrible has been released.</span>")
 				M.playsound_local(T, null, 100, FALSE, 0, FALSE, pressure_affected = FALSE, S = legion_sound)
-				flash_color(M, flash_color = "#FF0000", flash_time = 50)
+				flash_color(M, flash_color = COLOR_RED, flash_time = 50)
 		var/mutable_appearance/release_overlay = mutable_appearance('icons/effects/effects.dmi', "legiondoor")
 		notify_ghosts("Legion has been released in the [get_area(src)]!", source = src, alert_overlay = release_overlay, action = NOTIFY_JUMP)
 

--- a/code/modules/ruins/spaceruin_code/caravanambush.dm
+++ b/code/modules/ruins/spaceruin_code/caravanambush.dm
@@ -1,27 +1,27 @@
 //caravan ambush
 
 /obj/item/wrench/caravan
-	color = "#ff0000"
+	color = COLOR_RED
 	desc = "A prototype of a new wrench design, allegedly the red color scheme makes it go faster."
 	name = "experimental wrench"
 	toolspeed = 0.3
 
 /obj/item/screwdriver/caravan
-	color = "#ff0000"
+	color = COLOR_RED
 	desc = "A prototype of a new screwdriver design, allegedly the red color scheme makes it go faster."
 	name = "experimental screwdriver"
 	toolspeed = 0.3
 	random_color = FALSE
 
 /obj/item/wirecutters/caravan
-	color = "#ff0000"
+	color = COLOR_RED
 	desc = "A prototype of a new wirecutter design, allegedly the red color scheme makes it go faster."
 	name = "experimental wirecutters"
 	toolspeed = 0.3
 	random_color = FALSE
 
 /obj/item/crowbar/red/caravan
-	color = "#ff0000"
+	color = COLOR_RED
 	desc = "A prototype of a new crowbar design, allegedly the red color scheme makes it go faster."
 	name = "experimental crowbar"
 	toolspeed = 0.3
@@ -78,7 +78,7 @@
 	desc = "Used to control the Pirate Cutter."
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	circuit = /obj/item/circuitboard/computer/caravan/pirate
 	shuttleId = "caravanpirate"
 	possible_destinations = "caravanpirate_custom;caravanpirate_ambush"
@@ -101,7 +101,7 @@
 	desc = "Used to control the Syndicate Fighter."
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	req_access = list(ACCESS_SYNDICATE)
 	circuit = /obj/item/circuitboard/computer/caravan/syndicate1
 	shuttleId = "caravansyndicate1"
@@ -126,7 +126,7 @@
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
 	req_access = list(ACCESS_SYNDICATE)
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	circuit = /obj/item/circuitboard/computer/caravan/syndicate2
 	shuttleId = "caravansyndicate2"
 	possible_destinations = "caravansyndicate2_custom;caravansyndicate2_ambush;caravansyndicate1_listeningpost"
@@ -150,7 +150,7 @@
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
 	req_access = list(ACCESS_SYNDICATE)
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	circuit = /obj/item/circuitboard/computer/caravan/syndicate3
 	shuttleId = "caravansyndicate3"
 	possible_destinations = "caravansyndicate3_custom;caravansyndicate3_ambush;caravansyndicate3_listeningpost"

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -90,7 +90,7 @@
 	// New sleepers
 	for(var/i in found - sleepers)
 		var/mob/living/L = i
-		L.add_atom_colour("#800080", TEMPORARY_COLOUR_PRIORITY)
+		L.add_atom_colour(COLOR_PURPLE, TEMPORARY_COLOUR_PRIORITY)
 		L.visible_message("<span class='revennotice'>A strange purple glow wraps itself around [L] as [L.p_they()] suddenly fall[L.p_s()] unconscious.</span>",
 			"<span class='revendanger'>[desc]</span>")
 		// Don't let them sit suround unconscious forever
@@ -104,7 +104,7 @@
 	// Missing sleepers
 	for(var/i in sleepers - found)
 		var/mob/living/L = i
-		L.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, "#800080")
+		L.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, COLOR_PURPLE)
 		L.visible_message("<span class='revennotice'>The glow from [L] fades \
 			away.</span>")
 		L.grab_ghost()

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -6,7 +6,7 @@
 	circuit = /obj/item/circuitboard/computer/syndicate_shuttle
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 	req_access = list(ACCESS_SYNDICATE)
 	shuttleId = "syndicate"
 	possible_destinations = "syndicate_away;syndicate_z5;syndicate_ne;syndicate_nw;syndicate_n;syndicate_se;syndicate_sw;syndicate_s;syndicate_custom"

--- a/code/modules/spells/spell_types/lichdom.dm
+++ b/code/modules/spells/spell_types/lichdom.dm
@@ -52,7 +52,7 @@
 
 		marked_item.name = "ensouled [marked_item.name]"
 		marked_item.desc += "\nA terrible aura surrounds this item, its very existence is offensive to life itself..."
-		marked_item.add_atom_colour("#003300", ADMIN_COLOUR_PRIORITY)
+		marked_item.add_atom_colour(COLOR_VERY_DARK_LIME_GREEN, ADMIN_COLOUR_PRIORITY)
 
 		new /obj/item/phylactery(marked_item, M.mind)
 
@@ -76,8 +76,8 @@
 	desc = "Stores souls. Revives liches. Also repels mosquitos."
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "bluespace"
-	color = "#003300"
-	light_color = "#003300"
+	color = COLOR_VERY_DARK_LIME_GREEN
+	light_color = COLOR_VERY_DARK_LIME_GREEN
 	var/lon_range = 3
 	var/resurrections = 0
 	var/datum/mind/mind

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -98,7 +98,7 @@
 /obj/item/organ/cyberimp/brain/anti_stun
 	name = "CNS Rebooter implant"
 	desc = "This implant will automatically give you back control over your central nervous system, reducing downtime when stunned."
-	implant_color = "#FFFF00"
+	implant_color = COLOR_YELLOW
 	slot = ORGAN_SLOT_BRAIN_ANTISTUN
 
 /obj/item/organ/cyberimp/brain/anti_stun/on_life()

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -436,7 +436,7 @@
 	icon_state = "surgicaldrill_a"
 	hitsound = 'sound/items/welder.ogg'
 	toolspeed = 0.7
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 
 /obj/item/surgicaldrill/advanced/Initialize()
 	. = ..()
@@ -457,7 +457,7 @@
 	hitsound = 'sound/items/welder2.ogg'
 	force = 15
 	toolspeed = 0.7
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 
 /obj/item/cautery/advanced/Initialize()
 	. = ..()

--- a/hyperstation/code/modules/hydroponics/grown/kalyna.dm
+++ b/hyperstation/code/modules/hydroponics/grown/kalyna.dm
@@ -25,7 +25,7 @@
 	icon = 'hyperstation/icons/obj/hydroponics/harvest.dmi'
 	icon_state = "kalynaberries"
 	gender = PLURAL
-	filling_color = "#FF0000"
+	filling_color = COLOR_RED
 	bitesize_mod = 2
 	foodtype = FRUIT
 	juice_results = list(/datum/reagent/consumable/kalynajuice = 1)

--- a/hyperstation/code/modules/power/reactor/rbmk.dm
+++ b/hyperstation/code/modules/power/reactor/rbmk.dm
@@ -435,10 +435,8 @@ The reactor CHEWS through moderator. It does not do this slowly. Be very careful
 	if(warning)
 		if(!alert) //Congrats! You stopped the meltdown / blowout.
 			stop_relay(CHANNEL_REACTOR_ALERT)
-			warning = FALSE
-			set_light(0)
-			light_color = LIGHT_COLOR_CYAN
-			set_light(10)
+			warning = FAILED_UNFASTEN
+			set_light(l_range=10, l_color=LIGHT_COLOR_CYAN)
 	else
 		if(!alert)
 			return
@@ -447,9 +445,7 @@ The reactor CHEWS through moderator. It does not do this slowly. Be very careful
 		next_warning = world.time + 30 SECONDS //To avoid engis pissing people off when reaaaally trying to stop the meltdown or whatever.
 		warning = TRUE //Start warning the crew of the imminent danger.
 		relay('hyperstation/sound/effects/rbmk/alarm.ogg', null, loop=TRUE, channel = CHANNEL_REACTOR_ALERT)
-		set_light(0)
-		light_color = LIGHT_COLOR_RED
-		set_light(10)
+		set_light(l_range=10, l_color=COLOR_SOFT_RED)
 
 //Failure condition 1: Meltdown. Achieved by having heat go over tolerances. This is less devastating because it's easier to achieve.
 //Results: Engineering becomes unusable and your engine irreparable

--- a/hyperstation/code/modules/power/reactor/rbmk.dm
+++ b/hyperstation/code/modules/power/reactor/rbmk.dm
@@ -435,7 +435,7 @@ The reactor CHEWS through moderator. It does not do this slowly. Be very careful
 	if(warning)
 		if(!alert) //Congrats! You stopped the meltdown / blowout.
 			stop_relay(CHANNEL_REACTOR_ALERT)
-			warning = FAILED_UNFASTEN
+			warning = FALSE
 			set_light(l_range=10, l_color=LIGHT_COLOR_CYAN)
 	else
 		if(!alert)

--- a/hyperstation/code/obj/economy.dm
+++ b/hyperstation/code/obj/economy.dm
@@ -17,7 +17,7 @@
 	var/user = ""
 	light_power = 0
 	light_range = 7
-	light_color = "#ff3232"
+	light_color = COLOR_VIVID_RED
 	var/pin = 0
 
 /obj/machinery/atm/ui_interact(mob/user)

--- a/hyperstation/code/obj/rewards.dm
+++ b/hyperstation/code/obj/rewards.dm
@@ -168,7 +168,7 @@
 	icon_state = null
 	item_state = null
 	w_class = WEIGHT_CLASS_NORMAL
-	light_color = "#FFCC66"
+	light_color = COLOR_CREAMY_ORANGE
 	icon_off = "pipe"
 	icon_on = "pipe_lit"
 

--- a/modular_citadel/code/game/gamemodes/gangs/dominator.dm
+++ b/modular_citadel/code/game/gamemodes/gangs/dominator.dm
@@ -192,8 +192,7 @@
 		countdown.start()
 		countdown.color = gang.color
 
-		set_light(l_range = 3, l_power = 0.9)
-		light_color = gang.color
+		set_light(l_range = 3, l_power = 0.9, l_color=gang.color)
 		START_PROCESSING(SSmachines, src)
 
 		gang.message_gangtools("Hostile takeover in progress: Estimated [time] minutes until victory.[gang.dom_attempts ? "" : " This is your final attempt."]")

--- a/modular_citadel/code/game/gamemodes/gangs/gang_datums.dm
+++ b/modular_citadel/code/game/gamemodes/gangs/gang_datums.dm
@@ -8,13 +8,13 @@
 
 /datum/team/gang/clandestine
 	name = "Clandestine"
-	color = "#FF0000"
+	color = COLOR_RED
 	inner_outfits = list(/obj/item/clothing/under/syndicate/combat)
 	outer_outfits = list(/obj/item/clothing/suit/jacket)
 
 /datum/team/gang/prima
 	name = "Prima"
-	color = "#FFFF00"
+	color = COLOR_YELLOW
 	inner_outfits = list(/obj/item/clothing/under/color/yellow)
 	outer_outfits = list(/obj/item/clothing/suit/hastur)
 
@@ -26,31 +26,31 @@
 
 /datum/team/gang/max
 	name = "Max"
-	color = "#800000"
+	color = COLOR_RED
 	inner_outfits = list(/obj/item/clothing/under/color/maroon)
 	outer_outfits = list(/obj/item/clothing/suit/poncho/red)
 
 /datum/team/gang/blasto
 	name = "Blasto"
-	color = "#000080"
+	color = COLOR_NAVY
 	inner_outfits = list(/obj/item/clothing/under/suit_jacket/navy)
 	outer_outfits = list(/obj/item/clothing/suit/jacket/miljacket)
 
 /datum/team/gang/waffle
 	name = "Waffle"
-	color = "#808000" //shared color with cyber, but they can keep brown cause waffles.
+	color = COLOR_OLIVE //shared color with cyber, but they can keep brown cause waffles.
 	inner_outfits = list(/obj/item/clothing/under/suit_jacket/green)
 	outer_outfits = list(/obj/item/clothing/suit/poncho)
 
 /datum/team/gang/north
 	name = "North"
-	color = "#00FF00"
+	color = COLOR_GREEN
 	inner_outfits = list(/obj/item/clothing/under/color/green)
 	outer_outfits = list(/obj/item/clothing/suit/poncho/green)
 
 /datum/team/gang/omni
 	name = "Omni"
-	color = "#008080"
+	color = COLOR_TEAL
 	inner_outfits = list(/obj/item/clothing/under/color/teal)
 	outer_outfits = list(/obj/item/clothing/suit/studentuni)
 
@@ -68,13 +68,13 @@
 
 /datum/team/gang/donk
 	name = "Donk"
-	color = "#0000FF"
+	color = COLOR_BLUE
 	inner_outfits = list(/obj/item/clothing/under/color/darkblue)
 	outer_outfits = list(/obj/item/clothing/suit/apron/overalls)
 
 /datum/team/gang/gene
 	name = "Gene"
-	color = "#00FFFF"
+	color = COLOR_CYAN
 	inner_outfits = list(/obj/item/clothing/under/color/blue)
 	outer_outfits = list(/obj/item/clothing/suit/apron)
 
@@ -86,13 +86,13 @@
 
 /datum/team/gang/tunnel
 	name = "Tunnel"
-	color = "#FF00FF" //Gave the leather jacket to the tunnel gang over diablo.
+	color = COLOR_MAGENTA //Gave the leather jacket to the tunnel gang over diablo.
 	inner_outfits = list(/obj/item/clothing/under/villain)
 	outer_outfits = list(/obj/item/clothing/suit/jacket/leather)
 
 /datum/team/gang/diablo
 	name = "Diablo"
-	color = "#FF0000"   //literal early 90s skinhead regalia.
+	color = COLOR_RED   //literal early 90s skinhead regalia.
 	inner_outfits = list(/obj/item/clothing/under/pants/classicjeans)
 	outer_outfits = list(/obj/item/clothing/suit/suspenders)
 
@@ -110,13 +110,13 @@
 
 /datum/team/gang/sirius
 	name = "Sirius"
-	color = "#FFC0CB"
+	color = COLOR_PINK
 	inner_outfits = list(/obj/item/clothing/under/color/pink)
 	outer_outfits = list(/obj/item/clothing/suit/jacket/puffer/vest)
 
 /datum/team/gang/sleepingcarp
 	name = "Sleeping Carp"
-	color = "#800080"
+	color = COLOR_PURPLE
 	inner_outfits = list(/obj/item/clothing/under/color/lightpurple)
 	outer_outfits = list(/obj/item/clothing/suit/hooded/carp_costume)
 

--- a/modular_citadel/code/game/objects/items/melee/eutactic_blades.dm
+++ b/modular_citadel/code/game/objects/items/melee/eutactic_blades.dm
@@ -96,7 +96,7 @@
 	if(alert("Are you sure you want to recolor your blade?", "Confirm Repaint", "Yes", "No") == "Yes")
 		var/energy_color_input = input(usr,"","Choose Energy Color",light_color) as color|null
 		if(energy_color_input)
-			light_color = sanitize_hexcolor(energy_color_input, desired_format=6, include_crunch=1)
+			set_light_color(sanitize_hexcolor(energy_color_input, desired_format=6, include_crunch=1))
 		update_icon()
 		update_light()
 
@@ -205,7 +205,7 @@
 	if(alert("Are you sure you want to recolor your blade?", "Confirm Repaint", "Yes", "No") == "Yes")
 		var/energy_color_input = input(usr,"","Choose Energy Color",light_color) as color|null
 		if(energy_color_input)
-			light_color = sanitize_hexcolor(energy_color_input, desired_format=6, include_crunch=1)
+			set_light_color(sanitize_hexcolor(energy_color_input, desired_format=6, include_crunch=1))
 		update_icon()
 		update_light()
 
@@ -257,7 +257,7 @@
 	slowdown_wielded = 1
 	armour_penetration = 60
 	light_color = "#37FFF7"
-	rainbow_colors = list("#FF0000", "#FFFF00", "#00FF00", "#00FFFF", "#0000FF","#FF00FF", "#3399ff", "#ff9900", "#fb008b", "#9800ff", "#00ffa3", "#ccff00")
+	rainbow_colors = list(COLOR_RED, COLOR_YELLOW, COLOR_GREEN, COLOR_CYAN, COLOR_BLUE,COLOR_MAGENTA, "#3399ff", COLOR_ORANGE, "#fb008b", "#9800ff", "#00ffa3", "#ccff00")
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "destroyed", "ripped", "devastated", "shredded")
 	spinnable = FALSE
 	total_mass_on = 4
@@ -319,7 +319,7 @@
 		var/energy_color_input = input(usr,"","Choose Energy Color",light_color) as color|null
 		if(!energy_color_input || !user.canUseTopic(src, BE_CLOSE, FALSE) || hacked)
 			return
-		light_color = sanitize_hexcolor(energy_color_input, desired_format=6, include_crunch=1)
+		set_light_color(sanitize_hexcolor(energy_color_input, desired_format=6, include_crunch=1))
 		update_icon()
 		update_light()
 

--- a/modular_citadel/code/modules/awaymissions/citadel_ghostrole_spawners.dm
+++ b/modular_citadel/code/modules/awaymissions/citadel_ghostrole_spawners.dm
@@ -43,7 +43,7 @@
 	var/obj/item/card/id/knight/W = H.wear_id
 	W.assignment = "Knight"
 	W.registered_name = H.real_name
-	W.id_color = "#0000FF" //Regular knights get simple blue. Doesn't matter much because it's variable anyway
+	W.id_color = COLOR_BLUE //Regular knights get simple blue. Doesn't matter much because it's variable anyway
 	W.update_label(H.real_name)
 	W.update_icon()
 

--- a/modular_citadel/code/modules/projectiles/ammunition/caseless.dm
+++ b/modular_citadel/code/modules/projectiles/ammunition/caseless.dm
@@ -1,13 +1,13 @@
 /obj/item/ammo_casing/caseless/foam_dart/tag
 	name = "lastag foam dart"
 	desc = "Foam darts fitted with special lights. Compatible with existing laser tag systems. Ages 8 and up."
-	color = "#FF00FF"
+	color = COLOR_MAGENTA
 	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart/tag
 /obj/item/ammo_casing/caseless/foam_dart/tag/red
 	name = "lastag red foam dart"
-	color = "#FF0000"
+	color = COLOR_RED
 	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart/tag/red
 /obj/item/ammo_casing/caseless/foam_dart/tag/blue
 	name = "lastag blue foam dart"
-	color = "#0000FF"
+	color = COLOR_BLUE
 	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart/tag/blue

--- a/modular_citadel/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/modular_citadel/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -4,7 +4,7 @@
 	icon_state = "foambox"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/tag
 	max_ammo = 40
-	color = "#FF00FF"
+	color = COLOR_MAGENTA
 
 /obj/item/ammo_box/foambox/tag/red
 	name = "ammo box (Lastag Red Foam Darts)"
@@ -12,7 +12,7 @@
 	icon_state = "foambox"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/tag/red
 	max_ammo = 40
-	color = "#FF0000"
+	color = COLOR_RED
 
 /obj/item/ammo_box/foambox/tag/blue
 	name = "ammo box (Lastag Blue Foam Darts)"
@@ -20,4 +20,4 @@
 	icon_state = "foambox"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/tag/blue
 	max_ammo = 40
-	color = "#0000FF"
+	color = COLOR_BLUE

--- a/modular_citadel/code/modules/projectiles/guns/ballistic/magweapon.dm
+++ b/modular_citadel/code/modules/projectiles/guns/ballistic/magweapon.dm
@@ -50,7 +50,7 @@
 	light_range = 2
 	speed = 0.6
 	range = 25
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 
 /obj/item/projectile/bullet/nlmags //non-lethal boolets
 	icon = 'modular_citadel/icons/obj/guns/cit_guns.dmi'
@@ -204,7 +204,7 @@
 	light_range = 3
 	speed = 0.6
 	range = 35
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 
 /obj/item/projectile/bullet/nlmagrifle //non-lethal boolets
 	icon = 'modular_citadel/icons/obj/guns/cit_guns.dmi'
@@ -358,7 +358,7 @@
 	forcedodge = TRUE
 	range = 6
 	light_range = 1
-	light_color = LIGHT_COLOR_RED
+	light_color = COLOR_SOFT_RED
 
 /obj/item/projectile/bullet/mags/hyper/inferno
 	icon_state = "magjectile-large"

--- a/modular_citadel/code/modules/projectiles/projectiles/reusable.dm
+++ b/modular_citadel/code/modules/projectiles/projectiles/reusable.dm
@@ -12,11 +12,11 @@
 
 /obj/item/projectile/bullet/reusable/foam_dart/tag/red
 	name = "lastag red foam dart"
-	color = "#FF0000"
+	color = COLOR_RED
 	suit_types = list(/obj/item/clothing/suit/bluetag)
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/tag/red
 /obj/item/projectile/bullet/reusable/foam_dart/tag/blue
-	color = "#0000FF"
+	color = COLOR_BLUE
 	name = "lastag blue foam dart"
 	suit_types = list(/obj/item/clothing/suit/redtag)
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/tag/blue

--- a/modular_citadel/code/modules/vore/resizing/sizechemicals.dm
+++ b/modular_citadel/code/modules/vore/resizing/sizechemicals.dm
@@ -7,7 +7,7 @@
 	name = "Macrocillin"
 	description = "Glowing yellow liquid."
 	reagent_state = LIQUID
-	color = "#FFFF00" // rgb: 255, 255, 0
+	color = COLOR_YELLOW // rgb: 255, 255, 0
 	overdose_threshold = 20
 
 /datum/reagent/medicine/macrocillin/on_mob_life(mob/living/M, method=INGEST)
@@ -24,7 +24,7 @@
 	name = "Microcillin"
 	description = "Murky purple liquid."
 	reagent_state = LIQUID
-	color = "#800080"
+	color = COLOR_PURPLE
 	overdose_threshold = 20
 
 /datum/reagent/microcillin/on_mob_life(mob/living/M, method=INGEST)
@@ -42,7 +42,7 @@
 	name = "Normalcillin"
 	description = "Translucent cyan liquid."
 	reagent_state = LIQUID
-	color = "#00FFFF"
+	color = COLOR_CYAN
 	overdose_threshold = 20
 
 /datum/reagent/medicine/normalcillin/on_mob_life(mob/living/M, method=INGEST)


### PR DESCRIPTION
## About The Pull Request
Ports tgstation/tgstation#52574, defining and moving around color definitions, and adds new signals for when specific variables change for lights

atom/proc/set_light() is for setting any light variable, but sends a signal of light range, power, and color. This existed before.
atom/proc/set_light_range() is for sending a signal that light_range is about to change
atom/proc/set_light_power() is for sending a signal that light_power is about to change
atom/proc/set_light_color() is for sending a signal that light_color is about to change
set_light calls these before sending its own signal depending on what is about to change. If it's called with only light_range changing, it'll send the signal for the range changing, then the signal for all 3 variables changing
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sorts light colors into a single define file of colors for convenience, adds a few color defines, tidies up the file itself, and adds signals to lights on an atom changing. These signals aren't used at the moment, but the structure's there for future code

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Sorting color defines
code: New signals for lights
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
