### PR TITLE
pAI add

### DIFF
--- a/_maps/map_files/LayeniaStation/LayeniaStation.dmm
+++ b/_maps/map_files/LayeniaStation/LayeniaStation.dmm
@@ -24886,6 +24886,9 @@
 	name = "drain"
 	},
 /obj/structure/table,
+/obj/item/paicard{
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel{
 	dir = 8;
 	icon_state = "floor_trim"
@@ -88497,6 +88500,7 @@
 	name = "drain"
 	},
 /obj/structure/table,
+/obj/item/paicard,
 /turf/open/floor/plasteel{
 	dir = 4;
 	icon_state = "floor_trim"


### PR DESCRIPTION
## About The Pull Request

added two pAI cards to the crossroads section of the map to make it easier to advertise new pAI personalities without resorting to OOC

## Why It's Good For The Game

It is now easier to advertise new pAI personalities without resorting to OOC

## Changelog
:cl:
add: Added two pAI devices in the crossroad section of the map
/:cl: