### PR TITLE
Fixes size application to mobs

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -38,7 +38,7 @@
 	var/list/unattached_flesh
 	var/flesh_number = 0
 
-	var/size = 1
+	var/size = 100
 
 /obj/machinery/clonepod/Initialize()
 	. = ..()
@@ -129,7 +129,7 @@
 	return examine(user)
 
 //Start growing a human clone in the pod!
-/obj/machinery/clonepod/proc/growclone(ckey, clonename, ui, mutation_index, mindref, datum/species/mrace, list/features, factions, list/quirks, experimental = FALSE)
+/obj/machinery/clonepod/proc/growclone(ckey, clonename, ui, mutation_index, mindref, datum/species/mrace, list/features, custom_size, factions, list/quirks, experimental = FALSE)
 	if(panel_open)
 		return FALSE
 	if(mess || attempting)
@@ -220,10 +220,12 @@
 	attempting = FALSE
 
 	//sizecode stuff, check size of scanned individual to then pass in later. someone should turn size into a dna trait tbh
-	if(istype(clonemind))
-		var/mob/living/current = clonemind.current //gets body of current mind
-		if(!isnull(current))
-			size = current.size_multiplier * 100
+	//if(istype(clonemind))
+	//	var/mob/living/current = clonemind.current //gets body of current mind
+		//if(!isnull(current))
+			//size = current.client.preferences.body_size * 100
+
+	size = custom_size
 
 	return TRUE
 
@@ -401,10 +403,9 @@
 		qdel(fl)
 	unattached_flesh.Cut()
 
-	//Do the resize on ejection. The clone pod seems to do a lot of matrix transforms the way size code does, so we will handle our resize after.
-	mob_occupant.previous_size = 1 //Set the previous size to default so the resize properly set health and speed.
-	mob_occupant.custom_body_size = size //mob_occupant.client.prefs.body_size
-	mob_occupant.resize(mob_occupant.custom_body_size * 0.01)
+
+	//The size to resize to here is custom_body_size var for living mobs. Do not change that variable in round!
+	mob_occupant.resize(size / 100)//Do the resize on ejection. The clone pod seems to do a lot of matrix transforms the way size code does, so we will handle our resize after.
 	occupant = null
 
 /obj/machinery/clonepod/proc/malfunction()

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -76,7 +76,7 @@
 		if(pod.occupant)
 			continue	//how though?
 
-		if(pod.growclone(R.fields["ckey"], R.fields["name"], R.fields["UI"], R.fields["SE"], R.fields["mind"], R.fields["mrace"], R.fields["features"], R.fields["factions"], R.fields["quirks"]))
+		if(pod.growclone(R.fields["ckey"], R.fields["name"], R.fields["UI"], R.fields["SE"], R.fields["mind"], R.fields["mrace"], R.fields["features"], R.fields["size"], R.fields["factions"], R.fields["quirks"]))
 			temp = "[R.fields["name"]] => <font class='good'>Cloning cycle in progress...</font>"
 			records -= R
 
@@ -493,6 +493,7 @@
 	R.fields["SE"] = dna.mutation_index
 	R.fields["blood_type"] = dna.blood_type
 	R.fields["features"] = dna.features
+	R.fields["size"] = mob_occupant.custom_body_size //Gotten this way so stuff like normalizer rings don't fuck with stuff
 	R.fields["factions"] = mob_occupant.faction
 	R.fields["quirks"] = list()
 	for(var/V in mob_occupant.roundstart_quirks)

--- a/code/game/machinery/exp_cloner.dm
+++ b/code/game/machinery/exp_cloner.dm
@@ -301,6 +301,7 @@
 		var/UI = dna.uni_identity
 		var/SE = dna.mutation_index
 		var/features = dna.features
+		var/size = mob_occupant.custom_body_size
 		var/factions = mob_occupant.faction
 		var/list/quirks = list()
 
@@ -312,8 +313,8 @@
 			quirks[T.type] = T.clone_data()
 
 		//grows the clone, format;
-		// ckey, clonename, ui, mutation_index, mindref, datum/species/mrace, list/features, factions, list/quirks, experimental = FALSE
-		pod.growclone(null, name, UI, SE, mind, clone_species, features, factions, quirks, TRUE)
+		// ckey, clonename, ui, mutation_index, mindref, datum/species/mrace, list/featuresm custom_body_size, factions, list/quirks, experimental = FALSE
+		pod.growclone(null, name, UI, SE, mind, clone_species, features, size, factions, quirks, TRUE)
 		temp = "[mob_occupant.real_name] => <font class='good'>Cloning data sent to pod.</font>"
 		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 

--- a/code/game/machinery/exp_cloner.dm
+++ b/code/game/machinery/exp_cloner.dm
@@ -313,7 +313,7 @@
 			quirks[T.type] = T.clone_data()
 
 		//grows the clone, format;
-		// ckey, clonename, ui, mutation_index, mindref, datum/species/mrace, list/featuresm custom_body_size, factions, list/quirks, experimental = FALSE
+		// ckey, clonename, ui, mutation_index, mindref, datum/species/mrace, list/features, custom_body_size, factions, list/quirks, experimental = FALSE
 		pod.growclone(null, name, UI, SE, mind, clone_species, features, size, factions, quirks, TRUE)
 		temp = "[mob_occupant.real_name] => <font class='good'>Cloning data sent to pod.</font>"
 		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -56,7 +56,7 @@
 	var/mob_size = MOB_SIZE_HUMAN
 
 //H13 custom body size and impregnation
-	var/custom_body_size = 100
+	var/custom_body_size = 100 //Do not change this variable in round! It's their 'natural' roundstart size.
 	var/breedable = 0
 	var/impregchance = 30
 //h13 settings

--- a/hyperstation/code/game/machinery/safety_tether.dm
+++ b/hyperstation/code/game/machinery/safety_tether.dm
@@ -327,10 +327,10 @@
 	. = ..()
 
 	if(stat & NOPOWER)
-		if(SSticker.HasRoundStarted()&& radio && internal_radio) //If called while initializing results in a null error.
+		if(radio && internal_radio) //If called while initializing results in a null error.
 			SPEAKCOMMON("The Safety Tether's shut down from a lack of power.")
 	else
-		if(radio && internal_radio)
+		if(SSticker.HasRoundStarted() && radio && internal_radio)
 			SPEAKCOMMON("The Safety Tether is back online.")
 	update_icon()
 


### PR DESCRIPTION
## About The Pull Request

Ensures player's custom_body_size is applied to any new clone once they're out of the pod. Custom_body_size is only set once, so acts as 'natural' size, independent of things like normalizer rings. Also fixes nagging runtime in Tether code.

## Why It's Good For The Game

Makes sure one of the hardest variables to change in the game is applied to folks who're cloned to incentivize turning off unnecessary DNC orders and the like.

## Changelog
:cl:Haha26, Archiebeepboop
fix: fixed sizecode being applied to fresh clones
fix: fixed a runtime in Tether code courtesy of Archie
/:cl:
