### PR TITLE
fixes decay disk upgrade check

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -673,7 +673,7 @@
 		primetime = 10
 		return TRUE
 	if(istype(I, /obj/item/disk/medical/defib_decay))
-		if(!timedeath == initial(timedeath))
+		if(timedeath != initial(timedeath))
 			to_chat(user, "<span class='notice'>This unit is already upgraded with this disk!</span>")
 			return TRUE
 		to_chat(user, "<span class='notice'>You upgrade the unit with Longer Decay upgrade disk!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes the decayupgrade disk not properly checking if the defib is already upgraded
![image](https://github.com/quotefox/Hyper-Station-13/assets/66381600/8168e9a4-91e6-4bc0-acd4-51f094272910)

you'll notice that the defib speed upgrade hasn't been changed despite using the same expression. that one works properly, i checked, i don't know why
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
extremely minor fix since spam upgrading doesn't actually do anything. this is just to make things more consistent and less confusing
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Defib decay upgrade now properly checks if the unit is already upgraded.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
