### PR TITLE
Gives the chemistry subsystem a name

### DIFF
--- a/code/controllers/subsystem/processing/chemistry.dm
+++ b/code/controllers/subsystem/processing/chemistry.dm
@@ -1,5 +1,4 @@
 PROCESSING_SUBSYSTEM_DEF(chemistry)
+	name = "Chemistry"
 	wait = 5
 	flags = SS_KEEP_TIMING
-
-


### PR DESCRIPTION

## Changelog
:cl:
admin: the chemistry SS now has a name rather than looking like a duplicate of "Processing" in the MC tab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
