### PR TITLE
Adds a Midround Filler Event, and lets the HoS use ZaoCorp Gear

### DIFF
--- a/_maps/map_files/LayeniaStation/LayeniaStation.dmm
+++ b/_maps/map_files/LayeniaStation/LayeniaStation.dmm
@@ -10420,6 +10420,7 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
+/obj/item/stamp/hos,
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "bsL" = (

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
@@ -732,6 +732,16 @@
 	repeatable = TRUE
 	occurances_max = 100 //Our rounds can go for a WHILE
 
+/datum/dynamic_ruleset/event/filler
+	name = "Filler"
+	typepath = /datum/round_event/filler
+	chaos_max = 3
+	cost = 1
+	weight = 100
+	repeatable_weight_decrease = 0
+	repeatable = TRUE
+	occurances_max = 50
+
 /datum/dynamic_ruleset/event/disease_outbreak
 	name = "Disease Outbreak"
 	enemy_roles = list("Virologist","Chief Medical Officer","Chemist")

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -180,6 +180,19 @@
 /obj/item/storage/secure/briefcase/hos/multiphase_box/PopulateContents()
 	new /obj/item/gun/energy/e_gun/hos(src)
 
+/obj/item/storage/secure/briefcase/hos/zaocorp
+	name = "\improper ZaoCorp Contractor Kit"
+	desc = "A storage case for a temporary ZaoCorp Contract."
+
+/obj/item/storage/secure/briefcase/hos/zaocorp/PopulateContents()
+	new /obj/item/clothing/suit/toggle/zao(src)
+	new /obj/item/clothing/under/rank/security/zao(src)
+	new /obj/item/clothing/head/zao(src)
+	new /obj/item/clothing/glasses/hud/toggle/zao(src)
+	new /obj/item/clothing/shoes/jackboots(src)
+	new /obj/item/clothing/gloves/color/black(src)
+	new /obj/item/clothing/accessory/waistcoat(src)
+	new /obj/item/twohanded/required/zao/zweihander(src)
 
 // -----------------------------
 //        Secure Safe

--- a/hyperstation/code/modules/events/filler.dm
+++ b/hyperstation/code/modules/events/filler.dm
@@ -1,0 +1,15 @@
+//This event is intended to fill up a pool of otherwise empty events, until we can get more.
+//Just so we don't get back-to-back comms-outages and sentient animal spawns. They get a little annoying.
+
+/datum/round_event_control/filler
+	name = "Filler"
+	typepath = /datum/round_event/filler
+	weight = 100
+	earliest_start = 30 MINUTES //So other important events can roll before this one does
+	max_occurrences = 50 //For those reaaaaaaally drawn-out rounds. Adjust as it comes
+	alertadmins = 0
+
+/datum/round_event/filler
+	startWhen = 1
+	endWhen	= 2
+	fakeable = FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3199,6 +3199,7 @@
 #include "hyperstation\code\modules\economy\account.dm"
 #include "hyperstation\code\modules\events\crystalline_reentry.dm"
 #include "hyperstation\code\modules\events\crystalloid_entities.dm"
+#include "hyperstation\code\modules\events\filler.dm"
 #include "hyperstation\code\modules\food_and_drinks\food\snacks_vend.dm"
 #include "hyperstation\code\modules\food_and_drinks\recipes\drinks_recipes.dm"
 #include "hyperstation\code\modules\hydroponics\grown\kalyna.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a midround filler event, serving the sole purpose of adding something into our very empty pool of things that can roll under dynamic.
Also allows the HoS to select a ZaoCorp gear kit; despite it being unfinished, people really want it!
Aaaand adds a single stamp onto the HoS's office. Whoops.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Conteeeennnttt
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: event filler
add: ZaoCorp gear for HoS
fix: missing HoS stamp
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
