### PR TITLE
Small change to carry trait over after cloning

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -280,18 +280,22 @@
 	medical_record_text = "During physical examination, patient was found to have lungs adapted to low pressure environments."
 
 /datum/quirk/low_pressure_lungs/add() //*Edits your lungs*
-	var/obj/item/organ/lungs/lungs = quirk_holder.getorgan(/obj/item/organ/lungs)
-	
-	lungs.safe_oxygen_min = 3
-	lungs.safe_oxygen_max = 18
+	if (!quirk_holder.getorgan(/obj/item/organ/lungs))
+		sleep(10)
+		add()
+	else
+		var/obj/item/organ/lungs/lungs = quirk_holder.getorgan(/obj/item/organ/lungs)
+
+		lungs.safe_oxygen_min = 3
+		lungs.safe_oxygen_max = 18
 
 
-	lungs.cold_level_1_threshold = 280
-	lungs.cold_level_2_threshold = 240
-	lungs.cold_level_3_threshold = 200
+		lungs.cold_level_1_threshold = 280
+		lungs.cold_level_2_threshold = 240
+		lungs.cold_level_3_threshold = 200
 
-	lungs.heat_level_1_threshold = 400
-	lungs.heat_level_2_threshold = 600
+		lungs.heat_level_1_threshold = 400
+		lungs.heat_level_2_threshold = 600
 
 /datum/quirk/low_pressure_lungs/remove() //*Unedits your lungs*
 	var/obj/item/organ/lungs/lungs = quirk_holder.getorgan(/obj/item/organ/lungs)


### PR DESCRIPTION
Simple statement that just makes it so the game waits till you have lungs to apply the change, allowing the trait to carry over after cloning.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A simple bug fix for the Low Pressure Lungs trait to allow it to carry over post-cloning.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

General update for game health.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
Added a check to the add statement to make it wait till the lungs are added to attempt to change the lung variables.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
