### PR TITLE
Allows Tech/Design/Clone disks to be renamed

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -75,10 +75,10 @@
 	heal_level = CLAMP((efficiency * 10) + 10, MINIMUM_HEAL_LEVEL, 100)
 
 //The return of data disks?? Just for transferring between genetics machine/cloning machine.
-//TO-DO: Make the genetics machine accept them.
 /obj/item/disk/data
 	name = "cloning data disk"
 	icon_state = "datadisk0" //Gosh I hope syndies don't mistake them for the nuke disk.
+	obj_flags = UNIQUE_RENAME
 	var/list/fields = list()
 	var/list/mutations = list()
 	var/max_mutations = 6

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -70,6 +70,7 @@ other types of metals and chemistry for reagents).
 	name = "Component Design Disk"
 	desc = "A disk for storing device design data for construction in lathes."
 	icon_state = "datadisk1"
+	obj_flags = UNIQUE_RENAME
 	materials = list(MAT_METAL=300, MAT_GLASS=100)
 	var/list/blueprints = list()
 	var/max_blueprints = 1

--- a/code/modules/research/research_disk.dm
+++ b/code/modules/research/research_disk.dm
@@ -3,6 +3,7 @@
 	name = "technology disk"
 	desc = "A disk for storing technology data for further research."
 	icon_state = "datadisk0"
+	obj_flags = UNIQUE_RENAME
 	materials = list(MAT_METAL=300, MAT_GLASS=100)
 	var/datum/techweb/stored_research
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26515331/201489680-d210c057-798d-4583-bf8b-d8b5dc139851.png)

## Changelog
:cl:
add: Tech/Design/Cloning Disks can be renamed now with pens
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
