### PR TITLE
Balance damage, Random teleportation, Polish

### DIFF
--- a/_maps/map_files/LayeniaStation/LayeniaStation.dmm
+++ b/_maps/map_files/LayeniaStation/LayeniaStation.dmm
@@ -59843,6 +59843,7 @@
 	name = "Atmospherics External Access";
 	req_access_txt = "24"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/maintenance/theatre)
 "jnp" = (
@@ -101629,17 +101630,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main/upper)
-"ptb" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/delivery,
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkfull_whole_alt"
-	},
-/area/hallway/secondary/entry/upper)
 "ptc" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -144841,6 +144831,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel/dark{
 	icon_state = "darkfull_whole_alt"
 	},

--- a/_maps/map_files/LayeniaStation/LayeniaStation.dmm
+++ b/_maps/map_files/LayeniaStation/LayeniaStation.dmm
@@ -2941,6 +2941,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "aiI" = (
@@ -10940,6 +10941,10 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/mopbucket,
 /obj/item/mop,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 16
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/tether)
 "bxV" = (
@@ -91827,6 +91832,16 @@
 "ofn" = (
 /turf/closed/wall,
 /area/storage/D)
+"ofu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	name = "air supply pipe"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/power/grounding_rod{
+	anchored = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/tether)
 "ofE" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/stripes/line{
@@ -101614,6 +101629,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main/upper)
+"ptb" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/delivery,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/dark{
+	icon_state = "darkfull_whole_alt"
+	},
+/area/hallway/secondary/entry/upper)
 "ptc" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -109064,12 +109090,6 @@
 	name = "tile"
 	},
 /area/hallway/primary/aft)
-"qwN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	name = "air vent"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/tether)
 "qwP" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/auxiliary";
@@ -129701,12 +129721,12 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "tlH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8;
 	name = "air supply pipe"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/loading_area{
 	dir = 5;
@@ -141056,13 +141076,9 @@
 /turf/closed/wall,
 /area/medical/genetics)
 "uPI" = (
-/obj/machinery/power/grounding_rod{
-	anchored = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	name = "air vent"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	name = "air supply pipe"
-	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/tether)
 "uPP" = (
@@ -153544,6 +153560,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating/layenia,
 /area/maintenance/department/engine/upper)
 "wAM" = (
@@ -208014,8 +208031,8 @@ wWR
 woc
 txg
 pLi
-qwN
 uPI
+ofu
 xqo
 woc
 qMc
@@ -252280,7 +252297,7 @@ vka
 vka
 vka
 prt
-dvT
+ptb
 rFp
 vKI
 tGx

--- a/_maps/map_files/LayeniaStation/LayeniaStation.dmm
+++ b/_maps/map_files/LayeniaStation/LayeniaStation.dmm
@@ -2941,7 +2941,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "aiI" = (
@@ -7020,8 +7019,8 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "aRt" = (
-/obj/machinery/power/grounding_rod{
-	anchored = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	name = "air scrubber"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/tether)
@@ -10933,15 +10932,11 @@
 /turf/open/floor/plating/layenia,
 /area/layenia/cloudlayer)
 "bxU" = (
-/obj/machinery/light{
-	dir = 1;
-	pixel_y = 16
-	},
-/obj/machinery/power/grounding_rod{
-	anchored = 1
-	},
-/obj/machinery/power/grounding_rod{
-	anchored = 1
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "half_stairs_darkfull";
+	name = "dark steps"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/tether)
@@ -19216,6 +19211,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4;
 	name = "scrubbers pipe"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 5;
+	icon_state = "steel_panel";
+	name = "steel pannel"
 	},
 /turf/open/floor/plasteel/dark{
 	icon_state = "darkfull_plate"
@@ -42989,8 +42989,7 @@
 	},
 /area/chapel/main)
 "gQR" = (
-/obj/machinery/safety_tether,
-/turf/open/floor/engine,
+/turf/open/floor/carpet/kinaris,
 /area/engine/tether)
 "gQT" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -58849,7 +58848,13 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "jgm" = (
-/turf/open/floor/engine,
+/obj/structure/railing/handrail,
+/obj/effect/turf_decal/loading_area{
+	dir = 10;
+	icon_state = "steel_panel";
+	name = "steel pannel"
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/tether)
 "jgz" = (
 /obj/structure/cable{
@@ -59817,7 +59822,6 @@
 	name = "Atmospherics External Access";
 	req_access_txt = "24"
 	},
-/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/maintenance/theatre)
 "jnp" = (
@@ -62508,7 +62512,6 @@
 	dir = 10;
 	name = "air supply pipe"
 	},
-/obj/item/paper/fluff/safety_tether,
 /turf/open/floor/plasteel/dark{
 	dir = 1;
 	icon_state = "darkfull_plate"
@@ -72108,9 +72111,13 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat_interior)
 "lgU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	name = "air scrubber"
+/obj/machinery/power/grounding_rod{
+	anchored = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	name = "scrubbers pipe"
+	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/tether)
 "lgW" = (
@@ -80162,6 +80169,11 @@
 /obj/effect/turf_decal/arrows,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port/fore)
+"mwH" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/fulltile,
+/turf/open/floor/plating,
+/area/engine/tether)
 "mwM" = (
 /obj/structure/flora/crystal/small/pile{
 	icon_state = "crystals4"
@@ -87827,6 +87839,10 @@
 	},
 /turf/open/floor/plasteel/layenia,
 /area/layenia)
+"nAF" = (
+/obj/item/paper/fluff/safety_tether,
+/turf/open/floor/carpet/kinaris,
+/area/engine/tether)
 "nAJ" = (
 /obj/machinery/light{
 	dir = 8;
@@ -91780,17 +91796,6 @@
 "ofn" = (
 /turf/closed/wall,
 /area/storage/D)
-"ofu" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/delivery,
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkfull_whole_alt"
-	},
-/area/hallway/secondary/entry/upper)
 "ofE" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/stripes/line{
@@ -100338,10 +100343,6 @@
 	},
 /turf/open/floor/plating/layenia,
 /area/layenia/cloudlayer)
-"pkn" = (
-/obj/item/paper/fluff/safety_tether,
-/turf/open/floor/plasteel/dark,
-/area/engine/tether)
 "pko" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8;
@@ -101582,6 +101583,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main/upper)
+"ptb" = (
+/obj/machinery/safety_tether,
+/turf/open/floor/carpet/kinaris,
+/area/engine/tether)
 "ptc" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -103854,6 +103859,12 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/turf_decal/loading_area{
+	dir = 5;
+	icon_state = "steel_panel";
+	name = "steel pannel"
+	},
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark{
 	icon_state = "darkfull_trim"
 	},
@@ -104159,6 +104170,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig/upper)
 "pLi" = (
+/obj/machinery/power/grounding_rod{
+	anchored = 1
+	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/tether)
 "pLj" = (
@@ -109018,6 +109033,12 @@
 	name = "tile"
 	},
 /area/hallway/primary/aft)
+"qwN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	name = "air vent"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/tether)
 "qwP" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/auxiliary";
@@ -129644,12 +129665,17 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "tlH" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8;
 	name = "air supply pipe"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/loading_area{
+	dir = 5;
+	icon_state = "steel_panel";
+	name = "steel pannel"
 	},
 /turf/open/floor/plasteel/dark{
 	icon_state = "darkfull_plate"
@@ -131230,8 +131256,10 @@
 	dir = 1;
 	pixel_y = 16
 	},
-/obj/machinery/power/grounding_rod{
-	anchored = 1
+/obj/effect/turf_decal/loading_area{
+	dir = 4;
+	icon_state = "half_stairs_darkfull";
+	name = "dark steps"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/tether)
@@ -140981,9 +141009,13 @@
 /turf/closed/wall,
 /area/medical/genetics)
 "uPI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	name = "air vent"
+/obj/machinery/power/grounding_rod{
+	anchored = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	name = "air supply pipe"
+	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/tether)
 "uPP" = (
@@ -144746,7 +144778,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/structure/fans/tiny,
 /turf/open/floor/plasteel/dark{
 	icon_state = "darkfull_whole_alt"
 	},
@@ -153466,7 +153497,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/structure/fans/tiny,
 /turf/open/floor/plating/layenia,
 /area/maintenance/department/engine/upper)
 "wAM" = (
@@ -158924,10 +158954,6 @@
 /obj/machinery/light{
 	pixel_y = -1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 9;
-	name = "air supply pipe"
-	},
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/engine/tether";
 	dir = 4;
@@ -158936,6 +158962,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9;
+	name = "air supply pipe"
 	},
 /turf/open/floor/plasteel/dark{
 	icon_state = "darkfull_plate"
@@ -206646,9 +206676,9 @@ ykt
 wWR
 woc
 woc
-woc
-woc
-woc
+mwH
+mwH
+mwH
 woc
 woc
 wAU
@@ -207158,11 +207188,11 @@ ejD
 xdO
 ykt
 wWR
-woc
+mwH
 jgm
-jgm
-jgm
-pkn
+gQR
+gQR
+nAF
 cZp
 woc
 tgZ
@@ -207415,11 +207445,11 @@ ejD
 xdO
 ykt
 wWR
-woc
+mwH
 jgm
 gQR
-jgm
-pLi
+ptb
+gQR
 pIP
 vct
 fJb
@@ -207672,11 +207702,11 @@ ejD
 xdO
 ykt
 wWR
-woc
+mwH
 jgm
-jgm
-jgm
-pLi
+gQR
+gQR
+gQR
 tlH
 woc
 jJn
@@ -207932,7 +207962,7 @@ wWR
 woc
 txg
 pLi
-aRt
+qwN
 uPI
 xqo
 woc
@@ -252198,7 +252228,7 @@ vka
 vka
 vka
 prt
-ofu
+dvT
 rFp
 vKI
 tGx

--- a/_maps/map_files/LayeniaStation/LayeniaStation.dmm
+++ b/_maps/map_files/LayeniaStation/LayeniaStation.dmm
@@ -10932,12 +10932,14 @@
 /turf/open/floor/plating/layenia,
 /area/layenia/cloudlayer)
 "bxU" = (
-/obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/loading_area{
-	dir = 8;
-	icon_state = "half_stairs_darkfull";
-	name = "dark steps"
+	dir = 4;
+	icon_state = "ledge_short";
+	name = "short ledge"
 	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/mopbucket,
+/obj/item/mop,
 /turf/open/floor/plasteel/dark,
 /area/engine/tether)
 "bxV" = (
@@ -19211,6 +19213,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4;
 	name = "scrubbers pipe"
+	},
+/obj/structure/railing/handrail{
+	dir = 1;
+	pixel_y = 13
 	},
 /obj/effect/turf_decal/loading_area{
 	dir = 5;
@@ -58848,11 +58854,15 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "jgm" = (
-/obj/structure/railing/handrail,
 /obj/effect/turf_decal/loading_area{
 	dir = 10;
 	icon_state = "steel_panel";
 	name = "steel pannel"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4;
+	icon_state = "ledge_short";
+	name = "short ledge"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/tether)
@@ -89671,6 +89681,18 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/crew_quarters/kitchen)
+"nPr" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 10;
+	icon_state = "steel_panel";
+	name = "steel pannel"
+	},
+/obj/effect/turf_decal/loading_area{
+	icon_state = "ledge_short";
+	name = "short ledge"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/tether)
 "nPL" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4;
@@ -103865,6 +103887,10 @@
 	name = "steel pannel"
 	},
 /obj/effect/turf_decal/caution/stand_clear,
+/obj/structure/railing/handrail{
+	dir = 1;
+	pixel_y = 13
+	},
 /turf/open/floor/plasteel/dark{
 	icon_state = "darkfull_trim"
 	},
@@ -112544,6 +112570,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5;
 	name = "scrubbers pipe"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "half_stairs_darkfull";
+	name = "dark steps";
+	pixel_y = 16
 	},
 /turf/open/floor/plasteel/dark{
 	icon_state = "darkfull_plate"
@@ -129677,6 +129709,10 @@
 	icon_state = "steel_panel";
 	name = "steel pannel"
 	},
+/obj/structure/railing/handrail{
+	dir = 1;
+	pixel_y = 13
+	},
 /turf/open/floor/plasteel/dark{
 	icon_state = "darkfull_plate"
 	},
@@ -131257,9 +131293,12 @@
 	pixel_y = 16
 	},
 /obj/effect/turf_decal/loading_area{
-	dir = 4;
-	icon_state = "half_stairs_darkfull";
-	name = "dark steps"
+	icon_state = "ledge_short";
+	name = "short ledge"
+	},
+/obj/effect/turf_decal/loading_area{
+	icon_state = "steel_decals_central6";
+	name = "maintenance hatch"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/tether)
@@ -158966,6 +159005,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 9;
 	name = "air supply pipe"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "half_stairs_darkfull";
+	name = "dark steps";
+	pixel_y = 16
 	},
 /turf/open/floor/plasteel/dark{
 	icon_state = "darkfull_plate"
@@ -207446,7 +207491,7 @@ xdO
 ykt
 wWR
 mwH
-jgm
+nPr
 gQR
 ptb
 gQR

--- a/_maps/map_files/LayeniaStation/LayeniaStation.dmm
+++ b/_maps/map_files/LayeniaStation/LayeniaStation.dmm
@@ -19223,6 +19223,12 @@
 	icon_state = "steel_panel";
 	name = "steel pannel"
 	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "steel_panel";
+	name = "steel pannel"
+	},
+/obj/item/paper/fluff/safety_tether,
 /turf/open/floor/plasteel/dark{
 	icon_state = "darkfull_plate"
 	},
@@ -87850,7 +87856,10 @@
 /turf/open/floor/plasteel/layenia,
 /area/layenia)
 "nAF" = (
-/obj/item/paper/fluff/safety_tether,
+/obj/machinery/safety_tether{
+	pixel_x = 0;
+	pixel_y = 0
+	},
 /turf/open/floor/carpet/kinaris,
 /area/engine/tether)
 "nAJ" = (
@@ -101605,10 +101614,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main/upper)
-"ptb" = (
-/obj/machinery/safety_tether,
-/turf/open/floor/carpet/kinaris,
-/area/engine/tether)
 "ptc" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -112572,10 +112577,9 @@
 	name = "scrubbers pipe"
 	},
 /obj/effect/turf_decal/loading_area{
-	dir = 1;
+	dir = 8;
 	icon_state = "half_stairs_darkfull";
-	name = "dark steps";
-	pixel_y = 16
+	name = "dark steps"
 	},
 /turf/open/floor/plasteel/dark{
 	icon_state = "darkfull_plate"
@@ -129712,6 +129716,10 @@
 /obj/structure/railing/handrail{
 	dir = 1;
 	pixel_y = 13
+	},
+/obj/effect/turf_decal/loading_area{
+	icon_state = "steel_panel";
+	name = "steel pannel"
 	},
 /turf/open/floor/plasteel/dark{
 	icon_state = "darkfull_plate"
@@ -159007,10 +159015,9 @@
 	name = "air supply pipe"
 	},
 /obj/effect/turf_decal/loading_area{
-	dir = 1;
+	dir = 4;
 	icon_state = "half_stairs_darkfull";
-	name = "dark steps";
-	pixel_y = 16
+	name = "dark steps"
 	},
 /turf/open/floor/plasteel/dark{
 	icon_state = "darkfull_plate"
@@ -207493,7 +207500,7 @@ wWR
 mwH
 nPr
 gQR
-ptb
+gQR
 gQR
 pIP
 vct

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -123,8 +123,6 @@
 			var/mob/living/L = AM
 			//L.notransform = TRUE
 			L.Stun(200)
-			//if(!issilicon(AM))
-				//L.resting = TRUE
 			if(L.client && check_rights_for(L.client, R_FUN))
 				playsound(AM, pick('hyperstation/sound/misc/yodadeath.ogg', 'hyperstation/sound/misc/fallingthroughclouds.ogg', 'hyperstation/sound/misc/goofy.ogg', 'hyperstation/sound/misc/wilhelm.ogg'), 100, 0)
 

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -131,8 +131,8 @@
 			else if(prob(5))
 				playsound(AM, pick('hyperstation/sound/misc/yodadeath.ogg', 'hyperstation/sound/misc/fallingthroughclouds.ogg', 'hyperstation/sound/misc/goofy.ogg', 'hyperstation/sound/misc/wilhelm.ogg'), 100, 0)
 
-
-		if(linked_turf.name == "clouds" && (iscyborg(AM) || iscarbon(AM)))
+		//Mob types that could be protected by a tether
+		if(iscyborg(AM) || iscarbon(AM))
 			var/mob/living/victim = AM
 
 			var/tether_number = GLOB.safety_tethers_list.len
@@ -142,12 +142,12 @@
 				if(tether_number == 1)
 
 					// If teleportation fails
-					if(!GLOB.safety_tethers_list[1].bungee_teleport(victim))
+					if(!GLOB.safety_tethers_list[1].bungee_teleport(victim, linked_turf))
 						finishdrop(AM)
 				else
 
 					//Just in case multiple safety tethers are present
-					if(!GLOB.safety_tethers_list[rand(1,GLOB.safety_tethers_list.len)].bungee_teleport(victim))
+					if(!GLOB.safety_tethers_list[rand(1,GLOB.safety_tethers_list.len)].bungee_teleport(victim, linked_turf))
 						finishdrop(AM)
 				if(isliving(AM))
 					var/mob/living/L = AM

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -121,15 +121,33 @@
 
 		if (isliving(AM))
 			var/mob/living/L = AM
-			L.notransform = TRUE
+			//L.notransform = TRUE
 			L.Stun(200)
-			if(!issilicon(AM))
-				L.resting = TRUE
+			//if(!issilicon(AM))
+				//L.resting = TRUE
 			if(L.client && check_rights_for(L.client, R_FUN))
 				playsound(AM, pick('hyperstation/sound/misc/yodadeath.ogg', 'hyperstation/sound/misc/fallingthroughclouds.ogg', 'hyperstation/sound/misc/goofy.ogg', 'hyperstation/sound/misc/wilhelm.ogg'), 100, 0)
 
 			else if(prob(5))
 				playsound(AM, pick('hyperstation/sound/misc/yodadeath.ogg', 'hyperstation/sound/misc/fallingthroughclouds.ogg', 'hyperstation/sound/misc/goofy.ogg', 'hyperstation/sound/misc/wilhelm.ogg'), 100, 0)
+
+		var/oldalpha = AM.alpha
+		var/oldcolor = AM.color
+		var/oldtransform = AM.transform
+
+		//Animate our falling items
+		animate(AM, transform = matrix(0,0,0,0,0,0), alpha = 0, color = rgb(0, 0, 0), time = 10)
+
+		for(var/i in 1 to 5)
+			//Make sure the item is still there after our sleep
+			if(!AM || QDELETED(AM))
+				return
+			AM.pixel_y--
+			sleep(2)
+
+		//Make sure the item is still there after our sleep
+		if(!AM || QDELETED(AM))
+			return
 
 		//Mob types that could be protected by a tether
 		if(iscyborg(AM) || iscarbon(AM))
@@ -142,41 +160,23 @@
 				if(tether_number == 1)
 
 					// If teleportation fails
-					if(!GLOB.safety_tethers_list[1].bungee_teleport(victim, linked_turf))
+					if(!GLOB.safety_tethers_list[1].attempt_teleport(victim, linked_turf, oldalpha, oldcolor, oldtransform))
 						finishdrop(AM)
 				else
 
 					//Just in case multiple safety tethers are present
-					if(!GLOB.safety_tethers_list[rand(1,GLOB.safety_tethers_list.len)].bungee_teleport(victim, linked_turf))
+					if(!GLOB.safety_tethers_list[rand(1,GLOB.safety_tethers_list.len)].attempt_teleport(victim, linked_turf, oldalpha, oldcolor, oldtransform))
 						finishdrop(AM)
 				if(isliving(AM))
 					var/mob/living/L = AM
 					L.notransform = FALSE
 			else
-				finishdrop(AM)
+				finishdrop(AM, oldalpha, oldcolor, oldtransform)
 		else
-			finishdrop(AM)
+			finishdrop(AM, oldalpha, oldcolor, oldtransform)
 
 
-/datum/component/chasm/proc/finishdrop(atom/movable/AM)
-
-	var/oldalpha = AM.alpha
-	var/oldcolor = AM.color
-	var/oldtransform = AM.transform
-
-	//Animate our falling items, then delete them.
-	animate(AM, transform = matrix() - matrix(), alpha = 0, color = rgb(0, 0, 0), time = 10)
-
-	for(var/i in 1 to 5)
-		//Make sure the item is still there after our sleep
-		if(!AM || QDELETED(AM))
-			return
-		AM.pixel_y--
-		sleep(2)
-
-	//Make sure the item is still there after our sleep
-	if(!AM || QDELETED(AM))
-		return
+/datum/component/chasm/proc/finishdrop(atom/movable/AM, oldalpha, oldcolor, oldtransform)
 
 	if(iscyborg(AM))
 		var/mob/living/silicon/robot/S = AM

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -50,6 +50,7 @@
 		radio.keyslot = new radio_key
 		radio.subspace_transmission = TRUE
 		radio.canhear_range = 0
+		radio.listening = FALSE
 		radio.recalculateChannels()
 
 	update_icon()

--- a/hyperstation/code/game/machinery/safety_tether.dm
+++ b/hyperstation/code/game/machinery/safety_tether.dm
@@ -98,6 +98,8 @@
 	var/radio_key = /obj/item/encryptionkey/headset_medsci
 
 /obj/machinery/safety_tether/Initialize()
+	//ensures light is properly centered around the tether. Removes lighting system's pixel approximation that breaks it.
+	light_source = CENTER_TURF
 	. = ..()
 
 	//Adds this to the global list of safety tethers in the world to pull from when chasms attempt to drop mobs
@@ -125,8 +127,6 @@
 
 	allowed_turfs = make_associative(allowed_turf_types - disallowed_turf_types)
 
-	//ensures light is properly centered around the tether. Removes lighting system's pixel approximation that breaks it.
-	light_source = CENTER_TURF
 	update_icon()
 
 /obj/machinery/safety_tether/Destroy()
@@ -324,7 +324,7 @@
 	. = ..()
 
 	if(stat & NOPOWER)
-		if(radio && internal_radio) //If called while initializing results in a null error.
+		if(SSticker.HasRoundStarted()&& radio && internal_radio) //If called while initializing results in a null error.
 			SPEAKCOMMON("The Safety Tether's shut down from a lack of power.")
 	else
 		if(radio && internal_radio)
@@ -351,3 +351,4 @@
 #undef SPEAKCOMMON
 #undef SPEAKMEDICAL
 #undef SPEAKSCIENCE
+#undef CENTER_TURF


### PR DESCRIPTION
## About The Pull Request

Polishes up the fluff text, re-adds chasm animations and fixes them on the player side, adds a short wind-up to teleportation for flavor and looking cool, balances damage caused by the tether and guarantees death after a very short delay to let them realize the magnitude of their mistakes. Polishes the look of the room the Tether is in with some environmental storytelling type stuff. Makes the Tether randomly teleport players to maintenance.

## Why It's Good For The Game

Gives Medical Even More to do, ensures players aren't stuck in engineering without access to a medic, looks even cooler. New procedure that could be moved to helpers for finding random unoccupied tiles of a specified area and type.

## Changelog
:cl:Haha26
add: Adds random teleportation into maint complete with another harmless tesla arc
add: Adds delay to teleportation for fun sound effects
tweak: Re-enables chasm animations.
tweak: Tweaked fluff paper in light of new wind-up and damage values. Adds colored text to said warning.
map: Adds details to the Tether room
balance: Rebalanced tether damage. Damage to silicates completely disables all tools, kills players and presents some interesting new stuff for medical, since defibbing the player is the best bet (with formaldehyde added to the body to prevent organ decay and incentivize playing the game in a fun way). Also a pinpointer / body based scavenger hunt.
fix: Fixed chasm animations causing permanent player rotation, with added delay allows a moment for their gut to drop 
soundadd: Added a sound effect to the windup
code: new simple procedure to get a random and unoccupied safe turf with whitelists, blacklists, and turf types now in code for Tether
/:cl: