### PR TITLE
Change verbage of how the server notifies the client if their character is outdated

### DIFF
--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -52,4 +52,4 @@
 					S["new_differences_notification"] >> differing_version_notification
 					if(!differing_version_notification || differing_version_notification <= slot_version)
 						S["new_differences_notification"] << slot_version
-						to_chat(src, "<span class='danger'><B>There were recent changes with characters, and your savefiles are outdated.</B></span>")
+						to_chat(src, "<span class='danger'><B>There were recent changes with characters, and your savefiles are outdated. You are still able to play, but your characters may not look the same.</B></span>")

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -46,8 +46,9 @@
 			var/differing_version_notification = 0
 			if(slot)
 				S.cd = "/character[slot]"
-				var/slot_version = S["version"]
-				if(slot_version < SAVEFILE_VERSION_MAX)
+				var/slot_version = 0
+				S["version"] >> slot_version
+				if(slot_version && slot_version < SAVEFILE_VERSION_MAX)
 					S.cd = "/"
 					S["new_differences_notification"] >> differing_version_notification
 					if(!differing_version_notification || differing_version_notification <= slot_version)

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -43,7 +43,13 @@
 			S.cd = "/"
 			var/slot
 			S["default_slot"] >> slot
+			var/differing_version_notification = 0
 			if(slot)
 				S.cd = "/character[slot]"
-				if(S["version"] < SAVEFILE_VERSION_MAX)
-					to_chat(src, "<span class='redtext'>Your characters are outdated from recent updates. Please make sure if everything is within reasonable levels.</span>")
+				var/slot_version = S["version"]
+				if(slot_version < SAVEFILE_VERSION_MAX)
+					S.cd = "/"
+					S["new_differences_notification"] >> differing_version_notification
+					if(!differing_version_notification || differing_version_notification <= slot_version)
+						S["new_differences_notification"] << slot_version
+						to_chat(src, "<span class='danger'>There were recent changes with characters, and your savefiles are outdated.</span>")

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -52,4 +52,4 @@
 					S["new_differences_notification"] >> differing_version_notification
 					if(!differing_version_notification || differing_version_notification <= slot_version)
 						S["new_differences_notification"] << slot_version
-						to_chat(src, "<span class='danger'>There were recent changes with characters, and your savefiles are outdated.</span>")
+						to_chat(src, "<span class='danger'><B>There were recent changes with characters, and your savefiles are outdated.</B></span>")

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -52,4 +52,4 @@
 					S["new_differences_notification"] >> differing_version_notification
 					if(!differing_version_notification || differing_version_notification <= slot_version)
 						S["new_differences_notification"] << slot_version
-						to_chat(src, "<span class='danger'><B>There were recent changes with characters, and your savefiles are outdated. You are still able to play, but your characters may not look the same.</B></span>")
+						to_chat(src, "<span class='danger'><B>There were recent changes with characters, and your savefiles are outdated. Your characters may not look the same.</B></span>")

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -53,4 +53,4 @@
 					S["new_differences_notification"] >> differing_version_notification
 					if(!differing_version_notification || differing_version_notification <= slot_version)
 						S["new_differences_notification"] << slot_version
-						to_chat(src, "<span class='danger'><B>There were recent changes with characters, and your savefiles are outdated. Your characters may not look the same.</B></span>")
+						to_chat(src, "<span class='danger'><B>There were recent changes with characters, and your savefiles are outdated. Your characters may not look the same depending on what changed.</B></span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes how the notification for outdated characters is worded so it's more neutral. I don't like how I worded it where it says "you *should* do this".

Also changes so the message sends once to the client, rather than with each character file

## Changelog
:cl:
tweak: re-words the notification for outdated characters, and makes the message send only once
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
