### PR TITLE
Port: Citadel's Minimap Refresh (Multi-Z aware and pixel perfect)

### DIFF
--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -103,7 +103,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/maintenance
 	ambientsounds = MAINTENANCE
 	valid_territory = FALSE
-
+	minimap_color = "#454545"
 
 //Departments
 
@@ -255,6 +255,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 //Hallway
 
+/area/hallway
+	minimap_color = "#aaaaaa"
+
+/area/hallway/primary
+	name = "Primary Hallway"
+
 /area/hallway/primary/aft
 	name = "Aft Primary Hallway"
 	icon_state = "hallA"
@@ -302,6 +308,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/hallway/secondary/exit
 	name = "Escape Shuttle Hallway"
 	icon_state = "escape"
+	minimap_color = "#baa0a0"
 
 /area/hallway/secondary/exit/departure_lounge
 	name = "Departure Lounge"
@@ -310,6 +317,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/hallway/secondary/entry
 	name = "Arrival Shuttle Hallway"
 	icon_state = "entry"
+	minimap_color = "#a0a0ba"
 
 /area/hallway/secondary/service
 	name = "Service Hallway"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -73,6 +73,10 @@
 	/// Color on minimaps, if it's null (which is default) it makes one at random.
 	var/minimap_color
 
+	var/minimap_color2 // if this isn't null, then this will show as a checkerboard pattern mixed in with the above. works even if the above is null (for better or worse)
+
+	var/minimap_show_walls = TRUE
+
 /*Adding a wizard area teleport list because motherfucking lag -- Urist*/
 /*I am far too lazy to make it a proper list of areas so I'll just make it run the usual telepot routine at the start of the game*/
 GLOBAL_LIST_EMPTY(teleportlocs)

--- a/code/game/area/areas/ruins/_ruins.dm
+++ b/code/game/area/areas/ruins/_ruins.dm
@@ -7,7 +7,9 @@
 	hidden = TRUE
 	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
 	ambientsounds = RUINS
-
+	minimap_color = "#775940"
+	minimap_color2 = "#6b5d48"
+	minimap_show_walls = FALSE
 
 /area/ruin/unpowered
 	always_unpowered = FALSE

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -6,6 +6,8 @@
 	var/obj_flags = CAN_BE_HIT
 	var/set_obj_flags // ONLY FOR MAPPING: Sets flags from a string list, handled in Initialize. Usage: set_obj_flags = "EMAGGED;!CAN_BE_HIT" to set EMAGGED and clear CAN_BE_HIT.
 
+	var/minimap_override_color // allows this obj to set its own color on the minimap
+
 	var/damtype = BRUTE
 	var/force = 0
 

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -6,6 +6,7 @@
 	desc = "A solar panel. Generates electricity when in contact with sunlight."
 	icon = 'goon/icons/obj/power.dmi'
 	icon_state = "sp_base"
+	minimap_override_color = "#02026a"
 	density = TRUE
 	use_power = NO_POWER_USE
 	idle_power_usage = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports: https://github.com/Citadel-Station-13/Citadel-Station-13/pull/15664

**However, like Bhijn & Myr I have banged my head against this for a while trying to get it to display the areas for multi-z properly instead of displaying a broken name and I could not. If you're willing to give it a try, please do.**

> This PR focuses specifically on the station minimap (available in the OOC tab!). This improves it in a variety of ways! It now scales pixel-perfectly (it was kinda blurry and inconsistent before), the JS no longer errors when you mouse over it, the map now outlines more than just windows and grilles, it now features (somewhat limited) support for multi-z, ruins are now somewhat obfuscated, and some areas have been given nicer colors!

> Or to put it in simpler terms, here's a before and after:

>BEFORE:
![image](https://user-images.githubusercontent.com/53913550/189175114-c5f844a1-6bb7-4f70-b362-ddfbdb0a78c1.png)

>AFTER:
![image](https://user-images.githubusercontent.com/53913550/189175139-d1cf2511-33b2-454b-be05-ef54dc2c4536.png)

>To elaborate a little further on the multi-z support: I was unable to get the status display and tooltips fully working when multiple images are present. It took 7 hours of me banging my head against the wall until I eventually just gave up, and made the status display simply not be present if the minimap is multiz.

## Changelog
🆑 Bhijn & Myr
add: The station minimap now features higher detail! Instead of just windows and grilles being outlined, all dense+anchored structures and machinery are shown on the minimap.
add: The station minimap now supports obfuscating entire areas, via the minimap_show_walls var.
add: The station minimap now supports defining two area colors, allowing for a checkerboard pattern!
tweak: Hallways and maint have been given white and gray colors, respectively, for ease of readability.
tweak: Ruins are now obfuscated on the minimap, and have been given a subtle, yet distinct, color pattern!
fix: The station minimap no longer errors when you mouse over it
add: The station minimap now supports multiz! (However, due to bugginess, multiz minimaps won't display area tooltips.)
tweak: The station minimap now features pixel-perfect scaling.
code: The station minimap can now support managing data for up to 16,581,374 areas without any conflicts at all! Before, BYOND's psuedorandom RNG meant that it was somewhat common for areas to collide with each others' data.
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
