### PR TITLE
Wolf's Low Pressure Lungs Trait

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -196,7 +196,7 @@
 #define TRAIT_MACROPHILE		"macrophile" //likes the big
 #define TRAIT_MICROPHILE		"microphile" //likes the small
 #define TRAIT_APATHETIC			"apathetic" //doesn't care
-#define TRAIT_LOW_PRESSURE_LUNGS	"low_puressure_lungs" //used to lower kPa of Lavaland.
+#define TRAIT_LOW_PRESSURE_LUNGS	"low_puressure_lungs" //used to lower kPa of Lavaland and other low kPa Atmos.
 
 #define TRAIT_TOUGH		"tough" //you have 10% more maxhealth
 #define TRAIT_AUTO_CATCH_ITEM	"auto_catch_item"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -196,7 +196,7 @@
 #define TRAIT_MACROPHILE		"macrophile" //likes the big
 #define TRAIT_MICROPHILE		"microphile" //likes the small
 #define TRAIT_APATHETIC			"apathetic" //doesn't care
-#define TRAIT_LAVALAND_LUNGS	"lavalandian_lungs" //used to lower kPa of Lavaland.
+#define TRAIT_LOW_PRESSURE_LUNGS	"low_puressure_lungs" //used to lower kPa of Lavaland.
 
 #define TRAIT_TOUGH		"tough" //you have 10% more maxhealth
 #define TRAIT_AUTO_CATCH_ITEM	"auto_catch_item"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -196,6 +196,7 @@
 #define TRAIT_MACROPHILE		"macrophile" //likes the big
 #define TRAIT_MICROPHILE		"microphile" //likes the small
 #define TRAIT_APATHETIC			"apathetic" //doesn't care
+#define TRAIT_LAVALAND_LUNGS	"lavalandian_lungs" //used to lower kPa of Lavaland.
 
 #define TRAIT_TOUGH		"tough" //you have 10% more maxhealth
 #define TRAIT_AUTO_CATCH_ITEM	"auto_catch_item"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -292,6 +292,20 @@
 
 	lungs.heat_level_1_threshold = 400
 	lungs.heat_level_2_threshold = 600
+
+/datum/quirk/low_pressure_lungs/remove() //*Unedits your lungs*
+	var/obj/item/organ/lungs/lungs = quirk_holder.getorgan(/obj/item/organ/lungs)
+	
+	lungs.safe_oxygen_min = 16
+	lungs.safe_oxygen_max = 50
+
+
+	lungs.cold_level_1_threshold = 260
+	lungs.cold_level_2_threshold = 200
+	lungs.cold_level_3_threshold = 120
+
+	lungs.heat_level_1_threshold = 360
+	lungs.heat_level_2_threshold = 400
 	
 /datum/quirk/low_puressure_lungs/post_add()
 	to_chat(quirk_holder, "<span class='boldannounce'>Your [slot_string] feel the heavy pressure of the air.</span>")

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -267,22 +267,22 @@
 	if(quirk_holder)
 		quirk_holder.blood_ratio = 1
 
-/datum/quirk/lavalandian_lungs
-	name = "Lavalandian"
-	desc = "You're not quite used to the high air pressure!"
+/datum/quirk/low_puressure_lungs
+	name = "Low Pressure Lungs"
+	desc = "You're not quite used to the high air pressure! Perfect for characters who are used to the atmosphere of Lavaland or Asteroids!"
 	value = -1
 	category = CATEGORY_BODY
-	mob_trait = TRAIT_LAVALAND_LUNGS
+	mob_trait = TRAIT_LOW_PRESSURE_LUNGS
 	var/slot_string = "lungs"
 	var/specific = null
 	gain_text = "<span class='notice'>You feel your lungs taking in more air.</span>"
 	lose_text = "<span class='notice'>You feel like the air is not as plentiful.</span>"
-	medical_record_text = "During physical examination, patient was found to have lungs adapted to lavaland."
+	medical_record_text = "During physical examination, patient was found to have lungs adapted to low pressure environments."
 
