### PR TITLE
The math behind a client's ping average was a bit wacked up

### DIFF
--- a/code/modules/client/verbs/ping.dm
+++ b/code/modules/client/verbs/ping.dm
@@ -6,7 +6,7 @@
 	if (!avgping)
 		avgping = ping
 	else
-		avgping = MC_AVERAGE_SLOW(avgping, ping)
+		avgping = (ping+avgping)/2
 
 /client/proc/pingfromtime(time)
 	return ((world.time+world.tick_lag*TICK_USAGE_REAL/100)-time)*100


### PR DESCRIPTION
I saved all of your lives

## Changelog
:cl:
fix: Ping should properly display, now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
