### PR TITLE
Fixes the lawyer's roundstart spawn, corrects their info terminal

### DIFF
--- a/_maps/map_files/LayeniaStation/LayeniaStation.dmm
+++ b/_maps/map_files/LayeniaStation/LayeniaStation.dmm
@@ -15574,7 +15574,7 @@
 /obj/structure/table/wood,
 /obj/item/taperecorder,
 /obj/item/cartridge/lawyer,
-/obj/machinery/computer/lore_terminal,
+/obj/machinery/computer/lore_terminal/security,
 /turf/open/floor/wood,
 /area/lawoffice)
 "cmz" = (

--- a/_maps/map_files/LayeniaStation/LayeniaStation.dmm
+++ b/_maps/map_files/LayeniaStation/LayeniaStation.dmm
@@ -15574,7 +15574,7 @@
 /obj/structure/table/wood,
 /obj/item/taperecorder,
 /obj/item/cartridge/lawyer,
-/obj/machinery/computer/lore_terminal/security,
+/obj/machinery/computer/lore_terminal,
 /turf/open/floor/wood,
 /area/lawoffice)
 "cmz" = (
@@ -21661,6 +21661,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "drb" = (
+/obj/effect/landmark/start/lawyer,
 /turf/open/floor/carpet,
 /area/lawoffice)
 "drd" = (

--- a/hyperstation/code/game/machinery/lore_terminal.dm
+++ b/hyperstation/code/game/machinery/lore_terminal.dm
@@ -22,7 +22,7 @@ GLOBAL_DATUM_INIT(lore_terminal_controller, /datum/lore_controller, new)
 /obj/machinery/computer/lore_terminal/security
 	name = "Security info-link terminal"
 	access_tag = "knsecurity"
-	req_access = list(ACCESS_SECURITY)
+	req_access = list(ACCESS_SEC_DOORS)
 
 /obj/machinery/computer/lore_terminal/awaymission //Example for having a terminal preloaded with only a set list of files.
 	access_tag = "awaymission_default"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds the missing lawyer roundstart landmark so they can properly spawn in their office at the beginning of a round and also changes their info terminal access.

## Why It's Good For The Game

Simple fixes.

## Changelog
:cl:
add: proper lawyer spawnpoint
fix: lawyer infolink terminal access
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
