### PR TITLE
Freezer/Heater Power Fix

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -65,7 +65,11 @@
 		. += "<span class='notice'>The status display reads: Efficiency <b>[(heat_capacity/5000)*100]%</b>.</span>"
 		. += "<span class='notice'>Temperature range <b>[min_temperature]K - [max_temperature]K ([(T0C-min_temperature)*-1]C - [(T0C-max_temperature)*-1]C)</b>.</span>"
 
+//I have never coded in byond before lmao but it somehow works
 /obj/machinery/atmospherics/components/unary/thermomachine/process_atmos()
+	var/B
+	for(var/obj/item/stock_parts/matter_bin/M in component_parts)
+		B += M.rating
 	..()
 	if(!on || !nodes[1])
 		return
@@ -81,7 +85,7 @@
 
 	var/temperature_delta= abs(old_temperature - air_contents.temperature)
 	if(temperature_delta > 1)
-		active_power_usage = (heat_capacity * temperature_delta) / 10 + idle_power_usage
+		active_power_usage = ((((heat_capacity * temperature_delta) * (2 * (10 ** 9))) ** 0.19) / 0.3) * (1 + (B / 2000)) + idle_power_usage
 		update_parents()
 	else
 		active_power_usage = idle_power_usage


### PR DESCRIPTION
### About the Pull Request
Freezers and Heaters are kinda broken to the point of draining a room's APC within **seconds** of turning them on, usually when they're upgraded.

This ***HOPEFULLY*** fixes power draw from heaters/freezers reaching the megawatts range while using T4 parts. Hopefully. I don't really know what I'm doing 🐔

Literally just softens the power curve as to not draw literal gigawatts of energy when cooling gasses with upgraded parts. Saves a lot of "uhhh hey admeme can you hack my APC thanks"

### Why It's Good for the Game
Allows upgraded freezers to be actually used without draining the room's APC instantly. Engineering needs this for TEG and SM shenanigans, and medical needs this to actually use their cryo tubes.

### Note: 
Is this perfect? No! Is it rushed? Yes! Should I spend time understanding what the FUCK I'm doing? Probably! But it works! It somehow fucking works!

Again, have basically zero clue what I'm doing. Isn't even my code. I just want me thermomachines to be useful and not break the game >:)
