### PR TITLE
Floor lights no longer appear over mobs

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -223,6 +223,9 @@
 	var/bulb_emergency_pow_mul = 0.75	// the multiplier for determining the light's power in emergency mode
 	var/bulb_emergency_pow_min = 0.5	// the minimum value for the light's power in emergency mode
 
+	var/glow_layer = ABOVE_LIGHTING_LAYER	//The layer the glow effect is on
+	var/glow_plane = ABOVE_LIGHTING_PLANE	//The plane for the glow effect
+
 	var/obj/effect/light/lighteffect //light effect
 
 
@@ -314,7 +317,7 @@
 				if(on)
 					lighteffect.alpha = CLAMP(light_power*35, 5, 100)
 					lighteffect.color = light_color
-					var/mutable_appearance/glowybit = mutable_appearance(overlayicon, base_state, ABOVE_LIGHTING_LAYER, ABOVE_LIGHTING_PLANE)
+					var/mutable_appearance/glowybit = mutable_appearance(overlayicon, base_state, glow_layer, glow_plane)
 					glowybit.alpha = CLAMP(light_power*250, 30, 200)
 					add_overlay(glowybit)
 		if(LIGHT_EMPTY)
@@ -837,9 +840,11 @@
 /obj/machinery/light/floor
 	name = "floor light"
 	icon = 'icons/obj/lighting.dmi'
-	base_state = "floor"		// base description and icon_state
+	base_state = "floor"
 	icon_state = "floor"
 	brightness = 4
-	layer = 2.5
+	layer = LOW_OBJ_LAYER
+	glow_layer = LOW_SIGIL_LAYER
+	glow_plane = GAME_PLANE
 	light_type = /obj/item/light/bulb
 	fitting = "bulb"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lights have an overlay, which by default were always on the lighting plane above every normal object/mob. The overlays for floor lights are now behind players (to also include things like tables)
![image](https://user-images.githubusercontent.com/26515331/201490582-70894f0d-a875-4a20-be04-96722cf031cd.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Grrr ugly light

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Floor light overlays are brought from the lighting plane to the game plane
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
