### PR TITLE
Railings fix v2, electric boogaloo

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -6,6 +6,8 @@
 	var/climb_time = 20
 	var/climb_stun = 20
 	var/climbable = FALSE
+	var/rail_climbing = FALSE
+	var/passable = FALSE
 	var/mob/living/structureclimber
 	var/broken = 0 //similar to machinery's stat BROKEN
 
@@ -58,14 +60,30 @@
 
 /obj/structure/proc/do_climb(atom/movable/A)
 	if(climbable)
-		density = FALSE
-		. = step(A,get_dir(A,src.loc))
-		density = TRUE
+		if(rail_climbing == FALSE)
+			density = FALSE
+			. = step(A,get_dir(A,src.loc))
+			density = TRUE
+		else
+			//We're dealing with something like a railing with similar collision to glass and a false density.
+			passable = TRUE //Passable flag overrites CheckExit and CanPass procs to return true.
+
+			if(A.loc == src.loc)
+				//Step one further than just onto the object, we want to step over it to the next tile if possible.
+				. = step(A, get_dir(A, get_step(src, src.dir)))
+			else
+				. = step(A,get_dir(A,src.loc))
+			passable = FALSE
+			A.do_twist(targetangle = 45, timer = 8)
 
 /obj/structure/proc/climb_structure(mob/living/user)
 	src.add_fingerprint(user)
-	user.visible_message("<span class='warning'>[user] starts climbing onto [src].</span>", \
+	if(rail_climbing == FALSE)
+		user.visible_message("<span class='warning'>[user] starts climbing onto [src].</span>", \
 								"<span class='notice'>You start climbing onto [src]...</span>")
+	else
+		user.visible_message("<span class='warning'>[user] starts climbing over [src].</span>", \
+								"<span class='notice'>You start climbing over [src]...</span>")
 	var/adjusted_climb_time = climb_time
 	if(user.restrained()) //climbing takes twice as long when restrained.
 		adjusted_climb_time *= 2
@@ -77,14 +95,22 @@
 	if(do_mob(user, user, adjusted_climb_time))
 		if(src.loc) //Checking if structure has been destroyed
 			if(do_climb(user))
-				user.visible_message("<span class='warning'>[user] climbs onto [src].</span>", \
-									"<span class='notice'>You climb onto [src].</span>")
-				log_combat(user, src, "climbed onto")
+				if(rail_climbing == FALSE)
+					user.visible_message("<span class='warning'>[user] climbs onto [src].</span>", \
+										"<span class='notice'>You climb onto [src].</span>")
+					log_combat(user, src, "climbed onto")
+				else
+					user.visible_message("<span class='warning'>[user] climbs over [src].</span>", \
+										"<span class='notice'>You climb over [src].</span>")
+					log_combat(user, src, "climbed over")
 				if(climb_stun)
 					user.Stun(climb_stun)
 				. = 1
 			else
-				to_chat(user, "<span class='warning'>You fail to climb onto [src].</span>")
+				if(rail_climbing == FALSE)
+					to_chat(user, "<span class='warning'>You fail to climb onto [src].</span>")
+				else
+					to_chat(user, "<span class='warning'>You fail to climb over [src].</span>")
 	structureclimber = null
 
 /obj/structure/examine(mob/user)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -84,6 +84,17 @@
 	else
 		user.visible_message("<span class='warning'>[user] starts climbing over [src].</span>", \
 								"<span class='notice'>You start climbing over [src]...</span>")
+
+		var/obj/structure/railing/target = src
+
+		if(target.shock(user, 100))
+			return
+
+		// Ensures player is in the proper place for climbing.
+		if(user.loc != src.loc)
+			if(user.loc == (get_step(src, get_dir(src.loc, user))))
+				step(user, get_dir(user.loc,src.loc))
+
 	var/adjusted_climb_time = climb_time
 	if(user.restrained()) //climbing takes twice as long when restrained.
 		adjusted_climb_time *= 2

--- a/hyperstation/code/game/objects/structures/railings.dm
+++ b/hyperstation/code/game/objects/structures/railings.dm
@@ -237,6 +237,9 @@
 /obj/structure/railing/attack_paw(mob/user)
 	return attack_hand(user)
 
+/obj/structure/grille/hulk_damage()
+	return 60
+
 /obj/structure/railing/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
 	if(isobj(AM))
 		if(prob(50) && anchored && !broken)

--- a/hyperstation/code/game/objects/structures/railings.dm
+++ b/hyperstation/code/game/objects/structures/railings.dm
@@ -234,27 +234,36 @@
 	else if(istype(W, /obj/item/shard) || !shock(user, 70))
 		return ..()
 
-/obj/structure/grille/attack_paw(mob/user)
+/obj/structure/railing/attack_paw(mob/user)
 	return attack_hand(user)
 
-/obj/structure/grille/hulk_damage()
-	return 60
+/obj/structure/railing/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
+	if(isobj(AM))
+		if(prob(50) && anchored && !broken)
+			var/obj/O = AM
+			if(O.throwforce != 0 && O.damtype != STAMINA)//don't want to let people spam tesla bolts, this way it will break after time
+				var/turf/T = get_turf(src)
+				var/obj/structure/cable/C = T.get_cable_node()
+				if(C)
+					playsound(src, 'sound/magic/lightningshock.ogg', 100, 1, extrarange = 5)
+					tesla_zap(src, 3, C.newavail() * 0.01, TESLA_MOB_DAMAGE | TESLA_OBJ_DAMAGE | TESLA_MOB_STUN | TESLA_ALLOW_DUPLICATES) //Zap for 1/100 of the amount of power. At a million watts in the grid, it will be as powerful as a tesla revolver shot.
+					C.add_delayedload(C.newavail() * 0.0375) // you can gain up to 3.5 via the 4x upgrades power is halved by the pole so thats 2x then 1X then .5X for 3.5x the 3 bounces shock.
+	return ..()
 
-/obj/structure/grille/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
+/obj/structure/railing/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
 	if(user.a_intent == INTENT_HARM)
 		if(!shock(user, 70))
 			..(user, 1)
 		return TRUE
 
-/obj/structure/grille/attack_hand(mob/living/user)
+/obj/structure/railing/attack_hand(mob/living/user)
 	. = ..()
 	if(.)
 		return
 	if(!shock(user, 70))
 		user.visible_message("<span class='warning'>[user] gets shocked by [src]!</span>", null, null, COMBAT_MESSAGE_RANGE)
-		take_damage(rand(5,10), BRUTE, "melee", 1)
 
-/obj/structure/grille/attack_alien(mob/living/user)
+/obj/structure/railing/attack_alien(mob/living/user)
 	user.do_attack_animation(src)
 	user.changeNext_move(CLICK_CD_MELEE)
 	user.visible_message("<span class='warning'>[user] mangles [src].</span>", null, null, COMBAT_MESSAGE_RANGE)

--- a/hyperstation/code/game/objects/structures/railings.dm
+++ b/hyperstation/code/game/objects/structures/railings.dm
@@ -10,6 +10,10 @@
 	flags_1 = CONDUCT_1
 
 	density = FALSE
+	climbable = TRUE
+	rail_climbing = TRUE
+	climb_time = 15
+	//var/passable = FALSE // Equivalent of density check for other structures like tables, has to be different due to different collision
 	layer = 4
 	anchored = TRUE
 	flags_1 = ON_BORDER_1
@@ -63,6 +67,9 @@
 
 /obj/structure/railing/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && (mover.pass_flags & PASSGLASS) || is_type_in_typecache(mover, freepass))
+		return 1
+
+	if(passable)
 		return 1
 
 	if(get_dir(loc, target) != dir)
@@ -203,7 +210,6 @@
 		if(RCD_DECONSTRUCT)
 			to_chat(user, "<span class='notice'>You deconstruct the [src].</span>")
 			qdel(src)
-			NeighborsCheck()
 			return TRUE
 	return FALSE
 
@@ -306,32 +312,6 @@
 		else
 			return FALSE
 	return FALSE
-
-/obj/structure/railing/MouseDrop_T(mob/living/M, mob/living/user)
-	if(!istype(user))
-		return
-	if(!isliving(user))
-		return
-
-	//Sanity check so players can't climb over railings into occupied spaces.
-	var/turf/T = get_step(src, src.dir)
-	if(CanPass(user, T) == 0)
-		return FALSE
-
-	usr.visible_message("<span class='warning'>[user] starts climbing onto \the [src]!</span>")
-
-	if(!do_after(user, 15, src))
-		return
-
-	if(get_turf(user) == get_turf(src))
-		usr.dir = get_dir(usr.loc, get_step(src, src.dir))//turn and face railing
-		usr.forceMove(T)
-	else
-		usr.dir = get_dir(usr.loc, loc)//turn and face railing
-		usr.forceMove(get_turf(src))
-
-	usr.visible_message("<span class='warning'>[user] climbed over \the [src]!</span>")
-	usr.do_twist(targetangle = 45, timer = 8)
 
 /obj/structure/railing/proc/can_be_rotated(mob/user,rotation_type)
 	if(anchored)


### PR DESCRIPTION
## About The Pull Request
Fixes the ability to climb railings by removing the forcemove call that teleports players and instead refactoring the do_climb and climb_structure procedures in structure code itself.
Uses a similar method to tables of briefly turning collision off for the railing when the object is climbed in order to let players climb it, without moving the player into otherwise occupied space.

## Why It's Good For The Game

Fixes something previous updates broke, adds a progress bar to climbing over rails, as with climbing over tables or fences.

## Changelog
:cl:Haha26
add: adds arcing of electricity when an electrified rail is hit with something, the same as how grilles do.
fix: fixed the ability to climb over rails
refactor: refactored climbing over railings to instead rely on the do_climb and climb_structure procedures already present in structure code, which adds a progress meter and keeps in place sanity checks for other objects colliding.
/:cl: