### PR TITLE
Painkillers

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -441,14 +441,14 @@
 	desc = "An upgrade to the Medical module's hypospray, allowing it \
 		to treat a wider range of conditions and problems."
 	additional_reagents = list(/datum/reagent/medicine/mannitol, /datum/reagent/medicine/oculine, /datum/reagent/medicine/inacusiate,
-		/datum/reagent/medicine/mutadone, /datum/reagent/medicine/haloperidol)
+								/datum/reagent/medicine/mutadone, /datum/reagent/medicine/haloperidol)
 
 /obj/item/borg/upgrade/hypospray/high_strength
 	name = "medical cyborg high-strength hypospray"
 	desc = "An upgrade to the Medical module's hypospray, containing \
 		stronger versions of existing chemicals."
-	additional_reagents = list(/datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/sal_acid,
-								/datum/reagent/medicine/rezadone, /datum/reagent/medicine/pen_acid)
+	additional_reagents = list(/datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/rezadone,
+								/datum/reagent/medicine/pen_acid, /datum/reagent/medicine/morphine)
 
 /obj/item/borg/upgrade/piercing_hypospray
 	name = "cyborg piercing hypospray"

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -449,8 +449,9 @@
 	initial_contents = list(
 		/obj/item/reagent_containers/pill/epinephrine = 12,
 		/obj/item/reagent_containers/pill/charcoal = 5,
+		/obj/item/reagent_containers/pill/ibuprofen = 5,
 		/obj/item/reagent_containers/glass/bottle/epinephrine = 1,
-		/obj/item/reagent_containers/glass/bottle/charcoal = 1)
+		/obj/item/reagent_containers/glass/bottle/charcoal = 1,)
 
 // ----------------------------
 // Virology Medical Smartfridge

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -26,7 +26,7 @@ Borg Hypospray
 	var/bypass_protection = 0 //If the hypospray can go through armor or thick material
 
 	var/list/datum/reagents/reagent_list = list()
-	var/list/reagent_ids = list(/datum/reagent/medicine/dexalin, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/antitoxin,
+	var/list/reagent_ids = list(/datum/reagent/medicine/ibuprofen, /datum/reagent/medicine/dexalin, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/antitoxin,
 								/datum/reagent/medicine/epinephrine, /datum/reagent/medicine/spaceacillin, /datum/reagent/medicine/salglu_solution, /datum/reagent/medicine/insulin)
 	var/accepts_reagent_upgrades = TRUE //If upgrades can increase number of reagents dispensed.
 	var/list/modes = list() //Basically the inverse of reagent_ids. Instead of having numbers as "keys" and strings as values it has strings as keys and numbers as values.

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -12,6 +12,7 @@
 					/obj/item/pinpointer/crew = 2,
 					/obj/item/reagent_containers/medspray/sterilizine = 1,
 					/obj/item/stack/medical/gauze = 8,
+					/obj/item/reagent_containers/pill/ibuprofen = 5,
 					/obj/item/reagent_containers/pill/patch/styptic = 5,
 					/obj/item/reagent_containers/medspray/styptic = 2,
 					/obj/item/reagent_containers/pill/patch/silver_sulf = 5,
@@ -37,7 +38,7 @@
                /obj/item/storage/belt/medolier/full = 2,
                /obj/item/gun/syringe/dart = 2,
                /obj/item/storage/briefcase/medical = 2)
-               
+
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/medical

--- a/hyperstation/code/modules/reagents/chemistry/reagent_containers/pill.dm
+++ b/hyperstation/code/modules/reagents/chemistry/reagent_containers/pill.dm
@@ -1,0 +1,6 @@
+/obj/item/reagent_containers/pill/ibuprofen
+	name = "ibuprofen"
+	desc = "An ibuprofen pill. Reduces pain with a high overdose threshold and few ill effects"
+	icon_state = "pill19"
+	list_reagents = list(/datum/reagent/medicine/ibuprofen = 15)
+	roundstart = 1

--- a/hyperstation/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/hyperstation/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -39,7 +39,7 @@
 	pH = 4
 
 /datum/reagent/medicine/ibuprofen/on_mob_life(mob/living/carbon/M)
-	M.adjustPainLoss(-2*REM, 0)// mild painkiller. Better than bicardine, worse than morphine.
+	M.adjustPainLoss(-1.5*REM, 0)// mild painkiller. Better than bicardine, worse than morphine.
 	..()
 
 /datum/reagent/medicine/ibuprofen/overdose_process(mob/living/M)

--- a/hyperstation/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/hyperstation/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -27,3 +27,23 @@
 		M.Knockdown(40)
 
 //To-do: /datum/reagent/medicine/seethium
+
+/datum/reagent/medicine/ibuprofen
+	name = "Ibuprofen"
+	description = "A milder painkiller with a higher overdose threshold than morphine and fewer ill effects."
+	reagent_state = LIQUID
+	color = "#E6E6E6"
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	overdose_threshold = 60
+	//addiction_threshold = 25
+	pH = 4
+
+/datum/reagent/medicine/ibuprofen/on_mob_life(mob/living/carbon/M)
+	M.adjustPainLoss(-2*REM, 0)// mild painkiller. Better than bicardine, worse than morphine.
+	..()
+
+/datum/reagent/medicine/ibuprofen/overdose_process(mob/living/M)
+	if(prob(15))
+		//M.drop_all_held_items()
+		M.Dizzy(3)
+	..()

--- a/hyperstation/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/hyperstation/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -4,3 +4,9 @@
 	results = list(/datum/reagent/medicine/copium = 5)
 	required_reagents = list(/datum/reagent/medicine/mannitol = 2, /datum/reagent/water = 1, /datum/reagent/medicine/epinephrine = 1, /datum/reagent/consumable/sugar = 1)
 	required_temp = 266
+
+/datum/chemical_reaction/ibuprofen
+	name = "ibuprofen"
+	id = /datum/reagent/medicine/ibuprofen
+	results = list(/datum/reagent/medicine/ibuprofen = 5)
+	required_reagents = list(/datum/reagent/medicine/bicaridine = 3, /datum/reagent/carbon = 1, /datum/reagent/hydrogen = 1)

--- a/modular_citadel/code/game/machinery/vending.dm
+++ b/modular_citadel/code/game/machinery/vending.dm
@@ -6,6 +6,7 @@
 					/obj/item/pinpointer/crew = 2,
 					/obj/item/reagent_containers/medspray/sterilizine = 1,
 					/obj/item/stack/medical/gauze = 8,
+					/obj/item/reagent_containers/pill/ibuprofen = 5,
 					/obj/item/reagent_containers/pill/patch/styptic = 5,
 					/obj/item/reagent_containers/medspray/styptic = 2,
 					/obj/item/reagent_containers/pill/patch/silver_sulf = 5,

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3230,6 +3230,7 @@
 #include "hyperstation\code\modules\power\reactor\fuel_rods.dm"
 #include "hyperstation\code\modules\power\reactor\rbmk.dm"
 #include "hyperstation\code\modules\power\reactor\reactor_cargo.dm"
+#include "hyperstation\code\modules\reagents\chemistry\reagent_containers\pill.dm"
 #include "hyperstation\code\modules\reagents\chemistry\reagents\alcohol_reagents.dm"
 #include "hyperstation\code\modules\reagents\chemistry\reagents\drink_reagents.dm"
 #include "hyperstation\code\modules\reagents\chemistry\reagents\food_reagents.dm"


### PR DESCRIPTION
## About The Pull Request

Adds a milder painkiller in the form of ibuprofen, made with 3 bicardine, 1 carbon, 1 hydrogen. It has a high overdose threshold of 60 and mild side effects when ODed. Chemfridges start with 5 pills of 15 units each, as do medical vendors. Borgs can use it by default, and borgs can now use morphine when upgraded for painkilling purposes.

## Why It's Good For The Game

Adds an obvious option for painkilling to borgs, with better options given upgrades. Lower risk but also slightly less effective version of morphine now that it's mandatory in some cases.

## Changelog
:cl:
add: Added ibuprofen as a chem to the game
add: Added ibuprofen to default borg hyposprays
add: Added morphine to upgraded borg hyposprays
add: Added ibuprofen roundstart to chemfridges and medical vendors
/:cl: