### PR TITLE
Fixing Poss' Voidsuits

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -29,46 +29,6 @@
 	resistance_flags = NONE
 
 /*
- * Posshim's Corpus atire
- */
-/obj/item/clothing/suit/hooded/corpus/
-	name = "Standard Voidsuit"
-	desc = "Standard issue voidsuit in the name of Grofit!"
-	icon_state = "corpus"
-	item_state = "armor"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS|FEET|HANDS
-	hoodtype = /obj/item/clothing/head/hooded/corpus
-	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT //"Hide shoes" but digi shoes dont get hidden, too bad!
-	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
-	mutantrace_variation = NO_MUTANTRACE_VARIATION //There is no need for a digi variant, it's a costume
-
-/obj/item/clothing/suit/hooded/corpus/s //sec
-	name = "Enforcer Voidsuit"
-	desc = "Delux issue grofit voidsuit. Let the middle class know You're in charge."
-	icon_state = "corpuss"
-	hoodtype = /obj/item/clothing/head/hooded/corpus/s //Enjoy this nice red outfit Kinaris! There is NO NEED for a pink one! xoxo -VivI Fanteriso
-
-/obj/item/clothing/suit/hooded/corpus/c //command
-	name = "Commander Voidsuit"
-	desc = "Premium issue correctional worker attire. Grease the gears of production."
-	icon_state = "corpusc"
-	hoodtype = /obj/item/clothing/head/hooded/corpus/c
-
-/obj/item/clothing/head/hooded/corpus
-	name = "Voidsuit helmet"
-	desc = "galvanized reinforced helm to protect against the elements"
-	icon_state = "corpus"
-	body_parts_covered = HEAD
-	flags_inv = HIDEHAIR|HIDEEARS|HIDEFACIALHAIR|HIDEFACE|HIDEMASK|HIDESNOUT|HIDENECK //hide your ugly face with this one simple trick!
-	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
-
-/obj/item/clothing/head/hooded/corpus/s //sec
-	icon_state = "corpuss"
-
-/obj/item/clothing/head/hooded/corpus/c //command
-	icon_state = "corpusc"
-
-/*
  * Costume
  */
 /obj/item/clothing/suit/hooded/flashsuit

--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -8,8 +8,7 @@
 	vend_reply = "Thank you for using AutoDrobe!"
 	products = list(/obj/item/clothing/suit/chickensuit = 1,
 		            /obj/item/clothing/head/chicken = 1,
-					/obj/item/clothing/suit/hooded/corpus = 1,
-					/obj/item/clothing/suit/hooded/corpus/c = 1,
+					/obj/item/clothing/suit/hooded/wintercoat/corpus = 1,
 		            /obj/item/clothing/under/gladiator = 1,
 					/obj/item/clothing/head/helmet/gladiator = 1,
 					/obj/item/clothing/under/gimmick/rank/captain/suit = 1,
@@ -123,25 +122,26 @@
 		              /obj/item/clothing/glasses/sunglasses/blindfold = 1,
 		              /obj/item/clothing/mask/muzzle = 2)
 	premium = list(/obj/item/clothing/suit/pirate/captain = 2,
-		           /obj/item/clothing/head/pirate/captain = 2,
-		           /obj/item/clothing/head/helmet/roman/fake = 1,
-		           /obj/item/clothing/head/helmet/roman/legionnaire/fake = 1,
-		           /obj/item/clothing/under/roman = 1,
-		           /obj/item/clothing/shoes/roman = 1,
-		           /obj/item/shield/riot/roman/fake = 1,
-		           /obj/item/clothing/head/delinquent = 1, // One per vendor, please dear god don't mass produce these.
-		           /obj/item/skub = 1,
-		           /obj/item/clothing/under/lobster = 1,	 // CIT CHANGES
-		           /obj/item/clothing/head/lobsterhat = 1,
-		           /obj/item/clothing/head/drfreezehat = 1,
-		           /obj/item/clothing/suit/dracula = 1,
-		           /obj/item/clothing/suit/drfreeze_coat = 1,
-		           /obj/item/clothing/suit/gothcoat = 2,
-		           /obj/item/clothing/under/draculass = 1,
-                   /obj/item/clothing/under/drfreeze = 1,    //End of Cit Changes
+		        	/obj/item/clothing/head/pirate/captain = 2,
+		        	/obj/item/clothing/head/helmet/roman/fake = 1,
+		        	/obj/item/clothing/head/helmet/roman/legionnaire/fake = 1,
+		        	/obj/item/clothing/under/roman = 1,
+		        	/obj/item/clothing/shoes/roman = 1,
+		        	/obj/item/shield/riot/roman/fake = 1,
+		        	/obj/item/clothing/head/delinquent = 1, // One per vendor, please dear god don't mass produce these.
+		        	/obj/item/skub = 1,
+		        	/obj/item/clothing/under/lobster = 1,	 // CIT CHANGES
+		        	/obj/item/clothing/head/lobsterhat = 1,
+		        	/obj/item/clothing/head/drfreezehat = 1,
+		        	/obj/item/clothing/suit/dracula = 1,
+		        	/obj/item/clothing/suit/drfreeze_coat = 1,
+		        	/obj/item/clothing/suit/gothcoat = 2,
+		        	/obj/item/clothing/under/draculass = 1,
+                	/obj/item/clothing/under/drfreeze = 1,    //End of Cit Changes
 					/obj/item/clothing/under/wedding_dress = 1,
-				   /obj/item/clothing/under/tuxedo = 1,
-				   /obj/item/storage/belt/cummerbund = 1)
+					/obj/item/clothing/under/tuxedo = 1,
+					/obj/item/clothing/suit/hooded/wintercoat/corpus/command = 1,
+					/obj/item/storage/belt/cummerbund = 1)
 	refill_canister = /obj/item/vending_refill/autodrobe
 
 /obj/machinery/vending/autodrobe/all_access

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -19,7 +19,7 @@
 					/obj/item/clothing/under/rank/security/skirt = 5,
 					/obj/item/clothing/under/rank/security/grey = 5,
 					/obj/item/clothing/under/pants/khaki = 5,
