### PR TITLE
Fixes Client FPS not changing to the user's preference

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -277,7 +277,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 /datum/preferences/New(client/C)
 	parent = C
-	clientfps = world.fps*2
 	for(var/custom_name_id in GLOB.preferences_custom_names)
 		custom_names[custom_name_id] = get_default_name(custom_name_id)
 

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -57,7 +57,9 @@
 				var/datum/callback/CB = foo
 				CB.Invoke()
 
-	mind?.hide_ckey = client?.prefs?.hide_ckey
+		if(client.prefs)
+			mind?.hide_ckey = client.prefs.hide_ckey
+			client.fps = client.prefs.clientfps
 	log_message("Client [key_name(src)] has taken ownership of mob [src]([src.type])", LOG_OWNERSHIP)
 	SEND_SIGNAL(src, COMSIG_MOB_CLIENT_LOGIN, client)
 	client.init_verbs()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Client FPS changes when you actually set it while you're currently logged in. Reconnecting is also fine, because your "client" is still here, in the server.
However, when the server restarts and you're logging in for the first time, the FPS never sets, despite it being initialized in your preferences datum. This PR fixes that, everyone will now get that silky-smooth 60 FPS in the server


## Changelog
:cl:
fix: Changed the fps not setting right when a client joins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
