### PR TITLE
UNUM cards fixed

### DIFF
--- a/code/modules/games/unum.dm
+++ b/code/modules/games/unum.dm
@@ -10,13 +10,27 @@
 //Populate the deck.
 /obj/item/toy/cards/deck/unum/populate_deck()
 	for(var/colour in list("Red","Yellow","Green","Blue"))
-		cards += "[colour] 0" //Uno, i mean, cough cough, Unum decks have only one colour of each 0, weird huh?
+		cards += new_card("[colour] 0") //Uno, i mean, cough cough, Unum decks have only one colour of each 0, weird huh?
 		for(var/k in 0 to 1) //two of each colour of number
-			cards += "[colour] skip"
-			cards += "[colour] reverse"
-			cards += "[colour] draw 2"
+			cards += new_card("[colour] skip")
+			cards += new_card("[colour] reverse")
+			cards += new_card("[colour] draw 2")
 			for(var/i in 1 to 9)
-				cards += "[colour] [i]"
+				cards += new_card("[colour] [i]")
 	for(var/k in 0 to 3) //4 wilds and draw 4s
-		cards += "Wildcard"
-		cards += "Draw 4"
+		cards += new_card("Wildcard")
+		cards += new_card("Draw 4")
+
+
+//
+// hyperstation edits below
+// -- sarcoph (july 2022)
+//
+
+/obj/item/toy/cards/deck/unum/proc/new_card(name)
+	return list(list(
+		"name" = name,
+		"icon_state" = name,
+		"rotation" = null,
+		"face_up" = null
+	))


### PR DESCRIPTION
the `populate_deck()` proc needed to be updated so all the cards are lists instead of just strings

## About The Pull Request

a few months ago i overhauled cards to use TGUI, and one of those changes converted the cards from strings to lists in the `populate_deck()` proc. cards that are still strings would thus completely break in the new card system; they would have incorrect names and `icon_state`s, and it would show incorrectly in the card "peek" menu. UNUM was one such deck, so i fixed it.

## Why It's Good For The Game

bugfix

## Changelog
:cl:
fix: UNUM card game properly uses new playing card format
/:cl: