### PR TITLE
Game manifest update

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -89,7 +89,7 @@
 	if(foundrecord)
 		foundrecord.fields["rank"] = assignment
 
-/datum/datacore/proc/get_manifest(monochrome, OOC)
+/datum/datacore/proc/get_manifest(monochrome, OOC = FALSE)
 	var/list/heads = list()
 	var/list/sec = list()
 	var/list/eng = list()
@@ -143,6 +143,14 @@
 			department = 1
 		if(!department && !(name in heads))
 			misc[name] = rank
+
+	//If we're getting the manifest from out of the round, add borgs to it
+	if(OOC)
+		for(var/mob/living/silicon/robot/R in GLOB.silicon_mobs)
+			if(!R.hack_software || R.emagged) //If they're not hacked except via emag
+				var name = R.name
+				bot[name] = "Station Cyborg"
+
 	if(heads.len > 0)
 		dat += "<tr><th colspan=3>Heads</th></tr>"
 		for(var/name in heads)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -69,7 +69,7 @@
 		output += "<p><a href='byond://?src=[REF(src)];late_join=1'>[icon2html(preview_icon, world, "preview")]Join Game!</a></p>"
 		output += "<p><a href='byond://?src=[REF(src)];roleplay_join=1'>[icon2html('hyperstation/icons/menu/menu.dmi', world, "roleplay")]Roleplay Roles!</a></p>"
 		output += "<p><a href='byond://?src=[REF(src)];show_preferences=1'>[icon2html('hyperstation/icons/menu/menu.dmi', world, "settings")]Setup Character</a></p>"
-		output += "<p><a href='byond://?src=[REF(src)];manifest=1'>[icon2html('hyperstation/icons/menu/menu.dmi', world, "manifest")]View the Crew Manifest</a></p>"
+		output += "<p><a href='byond://?src=[REF(src)];manifest=1'>[icon2html('hyperstation/icons/menu/menu.dmi', world, "manifest")]View the Game Manifest</a></p>"
 		output += "<p><a href='byond://?src=[REF(src)];ready=[PLAYER_READY_TO_OBSERVE]'>[icon2html('hyperstation/icons/menu/menu.dmi', world, "ghost")]Observe</a></p>"
 
 	if(!IsGuestKey(src.key) && SSticker.current_state >= GAME_STATE_PREGAME)
@@ -764,8 +764,8 @@
 
 /mob/dead/new_player/proc/ViewManifest()
 	var/dat = "<html><body>"
-	dat += "<h4>Crew Manifest</h4>"
-	dat += GLOB.data_core.get_manifest(OOC = 1)
+	dat += "<h4>Game Manifest</h4>"
+	dat += GLOB.data_core.get_manifest(OOC = TRUE)
 
 	src << browse(dat, "window=manifest;size=387x420;can_close=1")
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -653,12 +653,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	return 1
 
 /mob/dead/observer/verb/view_manifest()
-	set name = "View Crew Manifest"
+	set name = "View Game Manifest"
 	set category = "Ghost"
 
 	var/dat
-	dat += "<h4>Crew Manifest</h4>"
-	dat += GLOB.data_core.get_manifest()
+	dat += "<h4>Game Manifest</h4>"
+	dat += GLOB.data_core.get_manifest(FALSE,TRUE) //Gets a more complete crew manifest
 
 	src << browse(dat, "window=manifest;size=387x420;can_close=1")
 


### PR DESCRIPTION
## About The Pull Request

Ensures (emagged or non hacked) borgs now show up on the manifest if found when either dead or in the round lobby.

## Why It's Good For The Game

Fixed a longstanding niggling issue of mine. Makes it more accessible for cyborgs to RP, or for people to RP with cyborgs

## Changelog
:cl:
tweak: changed name of crew manifest to game manifest when out-of-round or a ghost for accuracy
tweak: makes borgs show up on the OOC version of the game manifest
/:cl:
