### PR TITLE
Hydroponics plants aren't tiny af when inside bags anymore (icky scaling) + adding storage enter/exit signals

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -705,6 +705,11 @@
 ///(obj/item/insertion_candidate, mob/user, silent) - returns bool
 #define COMSIG_TRY_STORAGE_CAN_INSERT "storage_can_equip"
 
+//from base of atom/movable/on_enter_storage(): (datum/component/storage/concrete/master_storage)
+#define COMSIG_STORAGE_ENTERED "storage_entered"
+//from base of atom/movable/on_exit_storage(): (datum/component/storage/concrete/master_storage)
+#define COMSIG_STORAGE_EXITED "storage_exited"
+
 // /datum/component/two_handed signals
 
 ///from base of datum/component/two_handed/proc/wield(mob/living/carbon/user): (/mob/user)

--- a/code/datums/elements/item_scaling.dm
+++ b/code/datums/elements/item_scaling.dm
@@ -1,0 +1,35 @@
+/**
+ * Element for making items change scaling depending on if they appear in the world or in a storage container.
+ * 
+ * For context, overworld items are anything on a turf, storage scaling includes anywhere that the item is used as a UI element.
+ * Scaling should affect the target's icon and any affecting overlays
+ */
+/datum/element/item_scaling
+	element_flags = ELEMENT_BESPOKE
+	id_arg_index = 2
+	/// Value to scale the target by when it's in the overworld (on a turf)
+	var/overworld_scaling = 1
+	/// Value to scale the target by when it's in a storage component or inventory slot
+	var/storage_scaling = 1
+
+/datum/element/item_scaling/Attach(datum/target, overworld_scaling = 1, storage_scaling = 1)
+	. = ..()
+	if(!isatom(target))
+		return ELEMENT_INCOMPATIBLE
+	
+	scale(target, overworld_scaling)
+
+	RegisterSignal(target, list(COMSIG_ITEM_DROPPED, COMSIG_STORAGE_EXITED), .proc/scale_overworld)
+	RegisterSignal(target, list(COMSIG_ITEM_EQUIPPED, COMSIG_STORAGE_ENTERED), .proc/scale_storage)
+
+/datum/element/item_scaling/proc/scale(atom/source, scaling)
+	var/matrix/M = matrix()
+	source.transform = M.Scale(scaling)
+
+/// Signal handler for when the item is dropped
+/datum/element/item_scaling/proc/scale_overworld(datum/source)
+	scale(source, overworld_scaling)
+
+/// Signal handler for when the item is picked up
+/datum/element/item_scaling/proc/scale_storage(datum/source)
+	scale(source, storage_scaling)

--- a/code/datums/elements/item_scaling.dm
+++ b/code/datums/elements/item_scaling.dm
@@ -16,6 +16,9 @@
 	. = ..()
 	if(!isatom(target))
 		return ELEMENT_INCOMPATIBLE
+
+	src.overworld_scaling = overworld_scaling
+	src.storage_scaling = storage_scaling
 	
 	scale(target, overworld_scaling)
 

--- a/code/datums/elements/item_scaling.dm
+++ b/code/datums/elements/item_scaling.dm
@@ -25,6 +25,7 @@
 	RegisterSignal(target, list(COMSIG_ITEM_DROPPED, COMSIG_STORAGE_EXITED), .proc/scale_overworld)
 	RegisterSignal(target, list(COMSIG_ITEM_EQUIPPED, COMSIG_STORAGE_ENTERED), .proc/scale_storage)
 
+//scale :)
 /datum/element/item_scaling/proc/scale(atom/source, scaling)
 	var/matrix/M = matrix()
 	source.transform = M.Scale(scaling)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -699,11 +699,11 @@
 
 // called when this atom is removed from a storage item, which is passed on as S. The loc variable is already set to the new destination before this is called.
 /atom/movable/proc/on_exit_storage(datum/component/storage/concrete/S)
-	return
+	SEND_SIGNAL(src, COMSIG_STORAGE_EXITED, S)
 
 // called when this atom is added into a storage item, which is passed on as S. The loc variable is already set to the storage item.
 /atom/movable/proc/on_enter_storage(datum/component/storage/concrete/S)
-	return
+	SEND_SIGNAL(src, COMSIG_STORAGE_ENTERED, S)
 
 /atom/movable/proc/get_spacemove_backup()
 	var/atom/movable/dense_object_backup

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -33,6 +33,9 @@
 		// This is for adminspawn or map-placed growns. They get the default stats of their seed type.
 		seed = new seed()
 		seed.adjust_potency(50-seed.potency)
+	else if(!seed)
+		stack_trace("Grown initialized without seed. Okay.")
+		return INITIALIZE_HINT_QDEL
 
 	pixel_x = rand(-5, 5)
 	pixel_y = rand(-5, 5)
@@ -40,13 +43,11 @@
 	if(dried_type == -1)
 		dried_type = src.type
 
-	if(seed)
-		for(var/datum/plant_gene/trait/T in seed.genes)
-			T.on_new(src, loc)
-		seed.prepare_result(src)
-		transform *= TRANSFORM_USING_VARIABLE(seed.potency, 100) + 0.5 //Makes the resulting produce's sprite larger or smaller based on potency!
-		add_juice()
-
+	for(var/datum/plant_gene/trait/T in seed.genes)
+		T.on_new(src, loc)
+	seed.prepare_result(src)
+	AddElement(/datum/element/item_scaling, TRANSFORM_USING_VARIABLE(seed.potency, 100) + 0.5, 1)	//Makes the resulting produce's sprite larger or smaller based on potency!
+	add_juice()
 
 
 /obj/item/reagent_containers/food/snacks/grown/proc/add_juice()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -493,6 +493,7 @@
 #include "code\datums\elements\earhealing.dm"
 #include "code\datums\elements\flavor_text.dm"
 #include "code\datums\elements\ghost_role_eligibility.dm"
+#include "code\datums\elements\item_scaling.dm"
 #include "code\datums\elements\mob_holder.dm"
 #include "code\datums\elements\squish.dm"
 #include "code\datums\elements\swimming.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Harvested hydroponics plants scale depending on potency, but they also scaled when inside a storage container. This wasn't a problem, it just didn't look nice. This makes them look nice inside storage containers :)

(secretly a dependency for porting over tgstation's mail)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Just a visual change, harvested hydroponics plants don't scale inside storages like bags anymore
code: Added item_scaling element
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