-					/obj/item/clothing/suit/hooded/corpus/s = 5)
+					/obj/item/clothing/suit/hooded/wintercoat/corpus/sec = 5)
 	premium = list(/obj/item/clothing/under/rank/security/navyblue = 5,
 					/obj/item/clothing/suit/security/officer = 5,
 					/obj/item/clothing/head/beret/sec/navyofficer = 5,

--- a/hyperstation/code/modules/clothing/suits/misc.dm
+++ b/hyperstation/code/modules/clothing/suits/misc.dm
@@ -22,3 +22,42 @@
 	desc = "An open leather vest with battlescarred metal shoulderpads, discovered in a dimensional anomaly. Smells of gunpowder and plasma."
 	icon_state = "guncaster_alt"
 	item_state = "guncaster_alt"
+
+/*
+ * Posshim's Corpus atire
+ */
+ //Making this a subset of wintercoats/winterhoods since poss intends it to have wintercoat stats --Archie
+ 
+/obj/item/clothing/suit/hooded/wintercoat/corpus
+	name = "Standard Voidsuit"
+	desc = "Standard issue voidsuit in the name of Grofit!"
+	icon_state = "corpus"
+	item_state = "armor"
+	body_parts_covered = CHEST|GROIN|LEGS|ARMS|FEET|HANDS
+	hoodtype = /obj/item/clothing/head/hooded/winterhood/corpus
+	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT //"Hide shoes" but digi shoes dont get hidden, too bad!
+	mutantrace_variation = NO_MUTANTRACE_VARIATION //There is no need for a digi variant, it's a costume
+
+/obj/item/clothing/suit/hooded/wintercoat/corpus/sec
+	name = "Enforcer Voidsuit"
+	desc = "Delux issue grofit voidsuit. Let the middle class know You're in charge."
+	icon_state = "corpuss"
+	hoodtype = /obj/item/clothing/head/hooded/winterhood/corpus/sec //Enjoy this nice red outfit Kinaris! There is NO NEED for a pink one! xoxo -VivI Fanteriso
+
+/obj/item/clothing/suit/hooded/wintercoat/corpus/command
+	name = "Commander Voidsuit"
+	desc = "Premium issue correctional worker attire. Grease the gears of production."
+	icon_state = "corpusc"
+	hoodtype = /obj/item/clothing/head/hooded/winterhood/corpus/command
+
+/obj/item/clothing/head/hooded/winterhood/corpus
+	name = "Voidsuit helmet"
+	desc = "galvanized reinforced helm to protect against the elements"
+	icon_state = "corpus"
+	flags_inv = HIDEHAIR|HIDEEARS|HIDEFACIALHAIR|HIDEFACE|HIDEMASK|HIDESNOUT|HIDENECK //hide your ugly face with this one simple trick!
+
+/obj/item/clothing/head/hooded/winterhood/corpus/sec
+	icon_state = "corpuss"
+
+/obj/item/clothing/head/hooded/winterhood/corpus/command
+	icon_state = "corpusc"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so the costume corpus voidsuits are actually subsets of wintercoats, inheriting their properties and thus minimally insulating the user properly when the hood is deployed. 

Also shoves the costume to the misc.dm modular file and makes the command voidsuit costume a premium item instead of a normal one in the wardrobe.

## Why It's Good For The Game

fix gud

## Changelog
:cl:
fix: Voidsuits now minimally insulate you from the cold when you're outside, as they were supposed to.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