-/datum/quirk/lavalandian_lungs/post_add()
+/datum/quirk/low_puressure_lungs/post_add()
 	to_chat(quirk_holder, "<span class='boldannounce'>Your [slot_string] feel the heavy pressure of the air.</span>")
 
-/datum/quirk/lavalandian_lungs/on_spawn()
+/datum/quirk/low_puressure_lungs/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/clothing/mask/breath/breath = new(get_turf(H))
 	var/list/breth = list ( //shu-ut up, Brethyyyy.

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -267,6 +267,41 @@
 	if(quirk_holder)
 		quirk_holder.blood_ratio = 1
 
+/datum/quirk/lavalandian_lungs
+	name = "Lavalandian"
+	desc = "You're not quite used to the high air pressure!"
+	value = -1
+	category = CATEGORY_BODY
+	mob_trait = TRAIT_LAVALAND_LUNGS
+	var/slot_string = "lungs"
+	var/specific = null
+	gain_text = "<span class='notice'>You feel your lungs taking in more air.</span>"
+	lose_text = "<span class='notice'>You feel like the air is not as plentiful.</span>"
+	medical_record_text = "During physical examination, patient was found to have lungs adapted to lavaland."
+
+/datum/quirk/lavalandian_lungs/post_add()
+	to_chat(quirk_holder, "<span class='boldannounce'>Your [slot_string] feel the heavy pressure of the air.</span>")
+
+/datum/quirk/lavalandian_lungs/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/clothing/mask/breath/breath = new(get_turf(H))
+	var/list/breth = list ( //shu-ut up, Brethyyyy.
+		"face" = SLOT_WEAR_MASK
+	)
+	H.equip_in_one_of_slots(breath, breth, qdel_on_fail = FALSE)
+	
+	var/obj/item/tank/internals/emergency_oxygen/emergency_oxygen = new(get_turf(H))
+	var/list/oxy_tank = list (
+		"left pocket" = SLOT_L_STORE,
+		"right pocket" = SLOT_R_STORE,
+		"hands" = SLOT_HANDS
+	)
+	emergency_oxygen.air_contents.gases[/datum/gas/oxygen] = (6*ONE_ATMOSPHERE)*6/(R_IDEAL_GAS_EQUATION*T20C)
+	H.equip_in_one_of_slots(emergency_oxygen, oxy_tank, qdel_on_fail = FALSE)
+	H.internal = H.get_item_for_held_index(2)
+	H.update_internals_hud_icon(1)
+	H.regenerate_icons()
+
 /datum/quirk/tough
 	name = "Tough"
 	desc = "Your body is abnormally enduring and can take 10% more damage."

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -305,7 +305,7 @@
 		"face" = SLOT_WEAR_MASK
 	)
 	H.equip_in_one_of_slots(breath, breth, qdel_on_fail = FALSE)
-	
+
 	var/obj/item/tank/internals/emergency_oxygen/emergency_oxygen = new(get_turf(H))
 	var/list/oxy_tank = list (
 		"left pocket" = SLOT_L_STORE,
@@ -314,7 +314,7 @@
 	)
 	emergency_oxygen.air_contents.gases[/datum/gas/oxygen] = (6*ONE_ATMOSPHERE)*6/(R_IDEAL_GAS_EQUATION*T20C)
 	H.equip_in_one_of_slots(emergency_oxygen, oxy_tank, qdel_on_fail = FALSE)
-	H.internal = H.get_item_for_held_index(2)
+	H.internal = emergency_oxygen
 	H.update_internals_hud_icon(1)
 	H.regenerate_icons()
 

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -279,11 +279,27 @@
 	lose_text = "<span class='notice'>You feel like the air is not as plentiful.</span>"
 	medical_record_text = "During physical examination, patient was found to have lungs adapted to low pressure environments."
 
+/datum/quirk/low_pressure_lungs/add() //*Edits your lungs*
+	var/obj/item/organ/lungs/lungs = quirk_holder.getorgan(/obj/item/organ/lungs)
+	
+	lungs.safe_oxygen_min = 3
+	lungs.safe_oxygen_max = 18
+
+
+	lungs.cold_level_1_threshold = 280
+	lungs.cold_level_2_threshold = 240
+	lungs.cold_level_3_threshold = 200
+
+	lungs.heat_level_1_threshold = 400
+	lungs.heat_level_2_threshold = 600
+	
 /datum/quirk/low_puressure_lungs/post_add()
 	to_chat(quirk_holder, "<span class='boldannounce'>Your [slot_string] feel the heavy pressure of the air.</span>")
 
 /datum/quirk/low_puressure_lungs/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
+	
+	//Adding Breath Mask and Emergency Tank
 	var/obj/item/clothing/mask/breath/breath = new(get_turf(H))
 	var/list/breth = list ( //shu-ut up, Brethyyyy.
 		"face" = SLOT_WEAR_MASK

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -107,7 +107,7 @@
 		return
 	if(HAS_TRAIT(H, TRAIT_NOBREATH))
 		return
-	if(HAS_TRAIT(H, TRAIT_LAVALAND_LUNGS)) //Simple addon to test for the Lavalandian trait. Probably doesn't need to be done every check, but oh well.
+	if(HAS_TRAIT(H, TRAIT_LOW_PRESSURE_LUNGS)) //Simple addon to test for the Lavalandian trait. Probably doesn't need to be done every check, but oh well.
 		src.safe_oxygen_min = 3
 		src.safe_oxygen_max = 18
 

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -107,6 +107,17 @@
 		return
 	if(HAS_TRAIT(H, TRAIT_NOBREATH))
 		return
+	if(HAS_TRAIT(H, TRAIT_LAVALAND_LUNGS)) //Simple addon to test for the Lavalandian trait. Probably doesn't need to be done every check, but oh well.
+		src.safe_oxygen_min = 3
+		src.safe_oxygen_max = 18
+
+
+		src.cold_level_1_threshold = 280
+		src.cold_level_2_threshold = 240
+		src.cold_level_3_threshold = 200
+
+		src.heat_level_1_threshold = 400
+		src.heat_level_2_threshold = 600
 
 	if(!breath || (breath.total_moles() == 0))
 		if(H.reagents.has_reagent(crit_stabilizing_reagent))

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -107,17 +107,6 @@
 		return
 	if(HAS_TRAIT(H, TRAIT_NOBREATH))
 		return
-	if(HAS_TRAIT(H, TRAIT_LOW_PRESSURE_LUNGS)) //Simple addon to test for the Low Pressure Lungs trait. Probably doesn't need to be done every check, but oh well.
-		src.safe_oxygen_min = 3
-		src.safe_oxygen_max = 18
-
-
-		src.cold_level_1_threshold = 280
-		src.cold_level_2_threshold = 240
-		src.cold_level_3_threshold = 200
-
-		src.heat_level_1_threshold = 400
-		src.heat_level_2_threshold = 600
 
 	if(!breath || (breath.total_moles() == 0))
 		if(H.reagents.has_reagent(crit_stabilizing_reagent))

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -107,7 +107,7 @@
 		return
 	if(HAS_TRAIT(H, TRAIT_NOBREATH))
 		return
-	if(HAS_TRAIT(H, TRAIT_LOW_PRESSURE_LUNGS)) //Simple addon to test for the Lavalandian trait. Probably doesn't need to be done every check, but oh well.
+	if(HAS_TRAIT(H, TRAIT_LOW_PRESSURE_LUNGS)) //Simple addon to test for the Low Pressure Lungs trait. Probably doesn't need to be done every check, but oh well.
 		src.safe_oxygen_min = 3
 		src.safe_oxygen_max = 18
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new trait called the "low pressure lungs" trait to the body modifications section that when selected causes the player to spawn with an oxy tank equiped and with internals set along with making their lungs adapted to Much lower pressures of air.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Adds a further option for player immersion for those who wish to play characters alien to the atmosphere of the station.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

 - Low Pressure Lungs Trait Added
 - Traits.dm updated to include the Low Pressure Lungs Trait in the list

:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
